### PR TITLE
hardening: audit records for null safety (fixes #15)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/ArtistInfo.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/ArtistInfo.java
@@ -21,11 +21,19 @@ package org.airsonic.player.ajax;
 
 import org.airsonic.player.domain.ArtistBio;
 
+import jakarta.annotation.Nullable;
+
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
-public record ArtistInfo(List<SimilarArtist> similarArtists, ArtistBio artistBio, List<MediaFileEntry> topSongs) {
+public record ArtistInfo(List<SimilarArtist> similarArtists, @Nullable ArtistBio artistBio, List<MediaFileEntry> topSongs) {
+
+    public ArtistInfo {
+        Objects.requireNonNull(similarArtists, "similarArtists");
+        Objects.requireNonNull(topSongs, "topSongs");
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/BookmarksWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/BookmarksWSController.java
@@ -10,6 +10,8 @@ import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.stereotype.Controller;
 
+import jakarta.annotation.Nullable;
+
 import java.security.Principal;
 import java.time.Instant;
 import java.util.Collections;
@@ -71,7 +73,7 @@ public class BookmarksWSController {
             MediaFileEntry mediaFileEntry,
             Instant changed,
             Instant created,
-            String comment,
+            @Nullable String comment,
             long positionMillis) {
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/AlbumNotes.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/AlbumNotes.java
@@ -20,15 +20,17 @@
 
 package org.airsonic.player.domain;
 
+import jakarta.annotation.Nullable;
+
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
 public record AlbumNotes(
-        String notes,
-        String musicBrainzId,
-        String lastFmUrl,
-        String smallImageUrl,
-        String mediumImageUrl,
-        String largeImageUrl) {
+        @Nullable String notes,
+        @Nullable String musicBrainzId,
+        @Nullable String lastFmUrl,
+        @Nullable String smallImageUrl,
+        @Nullable String mediumImageUrl,
+        @Nullable String largeImageUrl) {
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/ArtistBio.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/ArtistBio.java
@@ -19,14 +19,16 @@
 
 package org.airsonic.player.domain;
 
+import jakarta.annotation.Nullable;
+
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
 public record ArtistBio(
-        String biography,
-        String musicBrainzId,
-        String lastFmUrl,
+        @Nullable String biography,
+        @Nullable String musicBrainzId,
+        @Nullable String lastFmUrl,
         @Deprecated String smallImageUrl,
         @Deprecated String mediumImageUrl,
         @Deprecated String largeImageUrl) {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/InternetRadioSource.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/InternetRadioSource.java
@@ -1,4 +1,10 @@
 package org.airsonic.player.domain;
 
+import java.util.Objects;
+
 public record InternetRadioSource(String streamUrl) {
+
+    public InternetRadioSource {
+        Objects.requireNonNull(streamUrl, "streamUrl");
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MusicFolderContent.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MusicFolderContent.java
@@ -20,6 +20,7 @@
 package org.airsonic.player.domain;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedMap;
 
 /**
@@ -29,4 +30,9 @@ import java.util.SortedMap;
 public record MusicFolderContent(
         SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithMediaFiles>> indexedArtists,
         List<MediaFile> singleSongs) {
+
+    public MusicFolderContent {
+        Objects.requireNonNull(indexedArtists, "indexedArtists");
+        Objects.requireNonNull(singleSongs, "singleSongs");
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/RandomSearchCriteria.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/RandomSearchCriteria.java
@@ -21,8 +21,11 @@ package org.airsonic.player.domain;
 
 import org.airsonic.player.service.SearchService;
 
+import jakarta.annotation.Nullable;
+
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Defines criteria used when generating random playlists.
@@ -32,19 +35,23 @@ import java.util.List;
  */
 public record RandomSearchCriteria(
         int count,
-        String genre,
-        Integer fromYear,
-        Integer toYear,
+        @Nullable String genre,
+        @Nullable Integer fromYear,
+        @Nullable Integer toYear,
         List<MusicFolder> musicFolders,
-        Instant minLastPlayedDate,
-        Instant maxLastPlayedDate,
-        Integer minAlbumRating,
-        Integer maxAlbumRating,
-        Integer minPlayCount,
-        Integer maxPlayCount,
+        @Nullable Instant minLastPlayedDate,
+        @Nullable Instant maxLastPlayedDate,
+        @Nullable Integer minAlbumRating,
+        @Nullable Integer maxAlbumRating,
+        @Nullable Integer minPlayCount,
+        @Nullable Integer maxPlayCount,
         boolean showStarredSongs,
         boolean showUnstarredSongs,
-        String format) {
+        @Nullable String format) {
+
+    public RandomSearchCriteria {
+        Objects.requireNonNull(musicFolders, "musicFolders");
+    }
 
     /**
      * Creates a new instance with default optional parameters.

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Theme.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Theme.java
@@ -19,12 +19,14 @@
  */
 package org.airsonic.player.domain;
 
+import jakarta.annotation.Nullable;
+
 /**
  * Contains the ID and name for a theme.
  *
  * @author Sindre Mehus
  */
-public record Theme(String id, String name, String parent) {
+public record Theme(String id, String name, @Nullable String parent) {
 
     public Theme(String id, String name) {
         this(id, name, null);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/sonos/AlbumList.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/sonos/AlbumList.java
@@ -22,10 +22,15 @@ package org.airsonic.player.service.sonos;
 import org.airsonic.player.domain.MediaFile;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
 record AlbumList(List<MediaFile> albums, int total) {
+
+    AlbumList {
+        Objects.requireNonNull(albums, "albums");
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/view/LyricsPage.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/view/LyricsPage.java
@@ -1,5 +1,7 @@
 package org.airsonic.player.view;
 
+import jakarta.annotation.Nullable;
+
 /**
  * Data holder for the lyrics view.
  *
@@ -7,5 +9,5 @@ package org.airsonic.player.view;
  * @param artist the artist name
  * @param song the song title
  */
-public record LyricsPage(Integer id, String artist, String song, String lyrics, String source) {
+public record LyricsPage(@Nullable Integer id, @Nullable String artist, @Nullable String song, @Nullable String lyrics, String source) {
 }


### PR DESCRIPTION
Audited all 14 record classes from the Phase 2 conversion. Added @Nullable annotations for legitimately nullable fields and requireNonNull guards for fields that must not be null. 10 files changed, 810/810 tests pass.