### PR TITLE
Add Debian-style EnvironmentFile path to systemd unit - fixes #26

### DIFF
--- a/install/systemd/airsonic.service
+++ b/install/systemd/airsonic.service
@@ -40,6 +40,7 @@ Environment="JAVA_ARGS="
 # Site-specific overrides (PORT, JAVA_OPTS, etc.) go in /etc/sysconfig/airsonic.
 # The file is optional; a missing file is silently ignored.
 EnvironmentFile=-/etc/sysconfig/airsonic
+EnvironmentFile=-/etc/default/airsonic
 
 ExecStart=/usr/bin/java \
           $JAVA_OPTS \


### PR DESCRIPTION
Add `EnvironmentFile=-/etc/default/airsonic` alongside the existing `/etc/sysconfig/airsonic` line so Debian/Ubuntu installations can use their native override path without modifying the unit file.

The `-` prefix means systemd silently ignores the file if it doesn't exist, so both lines are harmless on either distro family.

fixes #26