### PR TITLE
Fix CodeQL OOM and rename workflow - fixes #30

### DIFF
--- a/.github/workflows/any_codeql_scan.yml
+++ b/.github/workflows/any_codeql_scan.yml
@@ -48,8 +48,11 @@ jobs:
     - if: matrix.language == 'java'
       name: Build
       run: mvn package -DskipTests -Dcheckstyle.skip=true
-        
+      env:
+        MAVEN_OPTS: "-Xmx2048m"
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+        ram: 4096


### PR DESCRIPTION
CodeQL analysis was failing with `OutOfMemoryError` in multiple pool threads.

**Fixes:**
- Increase CodeQL analyze step RAM to 4096 MB via `ram:` parameter
- Add `MAVEN_OPTS=-Xmx2048m` to the Maven build step
- Rename `codeql.yml` → `any_codeql_scan.yml` to match workflow naming convention

fixes #30