### PR TITLE
Fix missing %S seek parameter in default transcode command on MariaDB - fixes #42

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
@@ -93,4 +93,14 @@
         </update>
         <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
     </changeSet>
+    <changeSet id="addsplittingtranscoder_001_mariadb" author="litebito" dbms="mariadb">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like binary '% %%S %'</sqlCheck>
+        </preConditions>
+        <update tableName="transcoding">
+            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <where>name='mp3 audio'</where>
+        </update>
+        <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The default `mp3 audio` transcoding command was missing the `%S` (seek/offset) parameter on MariaDB installations.


**Fix:** Added a MariaDB-specific changeset in `cue-support.xml` using `like binary` for case-sensitive precondition matching. Applies to both new and existing MariaDB installations.

fixes #42