### PR TITLE
Fix duplicate credentials on password recovery - fixes #44

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -235,6 +235,8 @@ public class SecurityService implements UserDetailsService {
         userRepository.findByUsername(username).ifPresentOrElse(u -> {
             u.setLdapAuthenticated(false);
             userRepository.save(u);
+            List<UserCredential> existing = userCredentialRepository.findByUserUsernameAndApp(username, App.AIRSONIC);
+            userCredentialRepository.deleteAll(existing);
             createAirsonicCredentialToUser(u, password, comment);
         }, () -> {
                 LOG.warn("Can't recover credential for a non-existent user {}", username);

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTest.java
@@ -213,9 +213,11 @@ public class SecurityServiceTest {
         verify(userRepository).save(any(User.class));
         verify(userCredentialRepository).save(any(UserCredential.class));
 
-        UserCredential actual = userCredentialRepository.findByUserUsernameAndApp(TEST_USER_NAME, App.AIRSONIC).get(0);
-        assertEquals("hex", actual.getEncoder());
-        assertEquals(PasswordEncoderConfig.ENCODERS.get("hex").encode("testPassword"), actual.getCredential());
+        List<UserCredential> credentials = userCredentialRepository.findByUserUsernameAndApp(TEST_USER_NAME, App.AIRSONIC);
+        assertEquals(1, credentials.size());
+        UserCredential actual = credentials.get(0);
+        assertEquals("bcrypt", actual.getEncoder());
+        assertTrue(PasswordEncoderConfig.ENCODERS.get("bcrypt").matches("testPassword", actual.getCredential()));
 
         User actualUser = userRepository.findByUsername(TEST_USER_NAME).get();
         assertFalse(actualUser.isLdapAuthenticated());


### PR DESCRIPTION
Password recovery was inserting a new bcrypt credential without deleting the existing one, leaving duplicate AIRSONIC credentials for the same user.

**Root cause:** `recoverCredential` called `createAirsonicCredentialToUser` which INSERTs a new credential without removing the old one. The test's `findByUserUsernameAndApp(...).get(0)` was order-dependent — HSQLDB returned the older hex credential first (passing locally), while MariaDB/PostgreSQL returned the newer bcrypt one first (failing in CI).

**Fix:**
- `SecurityService.recoverCredential` now deletes all existing AIRSONIC credentials before creating the new one
- Test updated to assert exactly one credential remains with `bcrypt` encoding and uses `matches()` for the non-deterministic bcrypt value

fixes #44