### PR TITLE
Fix VersionServiceTest network dependency causing CI failures - fixes #47

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -104,6 +104,17 @@ public class VersionService {
      */
     private static final long LAST_VERSION_FETCH_INTERVAL = 7L * 24L * 3600L * 1000L; // One week
 
+    // Package-private setters for testing — inject known versions without a network call.
+    void setLatestFinalVersion(Version version) {
+        this.latestFinalVersion = version;
+        this.lastVersionFetched = System.currentTimeMillis();
+    }
+
+    void setLatestBetaVersion(Version version) {
+        this.latestBetaVersion = version;
+        this.lastVersionFetched = System.currentTimeMillis();
+    }
+
     /**
      * Schedules periodic background refresh of the latest available version.
      */

--- a/airsonic-main/src/test/java/org/airsonic/player/service/VersionServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/VersionServiceTest.java
@@ -55,7 +55,7 @@ public class VersionServiceTest {
         properties.put("revision", COMMIT);
         properties.put("timestamp", TIMESTAMP);
         properties.put("name", NAME);
-        properties.put("projectUrl", "https://github.com/kagemomiji/airsonic-advanced");
+        properties.put("projectUrl", "https://github.com/litebito/airsonic-pulse");
         propertiesLoaderUtilsMockedStatic.when(() -> PropertiesLoaderUtils.loadAllProperties("build.properties")).thenReturn(properties);
     }
 
@@ -88,12 +88,14 @@ public class VersionServiceTest {
     @Test
     public void testIsNewFinalVersionAvailable() throws Exception {
         VersionService versionService = new VersionService();
+        versionService.setLatestFinalVersion(new Version("11.0.0"));
         assertTrue(versionService.isNewFinalVersionAvailable());
     }
 
     @Test
     public void testIsNewBetaVersionAvailable() throws Exception {
         VersionService versionService = new VersionService();
+        versionService.setLatestBetaVersion(new Version("11.0.0-SNAPSHOT"));
         assertTrue(versionService.isNewBetaVersionAvailable());
     }
 }


### PR DESCRIPTION
The `VersionServiceTest` tests `testIsNewFinalVersionAvailable` and `testIsNewBetaVersionAvailable` made real HTTP calls to the GitHub API. In CI these fail due to rate limiting or network restrictions, leaving version fields null.

**Fix:**
- Added package-private setters on `VersionService` to inject known versions without network calls
- Tests now use injected versions instead of relying on live GitHub API responses
- Updated mocked `projectUrl` from old upstream to `litebito/airsonic-pulse`

Production code already correctly points to `litebito/airsonic-pulse` (verified in pom.xml and VersionService fallback).

fixes #47