### PR TITLE
Update release workflow: fix runner compat, add Docker publish — fixes #51

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,80 @@
 name: Release
 
 on:
-    push:
-        tags:
-            - 'v*'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
-    release:
-        runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
-        permissions:
-            contents: write
+  build-and-release:
+    runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
+    steps:
+      - uses: actions/checkout@v5
 
-        steps:
-            - uses: actions/checkout@v5
+      - name: Verify environment
+        run: |
+          java -version
+          mvn --version
+          ffmpeg -version
 
-            - name: Set up Java 21
-              uses: actions/setup-java@v4
-              with:
-                  java-version: '21'
-                  distribution: 'temurin'
-                  cache: maven
+      - name: Create music directory
+        run: mkdir -p /tmp/music
 
-            - name: Install ffmpeg
-              run: sudo apt-get install -y ffmpeg
+      - name: Build and test
+        run: mvn clean verify
 
-            - name: Create music directory
-              run: mkdir -p /tmp/music
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-            - name: Build and test
-              run: mvn clean verify
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            airsonic-main/target/airsonic.war#airsonic.war
 
-            - name: Create GitHub Release
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  gh release create "${{ github.ref_name }}" \
-                    --title "${{ github.ref_name }}" \
-                    --generate-notes \
-                    airsonic-main/target/airsonic.war#airsonic.war
+      - name: Prepare Docker build context
+        run: |
+          mkdir -p install/docker/target/dependency
+          cp airsonic-main/target/airsonic.war install/docker/target/dependency/airsonic-main.war
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine Docker tags
+        id: docker-tags
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          TAGS="ghcr.io/litebito/airsonic-pulse:${VERSION}"
+          # Add 'latest' tag only for non-prerelease versions (no hyphen in version)
+          if [[ "${VERSION}" != *-* ]]; then
+            TAGS="${TAGS},ghcr.io/litebito/airsonic-pulse:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: install/docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker-tags.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}


### PR DESCRIPTION
Updates release.yml for the self-hosted CentOS runner and adds Docker image publishing.

**Fixes:**
- Remove actions/setup-java (pre-installed on runner)
- Remove apt-get install ffmpeg (wrong package manager, already installed)

**Docker image publishing:**
- Build and push to ghcr.io/litebito/airsonic-pulse
- Multi-arch: linux/amd64, linux/arm64 (via QEMU + buildx)
- Tagged with version from git tag (e.g. v13.0.0 → 13.0.0)
- Tagged with `latest` only for non-prerelease versions
- Uses GITHUB_TOKEN for GHCR authentication

fixes #51