### PR TITLE
chore: ignore liquibase-core major version updates in Dependabot — fixes #87

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,5 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "org.liquibase:liquibase-core"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
fixes #87