### PR TITLE
chore: rename Trivy job display name to 'Trivy scan' for clarity

### DIFF
--- a/.github/workflows/any_trivy_scan.yml
+++ b/.github/workflows/any_trivy_scan.yml
@@ -18,7 +18,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   scan:
-    name: scan
+    name: "trivy-scan"
     runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Update Trivy Scan YAML.