### PR TITLE
feat: implement OpenSubsonic transcodeOffset extension — fixes #132

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -112,7 +112,7 @@ public class StreamController {
             @RequestParam("maxBitRate") Optional<Integer> maxBitRate,
             @RequestParam("id") Optional<Integer> id,
             @RequestParam("path") Optional<String> path,
-            @RequestParam(required = false, name = "offsetSeconds") Double offsetSeconds,
+            @RequestParam(required = false, name = "timeOffset") Double offsetSeconds,
             ServletWebRequest swr) throws Exception {
 
         String username = securityService.getCurrentUsername(swr.getRequest());
@@ -188,12 +188,16 @@ public class StreamController {
 
             TranscodingService.Parameters parameters = transcodingService.getParameters(file, player, bitRate,
                     targetFormat, videoTranscodingSettings);
+            parameters.setOffsetSeconds(offsetSeconds);
 
             // Support ranges as long as we're not transcoding blindly
             expectedSize = parameters.isRangeAllowed() ? parameters.getExpectedLength() : null;
 
-            // roughly adjust for offset seconds
-            if (expectedSize != null && expectedSize > 0 && offsetSeconds != null && offsetSeconds > 0 && file.getDuration() != null) {
+            // For non-transcoded streams, roughly adjust for offset seconds via byte-level skip.
+            // Transcoded streams have ffmpeg seek the source via %o (-ss), so byte-skipping the
+            // re-encoded output here would double-seek.
+            if (!parameters.isTranscode() && expectedSize != null && expectedSize > 0
+                    && offsetSeconds != null && offsetSeconds > 0 && file.getDuration() != null) {
                 byteOffset = Math.round(expectedSize * offsetSeconds / file.getDuration());
                 expectedSize = Math.max(0, expectedSize - byteOffset);
             }
@@ -239,9 +243,13 @@ public class StreamController {
             statusService.removeActiveLocalPlay(
                     new PlayStatus(status.getId(), mediaFile, player, status.getMillisSinceLastUpdate()));
         };
+        final Double offsetSecondsF = offsetSeconds;
         Function<MediaFile, InputStream> streamGenerator = LambdaUtils.uncheckFunction(
-            mediaFile -> transcodingService.getTranscodedInputStream(
-                    transcodingService.getParameters(mediaFile, player, bitRate, targetFormat, videoTranscodingSettingsF)));
+            mediaFile -> {
+                TranscodingService.Parameters p = transcodingService.getParameters(mediaFile, player, bitRate, targetFormat, videoTranscodingSettingsF);
+                p.setOffsetSeconds(offsetSecondsF);
+                return transcodingService.getTranscodedInputStream(p);
+            });
 
         HttpHeaders headers = new HttpHeaders();
         InputStream playStream = new PlayQueueInputStream(player.getPlayQueue(), fileStartListener, fileEndListener, streamGenerator);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -62,7 +62,8 @@ public class SubsonicRESTController extends AbstractSubsonicController {
 
     private static List<OpenSubsonicExtension> buildExtensionList() {
         return List.of(
-            buildExtension("formPost", 1)
+            buildExtension("formPost", 1),
+            buildExtension("transcodeOffset", 1)
         );
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -99,7 +99,7 @@ public class SettingsService {
     private static final String KEY_UPLOAD_BITRATE_LIMIT = "UploadBitrateLimit";
     private static final String KEY_SPLIT_OPTIONS = "SplitOptions";
     private static final String KEY_SPLIT_COMMAND = "SplitCommand";
-    private static final String KEY_DOWNSAMPLING_COMMAND = "DownsamplingCommand4";
+    private static final String KEY_DOWNSAMPLING_COMMAND = "DownsamplingCommand5";
     private static final String KEY_HLS_COMMAND = "HlsCommand4";
     private static final String KEY_JUKEBOX_COMMAND = "JukeboxCommand2";
     private static final String KEY_VIDEO_IMAGE_COMMAND = "VideoImageCommand";
@@ -205,7 +205,7 @@ public class SettingsService {
     private static final long DEFAULT_UPLOAD_BITRATE_LIMIT = 0;
     private static final String DEFAULT_SPLIT_OPTIONS = "-ss %o -t %d";
     private static final String DEFAULT_SPLIT_COMMAND = "ffmpeg %S -i %s -vcodec copy -acodec copy -f %f -";
-    private static final String DEFAULT_DOWNSAMPLING_COMMAND = "ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -";
+    private static final String DEFAULT_DOWNSAMPLING_COMMAND = "ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -";
     private static final String DEFAULT_HLS_COMMAND = "ffmpeg -ss %o -i %s -s %wx%h -async 1 -c:v libx264 -flags +cgop -b:v %vk -maxrate %bk -preset superfast -copyts -b:a %rk -bufsize 256k -map 0:0 -map 0:%i -ac 2 -ar 44100 -v 0 -threads 0 -force_key_frames expr:gte(t,n_forced*10) -start_number %j -hls_time %d -hls_list_size 0 -hls_segment_filename %n %p";
     private static final String DEFAULT_JUKEBOX_COMMAND = "ffmpeg -ss %o -i %s -map 0:0 -v 0 -ar 44100 -ac 2 -f s16be -";
     private static final String DEFAULT_VIDEO_IMAGE_COMMAND = "ffmpeg -r 1 -ss %o -t 1 -i %s -s %wx%h -v 0 -f mjpeg -";
@@ -281,7 +281,7 @@ public class SettingsService {
 
     // Array of obsolete properties. Used to clean property file.
     private static final List<String> OBSOLETE_KEYS = Arrays.asList("PortForwardingPublicPort", "PortForwardingLocalPort",
-            "DownsamplingCommand", "DownsamplingCommand2", "DownsamplingCommand3", "AutoCoverBatch", "MusicMask",
+            "DownsamplingCommand", "DownsamplingCommand2", "DownsamplingCommand3", "DownsamplingCommand4", "AutoCoverBatch", "MusicMask",
             "VideoMask", "CoverArtMask", "HlsCommand", "HlsCommand2", "HlsCommand3", "JukeboxCommand",
             "CoverArtFileTypes", "UrlRedirectCustomHost", "CoverArtLimit", "StreamPort",
             "PortForwardingEnabled", "RewriteUrl", "UrlRedirectCustomUrl", "UrlRedirectContextPath",

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -337,15 +337,16 @@ public class TranscodingService {
         Integer maxBitRate = parameters.getMaxBitRate();
         VideoTranscodingSettings videoTranscodingSettings = parameters.getVideoTranscodingSettings();
         MediaFile mediaFile = parameters.getMediaFile();
+        Double offsetSeconds = parameters.getOffsetSeconds();
 
-        TranscodeInputStream in = createTranscodeInputStream(transcoding.getStep1(), maxBitRate, videoTranscodingSettings, mediaFile, null);
+        TranscodeInputStream in = createTranscodeInputStream(transcoding.getStep1(), maxBitRate, videoTranscodingSettings, offsetSeconds, mediaFile, null);
 
         if (transcoding.getStep2() != null) {
-            in = createTranscodeInputStream(transcoding.getStep2(), maxBitRate, videoTranscodingSettings, mediaFile, in);
+            in = createTranscodeInputStream(transcoding.getStep2(), maxBitRate, videoTranscodingSettings, offsetSeconds, mediaFile, in);
         }
 
         if (transcoding.getStep3() != null) {
-            in = createTranscodeInputStream(transcoding.getStep3(), maxBitRate, videoTranscodingSettings, mediaFile, in);
+            in = createTranscodeInputStream(transcoding.getStep3(), maxBitRate, videoTranscodingSettings, offsetSeconds, mediaFile, in);
         }
 
         return in;
@@ -378,6 +379,7 @@ public class TranscodingService {
      */
     private TranscodeInputStream createTranscodeInputStream(String command, Integer maxBitRate,
                                                             VideoTranscodingSettings videoTranscodingSettings,
+                                                            Double offsetSeconds,
                                                             MediaFile mediaFile, InputStream in) throws IOException {
 
         // Work-around for filename character encoding problem on Windows.
@@ -402,7 +404,9 @@ public class TranscodingService {
                 Optional.ofNullable(mediaFile.getAlbumName()).orElse("Unknown Album"),
                 Optional.ofNullable(maxBitRate).map(String::valueOf).orElse(null),
                 Optional.ofNullable(mediaFile.getFormat()).orElse(null),
-                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getTimeOffset).map(String::valueOf).orElse(String.valueOf(mediaFile.getStartPosition())),
+                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getTimeOffset).map(String::valueOf)
+                        .or(() -> Optional.ofNullable(offsetSeconds).filter(v -> v > 0).map(v -> String.valueOf(v.intValue())))
+                        .orElse(String.valueOf(mediaFile.getStartPosition())),
                 Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getDuration).map(String::valueOf).orElse(String.valueOf(mediaFile.getDuration())),
                 Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getWidth).map(String::valueOf).orElse(null),
                 Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getHeight).map(String::valueOf).orElse(null),
@@ -677,6 +681,7 @@ public class TranscodingService {
         private final VideoTranscodingSettings videoTranscodingSettings;
         private Integer maxBitRate;
         private Transcoding transcoding;
+        private Double offsetSeconds;
 
         public Parameters(MediaFile mediaFile, VideoTranscodingSettings videoTranscodingSettings) {
             this.mediaFile = mediaFile;
@@ -730,6 +735,14 @@ public class TranscodingService {
 
         public VideoTranscodingSettings getVideoTranscodingSettings() {
             return videoTranscodingSettings;
+        }
+
+        public Double getOffsetSeconds() {
+            return offsetSeconds;
+        }
+
+        public void setOffsetSeconds(Double offsetSeconds) {
+            this.offsetSeconds = offsetSeconds;
         }
     }
 }

--- a/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
@@ -74,31 +74,34 @@
         </rollback>
     </changeSet>
     <changeSet id="addsplittingtranscoder_001" author="yetangitu" dbms="!mysql">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like '% %%S %'</sqlCheck>
         </preConditions>
         <update tableName="transcoding">
-            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <column name="step1" value="ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
             <where>name='mp3 audio'</where>
         </update>
         <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
     </changeSet>
     <changeSet id="addsplittingtranscoder_001_mysql" author="kagemomiji" dbms="mysql">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like binary '% %%S %'</sqlCheck>
         </preConditions>
         <update tableName="transcoding">
-            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <column name="step1" value="ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
             <where>name='mp3 audio'</where>
         </update>
         <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
     </changeSet>
     <changeSet id="addsplittingtranscoder_001_mariadb" author="litebito" dbms="mariadb">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like binary '% %%S %'</sqlCheck>
         </preConditions>
         <update tableName="transcoding">
-            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <column name="step1" value="ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
             <where>name='mp3 audio'</where>
         </update>
         <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />

--- a/airsonic-main/src/main/resources/liquibase/13.1/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.1/changelog.xml
@@ -3,4 +3,5 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <include file="fix-avatar-mime-type.xml" relativeToChangelogFile="true"/>
+    <include file="fix-transcode-offset-mp3.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.1/fix-transcode-offset-mp3.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.1/fix-transcode-offset-mp3.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="fix-transcode-offset-mp3-step1" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*) FROM transcoding WHERE name='mp3 audio' AND step1='ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -'</sqlCheck>
+        </preConditions>
+        <comment>
+            Add -ss %o to the default mp3 audio transcoding step1 so that
+            timeOffset is honored source-side by ffmpeg rather than via a
+            wasteful post-encoding byte-skip. Issue #132 / OpenSubsonic
+            transcodeOffset extension. The preCondition skips this changeset
+            if the admin has customized the mp3 profile, preserving their
+            customization.
+        </comment>
+        <sql>UPDATE transcoding SET step1='ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -' WHERE name='mp3 audio' AND step1='ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -'</sql>
+        <rollback>
+            <sql>UPDATE transcoding SET step1='ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -' WHERE name='mp3 audio' AND step1='ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -'</sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/TranscodingServiceIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/TranscodingServiceIntTest.java
@@ -47,7 +47,7 @@ public class TranscodingServiceIntTest {
         Transcoding mp3Transcode = transcodings.stream().filter(t -> t.getName().equals("mp3 audio")).findFirst().get();
         assertNotNull(mp3Transcode);
         assertEquals("ogg oga aac m4a flac wav wma aif aiff ape mpc shn wv", mp3Transcode.getSourceFormats());
-        assertEquals("ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -", mp3Transcode.getStep1());
+        assertEquals("ffmpeg %S -ss %o -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -", mp3Transcode.getStep1());
         assertEquals("mp3", mp3Transcode.getTargetFormat());
         assertNull(mp3Transcode.getStep2());
         assertNull(mp3Transcode.getStep3());


### PR DESCRIPTION
fixes #132

Honors the timeOffset URL parameter on /stream for audio (not just video). Plumbs offsetSeconds through TranscodingService.Parameters into the ffmpeg command via the -ss flag, producing fast accurate source-side seek instead of a wasteful post-encoding byte-skip.

Affects three code paths:
- mp3 audio transcoding profile (Liquibase changeset updates default; sqlCheck preserves admin customizations)
- Downsample command (SettingsService default constant updated; KEY suffix bumped 4→5 per upstream pattern)
- Per-MediaFile streaming lambda (captures offsetSeconds in lambda closure)

Declares transcodeOffset v1 in getOpenSubsonicExtensions response.