### PR TITLE
feat: implement OpenSubsonic getPodcastEpisode endpoint — fixes #133

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPodcastController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPodcastController.java
@@ -121,6 +121,25 @@ public class SubsonicPodcastController extends AbstractSubsonicController {
         jaxbWriter.writeResponse(request, response, res);
     }
 
+    @RequestMapping({"/getPodcastEpisode", "/getPodcastEpisode.view"})
+    public void getPodcastEpisode(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        request = wrapRequest(request);
+        String username = securityService.getCurrentUsername(request);
+        Player player = playerService.getPlayer(request, response, username);
+
+        int id = getRequiredIntParameter(request, "id");
+
+        org.airsonic.player.domain.PodcastEpisode episode = podcastPersistenceService.getEpisode(id, true);
+        if (episode == null) {
+            error(request, response, SubsonicRESTController.ErrorCode.NOT_FOUND, "Podcast episode " + id + " not found.");
+            return;
+        }
+
+        Response res = createResponse();
+        res.setPodcastEpisode(createJaxbPodcastEpisode(player, username, episode));
+        jaxbWriter.writeResponse(request, response, res);
+    }
+
     private org.subsonic.restapi.PodcastEpisode createJaxbPodcastEpisode(Player player, String username, org.airsonic.player.domain.PodcastEpisode episode) {
         org.subsonic.restapi.PodcastEpisode e = new org.subsonic.restapi.PodcastEpisode();
 

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -41,6 +41,7 @@
             <xs:element name="lyrics" type="sub:Lyrics" minOccurs="1" maxOccurs="1"/>
             <xs:element name="podcasts" type="sub:Podcasts" minOccurs="1" maxOccurs="1"/>
             <xs:element name="newestPodcasts" type="sub:NewestPodcasts" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="podcastEpisode" type="sub:PodcastEpisode" minOccurs="1" maxOccurs="1"/>
             <xs:element name="internetRadioStations" type="sub:InternetRadioStations" minOccurs="1" maxOccurs="1"/>
             <xs:element name="bookmarks" type="sub:Bookmarks" minOccurs="1" maxOccurs="1"/>
             <xs:element name="playQueue" type="sub:PlayQueue" minOccurs="1" maxOccurs="1"/>


### PR DESCRIPTION
fixes #133

New endpoint per OpenSubsonic spec: `/rest/getPodcastEpisode?id=N` returns a single PodcastEpisode by id.

Implementation:
- New `podcastEpisode` element on Response in subsonic-rest-api.xsd (JAXB regenerated)
- New `getPodcastEpisode` method in SubsonicPodcastController (modeled on getNewestPodcasts)
- Returns NOT_FOUND envelope for unknown id, MISSING_PARAMETER for missing id
- No role gate — matches existing read-only podcast endpoint behavior