### PR TITLE
feat: implement OpenSubsonic songLyrics extension (unsynced) — fixes #131

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
@@ -19,6 +19,7 @@
  */
 package org.airsonic.player.controller;
 
+import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.User;
 import org.airsonic.player.service.LyricsService;
@@ -35,8 +36,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.subsonic.restapi.Line;
 import org.subsonic.restapi.Lyrics;
+import org.subsonic.restapi.LyricsList;
 import org.subsonic.restapi.Response;
+import org.subsonic.restapi.StructuredLyrics;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -156,6 +160,42 @@ public class SubsonicMediaController extends AbstractSubsonicController {
 
         Response res = createResponse();
         res.setLyrics(result);
+        jaxbWriter.writeResponse(request, response, res);
+    }
+
+    @RequestMapping({"/getLyricsBySongId", "/getLyricsBySongId.view"})
+    public void getLyricsBySongId(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        request = wrapRequest(request);
+
+        int id = ServletRequestUtils.getRequiredIntParameter(request, "id");
+
+        MediaFile mediaFile = mediaFileService.getMediaFile(id);
+        if (mediaFile == null) {
+            error(request, response, SubsonicRESTController.ErrorCode.NOT_FOUND, "Media file " + id + " not found.");
+            return;
+        }
+
+        LyricsList result = new LyricsList();
+
+        org.airsonic.player.domain.Lyrics lyrics = lyricsService.getLyricsFromMediaFile(mediaFile);
+        if (lyrics != null && lyrics.getLyrics() != null && !lyrics.getLyrics().isBlank()) {
+            StructuredLyrics structured = new StructuredLyrics();
+            structured.setDisplayArtist(mediaFile.getArtist());
+            structured.setDisplayTitle(mediaFile.getTitle());
+            structured.setLang("xxx");
+            structured.setSynced(false);
+
+            for (String lineText : lyrics.getLyrics().split("\\R")) {
+                Line line = new Line();
+                line.setValue(lineText);
+                structured.getLine().add(line);
+            }
+
+            result.getStructuredLyrics().add(structured);
+        }
+
+        Response res = createResponse();
+        res.setLyricsList(result);
         jaxbWriter.writeResponse(request, response, res);
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -63,7 +63,8 @@ public class SubsonicRESTController extends AbstractSubsonicController {
     private static List<OpenSubsonicExtension> buildExtensionList() {
         return List.of(
             buildExtension("formPost", 1),
-            buildExtension("transcodeOffset", 1)
+            buildExtension("transcodeOffset", 1),
+            buildExtension("songLyrics", 1)
         );
     }
 

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -39,6 +39,7 @@
             <xs:element name="randomSongs" type="sub:Songs" minOccurs="1" maxOccurs="1"/>
             <xs:element name="songsByGenre" type="sub:Songs" minOccurs="1" maxOccurs="1"/>
             <xs:element name="lyrics" type="sub:Lyrics" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="lyricsList" type="sub:LyricsList" minOccurs="1" maxOccurs="1"/>
             <xs:element name="podcasts" type="sub:Podcasts" minOccurs="1" maxOccurs="1"/>
             <xs:element name="newestPodcasts" type="sub:NewestPodcasts" minOccurs="1" maxOccurs="1"/>
             <xs:element name="podcastEpisode" type="sub:PodcastEpisode" minOccurs="1" maxOccurs="1"/>
@@ -417,6 +418,28 @@
     <xs:complexType name="Lyrics" mixed="true">
         <xs:attribute name="artist" type="xs:string" use="optional"/>
         <xs:attribute name="title" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="LyricsList">
+        <xs:sequence>
+            <xs:element name="structuredLyrics" type="sub:StructuredLyrics" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="StructuredLyrics">
+        <xs:sequence>
+            <xs:element name="line" type="sub:Line" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="displayArtist" type="xs:string" use="optional"/>
+        <xs:attribute name="displayTitle" type="xs:string" use="optional"/>
+        <xs:attribute name="lang" type="xs:string" use="required"/>
+        <xs:attribute name="synced" type="xs:boolean" use="required"/>
+        <xs:attribute name="offset" type="xs:int" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="Line">
+        <xs:attribute name="value" type="xs:string" use="required"/>
+        <xs:attribute name="start" type="xs:long" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="Podcasts">


### PR DESCRIPTION
fixes #131

New OpenSubsonic endpoint `/rest/getLyricsBySongId?id=N` returns structured lyrics for a song.

Implementation:
- New XSD types: LyricsList, StructuredLyrics, Line
- New `lyricsList` element on Response
- New endpoint in SubsonicMediaController, wraps existing LyricsService.getLyricsFromMediaFile() result
- Declares `songLyrics v1` in getOpenSubsonicExtensions

Scope: This PR ships the API endpoint and response shape using the existing sidecar-LRC-file lyrics infrastructure. A follow-up issue will be filed for milestone 13.2.x to add embedded-tag (FieldKey.LYRICS) reading via jaudiotagger, which benefits both this endpoint and the legacy /getLyrics endpoint.