### PR TITLE
chore: release workflow uses committed release-notes file

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -1,23 +1,39 @@
 #!/bin/bash
 set -euo pipefail
 
-# format-release-notes.sh — Generate formatted release notes from merged PRs
+# release-notes.sh — Generate formatted release notes and write to file
 #
 # Usage:
-#   ./scripts/format-release-notes.sh <release-tag> [since-tag]
+#   ./scripts/release-notes.sh <release-tag> [since-tag]
+#
+# Behavior:
+#   - Generates the auto-categorized "What's Changed" section from merged PRs
+#   - Writes to docs/release-notes/<tag>.md
+#   - Also emits the auto section to stdout for piping/preview
+#   - On first run for a tag, creates the file with a title header and marker:
+#       # Airsonic-Pulse <tag>
+#
+#       <!-- AUTO-GENERATED-BELOW -->
+#       ## What's Changed
+#       [... auto content ...]
+#   - On subsequent runs, finds the <!-- AUTO-GENERATED-BELOW --> marker and
+#     replaces everything from that line down with freshly-generated content.
+#     Content above the marker (Highlights, Upgrade notes, etc.) is preserved.
+#   - If the file exists but has no marker line, appends marker + auto content
+#     to the end (safety fallback).
 #
 # Examples:
-#   ./scripts/format-release-notes.sh v13.1.0 v13.0.0
-#   ./scripts/format-release-notes.sh v13.1.0              # auto-detects previous tag
-#   ./scripts/format-release-notes.sh v13.1.0 v13.0.0 | gh release edit v13.1.0 --notes-file -
+#   ./scripts/release-notes.sh v13.1.0 v13.0.0
+#   ./scripts/release-notes.sh v13.1.0              # auto-detects previous tag
+#   ./scripts/release-notes.sh v13.1.0 | less       # preview while writing
 #
 # Categorization priority:
 #   1. Issue labels (if PR references an issue via "fixes #N" or "closes #N")
 #   2. PR title pattern (fallback for PRs without issue references)
 #
-# Label-to-category mapping (in priority order — highest wins):
+# Label-to-category mapping (highest priority first):
 #   bug                  → Bug Fixes
-#   hardening, security  → Hardening
+#   hardening, security  → Hardening & Security
 #   infrastructure       → Infrastructure & CI
 #   documentation        → Documentation
 #   enhancement          → Features & Enhancements
@@ -27,6 +43,9 @@ set -euo pipefail
 
 RELEASE_TAG="${1:-}"
 SINCE_TAG="${2:-}"
+MARKER="<!-- AUTO-GENERATED-BELOW -->"
+NOTES_DIR="docs/release-notes"
+NOTES_FILE="${NOTES_DIR}/${RELEASE_TAG}.md"
 
 if [[ -z "${RELEASE_TAG}" ]]; then
     echo "Usage: $0 <release-tag> [since-tag]" >&2
@@ -89,8 +108,6 @@ fi
 # ---------------------------------------------------------------------------
 
 # Label priority order (highest priority first).
-# When an issue has multiple labels, the highest-priority match wins.
-# E.g. an issue labeled "bug" + "hardening" → Bug Fixes (bug is higher priority).
 LABEL_PRIORITY=(
     bug
     hardening
@@ -102,7 +119,6 @@ LABEL_PRIORITY=(
     chore
 )
 
-# Map a label name to a category key
 label_to_category() {
     local label="$1"
     case "${label}" in
@@ -118,8 +134,6 @@ label_to_category() {
     esac
 }
 
-# Given a newline-separated list of labels, return the category for the
-# highest-priority label that maps to a category.
 labels_to_category() {
     local labels="$1"
     local priority_label
@@ -132,7 +146,6 @@ labels_to_category() {
     echo ""
 }
 
-# Fallback: guess category from PR title (for PRs without issue references)
 title_to_category() {
     local title_lower
     title_lower="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
@@ -157,7 +170,6 @@ title_to_category() {
     fi
 }
 
-# Arrays for categorized output
 declare -a CAT_FEATURES=()
 declare -a CAT_DOCUMENTATION=()
 declare -a CAT_BUGFIXES=()
@@ -165,14 +177,12 @@ declare -a CAT_HARDENING=()
 declare -a CAT_INFRASTRUCTURE=()
 declare -a CAT_MAINTENANCE=()
 
-# Process each PR
 while IFS= read -r pr_line; do
     PR_NUM="$(echo "${pr_line}" | jq -r '.number')"
     PR_TITLE="$(echo "${pr_line}" | jq -r '.title')"
     PR_AUTHOR="$(echo "${pr_line}" | jq -r '.author.login')"
     PR_BODY="$(echo "${pr_line}" | jq -r '.body // ""')"
 
-    # Extract issue number from PR title or body ("fixes #N", "closes #N")
     ISSUE_NUM=""
     if [[ "${PR_TITLE}" =~ [Ff]ixes[[:space:]]+#([0-9]+) ]]; then
         ISSUE_NUM="${BASH_REMATCH[1]}"
@@ -184,38 +194,30 @@ while IFS= read -r pr_line; do
         ISSUE_NUM="${BASH_REMATCH[1]}"
     fi
 
-    # Build the formatted line
     CATEGORY=""
     if [[ -n "${ISSUE_NUM}" ]]; then
-        # Fetch issue title and labels
         ISSUE_DATA="$(gh issue view "${ISSUE_NUM}" --json title,labels 2>/dev/null || echo "")"
         if [[ -n "${ISSUE_DATA}" ]]; then
             ISSUE_TITLE="$(echo "${ISSUE_DATA}" | jq -r '.title')"
-            # Strip common prefixes from issue titles
             ISSUE_TITLE="${ISSUE_TITLE#\[Feature Request\]: }"
             ISSUE_TITLE="${ISSUE_TITLE#\[Bug Report\]: }"
 
             LINE="* #${ISSUE_NUM} ${ISSUE_TITLE} by @${PR_AUTHOR} in #${PR_NUM}"
 
-            # Categorize from labels (highest-priority label wins)
             LABELS="$(echo "${ISSUE_DATA}" | jq -r '[.labels[].name] | join("\n")')"
             CATEGORY="$(labels_to_category "${LABELS}")"
         else
-            # Issue not found — use PR title
             CLEAN_TITLE="$(echo "${PR_TITLE}" | sed -E 's/[[:space:]]*[-—]+[[:space:]]*[Ff]ixes[[:space:]]+#[0-9]+//')"
             LINE="* #${ISSUE_NUM} ${CLEAN_TITLE} by @${PR_AUTHOR} in #${PR_NUM}"
         fi
     else
-        # No issue reference — use PR title as-is
         LINE="* ${PR_TITLE} by @${PR_AUTHOR} in #${PR_NUM}"
     fi
 
-    # Fallback to title-based categorization if labels didn't match
     if [[ -z "${CATEGORY}" ]]; then
         CATEGORY="$(title_to_category "${PR_TITLE}")"
     fi
 
-    # Add to appropriate category array
     case "${CATEGORY}" in
         features)       CAT_FEATURES+=("${LINE}") ;;
         documentation)  CAT_DOCUMENTATION+=("${LINE}") ;;
@@ -230,46 +232,101 @@ while IFS= read -r pr_line; do
 done < <(echo "${PRS_FILTERED}" | jq -c '.[]')
 
 # ---------------------------------------------------------------------------
-# Output
+# Build the auto section
 # ---------------------------------------------------------------------------
 
-echo "## What's Changed"
-echo ""
+AUTO_CONTENT="$(mktemp --suffix=.md)"
+trap 'rm -f "${AUTO_CONTENT}"' EXIT
 
-if [[ ${#CAT_FEATURES[@]} -gt 0 ]]; then
-    echo "### Features & Enhancements"
-    printf '%s\n' "${CAT_FEATURES[@]}"
+{
+    echo "## What's Changed"
     echo ""
+
+    if [[ ${#CAT_FEATURES[@]} -gt 0 ]]; then
+        echo "### Features & Enhancements"
+        printf '%s\n' "${CAT_FEATURES[@]}"
+        echo ""
+    fi
+
+    if [[ ${#CAT_DOCUMENTATION[@]} -gt 0 ]]; then
+        echo "### Documentation"
+        printf '%s\n' "${CAT_DOCUMENTATION[@]}"
+        echo ""
+    fi
+
+    if [[ ${#CAT_BUGFIXES[@]} -gt 0 ]]; then
+        echo "### Bug Fixes"
+        printf '%s\n' "${CAT_BUGFIXES[@]}"
+        echo ""
+    fi
+
+    if [[ ${#CAT_HARDENING[@]} -gt 0 ]]; then
+        echo "### Hardening & Security"
+        printf '%s\n' "${CAT_HARDENING[@]}"
+        echo ""
+    fi
+
+    if [[ ${#CAT_INFRASTRUCTURE[@]} -gt 0 ]]; then
+        echo "### Infrastructure & CI"
+        printf '%s\n' "${CAT_INFRASTRUCTURE[@]}"
+        echo ""
+    fi
+
+    if [[ ${#CAT_MAINTENANCE[@]} -gt 0 ]]; then
+        echo "### Maintenance"
+        printf '%s\n' "${CAT_MAINTENANCE[@]}"
+        echo ""
+    fi
+
+    echo "**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/${SINCE_TAG}...${RELEASE_TAG}"
+} > "${AUTO_CONTENT}"
+
+# ---------------------------------------------------------------------------
+# Write to file (creating, updating, or appending as appropriate)
+# ---------------------------------------------------------------------------
+
+mkdir -p "${NOTES_DIR}"
+
+if [[ ! -f "${NOTES_FILE}" ]]; then
+    # First run for this tag — create the file with title, marker, and auto content
+    {
+        echo "# Airsonic-Pulse ${RELEASE_TAG}"
+        echo ""
+        echo "${MARKER}"
+        cat "${AUTO_CONTENT}"
+    } > "${NOTES_FILE}"
+    echo "Created ${NOTES_FILE}" >&2
+    echo "Add Highlights / Upgrade notes between the title and the ${MARKER} marker," >&2
+    echo "then commit and push before tagging." >&2
+
+elif grep -qF "${MARKER}" "${NOTES_FILE}"; then
+    # File exists with marker — preserve everything up to and including the marker,
+    # replace everything below with fresh auto content
+    PRESERVED="$(mktemp --suffix=.md)"
+    trap 'rm -f "${AUTO_CONTENT}" "${PRESERVED}"' EXIT
+
+    # Extract content up to and including the marker line
+    awk -v marker="${MARKER}" '
+        { print }
+        index($0, marker) { exit }
+    ' "${NOTES_FILE}" > "${PRESERVED}"
+
+    {
+        cat "${PRESERVED}"
+        cat "${AUTO_CONTENT}"
+    } > "${NOTES_FILE}"
+
+    echo "Updated ${NOTES_FILE} (regenerated auto section below ${MARKER})" >&2
+
+else
+    # File exists but no marker — append marker + auto content as safety fallback
+    {
+        echo ""
+        echo "${MARKER}"
+        cat "${AUTO_CONTENT}"
+    } >> "${NOTES_FILE}"
+    echo "Appended marker + auto content to ${NOTES_FILE} (no existing marker found)" >&2
 fi
 
-if [[ ${#CAT_DOCUMENTATION[@]} -gt 0 ]]; then
-    echo "### Documentation"
-    printf '%s\n' "${CAT_DOCUMENTATION[@]}"
-    echo ""
-fi
-
-if [[ ${#CAT_BUGFIXES[@]} -gt 0 ]]; then
-    echo "### Bug Fixes"
-    printf '%s\n' "${CAT_BUGFIXES[@]}"
-    echo ""
-fi
-
-if [[ ${#CAT_HARDENING[@]} -gt 0 ]]; then
-    echo "### Hardening & Security"
-    printf '%s\n' "${CAT_HARDENING[@]}"
-    echo ""
-fi
-
-if [[ ${#CAT_INFRASTRUCTURE[@]} -gt 0 ]]; then
-    echo "### Infrastructure & CI"
-    printf '%s\n' "${CAT_INFRASTRUCTURE[@]}"
-    echo ""
-fi
-
-if [[ ${#CAT_MAINTENANCE[@]} -gt 0 ]]; then
-    echo "### Maintenance"
-    printf '%s\n' "${CAT_MAINTENANCE[@]}"
-    echo ""
-fi
-
-echo "**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/${SINCE_TAG}...${RELEASE_TAG}"
+# Always emit to stdout for piping/preview
+cat "${AUTO_CONTENT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,22 @@ jobs:
           mvn --version
           ffmpeg -version
 
+      - name: Locate release notes
+        id: notes
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          NOTES_FILE="docs/release-notes/${REF_NAME}.md"
+          if [[ ! -f "${NOTES_FILE}" ]]; then
+            echo "::error::Release notes file missing at ${NOTES_FILE}"
+            echo "::error::Generate it locally with:"
+            echo "::error::  bash .github/scripts/release-notes.sh ${REF_NAME}"
+            echo "::error::Edit the file to add Highlights / Upgrade notes above the marker,"
+            echo "::error::then commit, push, and re-tag."
+            exit 1
+          fi
+          echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+
       - name: Create music directory
         run: mkdir -p /tmp/music
 
@@ -29,20 +45,38 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums
         run: |
           cd airsonic-main/target
           sha256sum airsonic.war > artifacts-checksums.sha256
 
+      - name: Determine prerelease flag
+        id: prerelease
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Tag contains a hyphen → prerelease (e.g. v13.1.0-rc.1, v13.1.0-beta.2)
+          if [[ "${REF_NAME}" == *-* ]]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
+          PRERELEASE_FLAG: ${{ steps.prerelease.outputs.flag }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
+          gh release create "${REF_NAME}" \
+            --title "${REF_NAME}" \
+            --notes-file "${NOTES_FILE}" \
+            ${PRERELEASE_FLAG} \
             airsonic-main/target/airsonic.war#airsonic.war \
             airsonic-main/target/artifacts-checksums.sha256#artifacts-checksums.sha256
 
@@ -66,8 +100,9 @@ jobs:
 
       - name: Determine Docker tags
         id: docker-tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
           TAGS="ghcr.io/litebito/airsonic-pulse:${VERSION}"
           # Add 'latest' tag only for non-prerelease versions (no hyphen in version)
           if [[ "${VERSION}" != *-* ]]; then

--- a/docs/release-notes/v13.1.0-rc.1.md
+++ b/docs/release-notes/v13.1.0-rc.1.md
@@ -1,0 +1,89 @@
+# Airsonic-Pulse v13.1.0-rc.1
+
+## Highlights
+
+**OpenSubsonic API support.** Airsonic-Pulse 13.1.0 is the first kagemomiji-descended fork to implement the OpenSubsonic API specification. Five OpenSubsonic extensions and endpoints are now supported:
+
+- `transcodeOffset v1` — `/stream` honors `timeOffset` accurately via source-side ffmpeg seek (was a wasteful post-encoding byte skip)
+- `songLyrics v1` — new `/getLyricsBySongId` endpoint returns structured lyrics
+- `/getPodcastEpisode` — new endpoint for per-episode lookup
+- `AlbumID3.playCount` wiring (existing field, never previously populated)
+- New optional fields on Child/AlbumID3/ArtistID3: `played`, `musicBrainzId`, `displayArtist`, `displayAlbumArtist`, `mediaType`
+
+OpenSubsonic-compliant clients (Symfonium, Tempo, others) will now see Pulse declare its supported extensions via `getOpenSubsonicExtensions` and use the extended response shapes automatically.
+
+**SubsonicRESTController refactor.** The monolithic `SubsonicRESTController` has been split into 13 domain-specific controllers (system, browsing, ID3, search, annotation, play queue, bookmark, share, podcast, radio, jukebox, playlist, artist info, user, media). Shared utilities are lifted into a new `AbstractSubsonicController` base class, and exception handling is consolidated via a `@ControllerAdvice`. Result: ~1000 fewer lines of duplicated boilerplate, clearer ownership, and easier future maintenance. No API contract changes for clients.
+
+**Subsonic API 1.16.1.** The server now declares itself as Subsonic API version 1.16.1 (was 1.15.0). Internet radio CRUD endpoints from Subsonic 1.16.0 are implemented (`createInternetRadioStation`, `updateInternetRadioStation`, `deleteInternetRadioStation`). Modern clients sending `v=1.16.1` are no longer rejected.
+
+## Upgrade notes
+
+**Audio transcoding offsets (admins of customized transcoding profiles).**
+
+13.1.0 plumbs the user's `timeOffset` directly into the ffmpeg command via the `-ss` flag, producing a fast, accurate source-side seek for transcoded audio. Previously, audio offsets were applied via a byte-level skip on the transcoded output — wasteful (ffmpeg encoded audio that was then discarded) and imprecise (especially for VBR sources).
+
+Two settings power this behavior:
+
+- The **`mp3 audio` transcoding profile** — updated automatically on upgrade. A Liquibase precondition preserves admin customizations: if you previously changed this profile, your changes are kept intact. To benefit from accurate seek in customized configurations, manually add `-ss %o` immediately after `ffmpeg %S` in your profile's Step 1.
+- The **system Downsample command** — reset to the new default on upgrade. Any customization of the Downsample command will be lost (consistent with how prior Airsonic versions handled forced default upgrades). If you had a custom Downsample command, recreate it post-upgrade and add `-ss %o` after `ffmpeg %S` to benefit from accurate seek.
+
+---
+
+<!-- AUTO-GENERATED-BELOW -->
+## What's Changed
+
+### Features & Enhancements
+* #64 Add OpenSubsonic response envelope fields by @litebito in #65
+* #66 Add getOpenSubsonicExtensions endpoint by @litebito in #68
+* #98 Refactor: extract APIException @ExceptionHandler into @ControllerAdvice by @litebito in #118
+* #112 Refactor: extract AbstractSubsonicController base class for shared utilities by @litebito in #119
+* #67 Clean up version display for non-SNAPSHOT releases by @litebito in #121
+* #123 Implement Subsonic 1.16.0 internet radio CRUD endpoints by @litebito in #128
+* #129 [OpenSubsonic] Wire already-in-XSD response fields (Child.played, AlbumID3.playCount/played) by @litebito in #146
+* #130 [OpenSubsonic] Add musicBrainzId, displayArtist, displayAlbumArtist, mediaType to XSD and wire by @litebito in #147
+* #132 [OpenSubsonic] Verify transcodeOffset extension and declare support by @litebito in #149
+* #133 [OpenSubsonic] Implement getPodcastEpisode endpoint by @litebito in #155
+* #131 [OpenSubsonic] Implement songLyrics extension (unsynced, tag-read-at-request-time) by @litebito in #156
+
+### Bug Fixes
+* #57 [Bug]: updateUser REST endpoint maps streamRole from downloadRole by @litebito in #58
+* #59 [Bug]: getVideoInfo and getCaptions return plain text 501 instead of JAXB error envelope by @litebito in #61
+* #115 [Bug]: /getAvatar returns non-standard Content-Type 'img/png' instead of 'image/png' by @litebito in #120
+* #117 [Bug]: /stream returns empty 200 with application/octet-stream for non-existent media ID by @litebito in #122
+* #113 [Bug]: Server reports Subsonic API version 1.15.0 — modern clients sending v=1.16.1 get rejected by @litebito in #124
+* #126 [Bug]: PodcastRepositoryTest is non-deterministic on HSQLDB due to missing ORDER BY in repository queries by @litebito in #127
+
+### Infrastructure & CI
+* ci: bump docker/setup-qemu-action from 3 to 4 by @app/dependabot in #74
+* chore: rename Trivy job display name to 'Trivy scan' for clarity by @litebito in #148
+
+### Maintenance
+* #62 [Chore]: Make JAXBWriter a Spring @Component by @litebito in #63
+* #69 [Chore]: Extract SubsonicSystemController from SubsonicRESTController by @litebito in #70
+* #71 [Chore]: Extract SubsonicBrowsingController from SubsonicRESTController by @litebito in #72
+* deps: bump org.codehaus.mojo:buildnumber-maven-plugin from 3.2.1 to 3.3.0 by @app/dependabot in #77
+* deps: bump com.twelvemonkeys.imageio:imageio-webp from 3.12.0 to 3.13.1 by @app/dependabot in #78
+* deps: bump ch.qos.logback:logback-core from 1.5.18 to 1.5.25 in the maven group across 1 directory by @app/dependabot in #81
+* Bump com.github.junrar:junrar from 7.5.5 to 7.5.10 in /airsonic-main in the maven group across 1 directory by @app/dependabot in #82
+* Bump org.bouncycastle:bcprov-jdk18on from 1.81 to 1.84 in /airsonic-main in the maven group across 1 directory by @app/dependabot in #83
+* #80 [Chore]: Extract SubsonicID3Controller from SubsonicRESTController by @litebito in #84
+* #85 [Chore]: Extract SubsonicSearchController from SubsonicRESTController by @litebito in #86
+* #87 [Chore]: Ignore liquibase-core major version updates in Dependabot by @litebito in #88
+* #89 [Chore]: Extract SubsonicAnnotationController from SubsonicRESTController by @litebito in #90
+* #91 [Chore]: Extract SubsonicPlayQueueController from SubsonicRESTController by @litebito in #92
+* #93 [Chore]: Extract SubsonicBookmarkController from SubsonicRESTController by @litebito in #94
+* #95 [Chore]: Extract SubsonicShareController from SubsonicRESTController by @litebito in #96
+* #97 [Chore]: Extract SubsonicPodcastController from SubsonicRESTController by @litebito in #99
+* #100 [Chore]: Extract SubsonicRadioController from SubsonicRESTController by @litebito in #101
+* #102 [Chore]: Extract SubsonicJukeboxController from SubsonicRESTController by @litebito in #103
+* #104 [Chore]: Extract SubsonicPlaylistController from SubsonicRESTController by @litebito in #105
+* #106 [Chore]: Extract SubsonicArtistInfoController from SubsonicRESTController by @litebito in #107
+* #108 [Chore]: Extract SubsonicUserController from SubsonicRESTController by @litebito in #109
+* #110 [Chore]: Extract SubsonicMediaController from SubsonicRESTController by @litebito in #111
+* deps: bump com.google.guava:guava from 33.4.8-jre to 33.6.0-jre by @app/dependabot in #150
+* deps: bump org.apache.commons:commons-configuration2 from 2.12.0 to 2.14.0 by @app/dependabot in #151
+* deps: bump com.google.errorprone:error_prone_annotations from 2.41.0 to 2.49.0 by @app/dependabot in #152
+* deps: bump net.java.dev.jna:jna from 5.17.0 to 5.18.1 by @app/dependabot in #153
+* deps: bump org.apache.commons:commons-lang3 from 3.18.0 to 3.20.0 by @app/dependabot in #154
+
+**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.1


### PR DESCRIPTION
Updates the release process to use hand-authored prose + auto-generated PR list.

**Script changes (`format-release-notes.sh` → `release-notes.sh`):**
- Writes to `docs/release-notes/<tag>.md` instead of stdout-only
- Uses `<- No functional changes to any API AUTO-GENERATED-BELOW -->` marker to preserve prose (Highlights, Upgrade notes) across re-runs
- First run creates the file with title + marker + auto content
- Subsequent runs replace only the content below the marker
- Still emits to stdout for piping/preview

**Workflow changes:**
- Validates `docs/release-notes/<tag>.md` exists; fails fast with clear error if missing
- Replaces `--generate-notes` with `--notes-file` pointing at the committed file
- Auto-detects `--prerelease` from tag name (hyphen present = prerelease)
- No more silently shipping GitHub's flat unstyled list

**New release prep flow:**

1. `bash .github/scripts/release-notes.sh <tag>` — creates/updates `docs/release-notes/<tag>.md`
2. Edit the file to add Highlights / Upgrade notes above the marker
3. Commit and push to main
4. Tag and push — workflow handles the rest