### PR TITLE
chore: rename in-repo references for Airsonic-Pulse org transfer (fixes #162)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS for litebito/airsonic-pulse
+# CODEOWNERS for Airsonic-Pulse/airsonic-pulse
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 # When a PR is opened, GitHub auto-requests review from the matching owner(s).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Global Guidelines for Contributing
 
 
-litebito/airsonic-pulse development is a community project, and contributions are welcomed. Here are a few guidelines you should follow before submitting:
+Airsonic-Pulse/airsonic-pulse development is a community project, and contributions are welcomed. Here are a few guidelines you should follow before submitting:
 
-  1.  **License Acceptance** All contributions must be licensed as [GNU GPLv3](https://github.com/litebito/airsonic-pulse/blob/main/LICENSE.txt) to be accepted. Use [`git commit --signoff`](https://jk.gs/git-commit.html) to acknowledge this.
+  1.  **License Acceptance** All contributions must be licensed as [GNU GPLv3](https://github.com/Airsonic-Pulse/airsonic-pulse/blob/main/LICENSE.txt) to be accepted. Use [`git commit --signoff`](https://jk.gs/git-commit.html) to acknowledge this.
   2.  **No Breakage** New features or changes to existing ones must not degrade the user experience. This means do not introduce bugs, remove functionality, or make large changes to existing themes/UI without prior discussion in an Issue.
   3.  **Coding standards** Language best-practices should be followed, comment generously, and avoid "clever" algorithms. Refactoring existing messes is great, but watch out for breakage.
-  4.  **Be bold!** Without contributions, this project will vanish. If you just want to help out, try [submitting a patch](https://github.com/litebito/airsonic-pulse/issues?q=is%3Aissue+is%3Aopen+label%3Apatches-welcome) for an open Issue.
-  5.  **Stay relevant** Issues or commentary that is off-topic or tangential to litebito/airsonic-pulse development is subject to moderation. Questions should be focused on improving documentation to solve a problem. Visit [GitHub Discussions](https://github.com/litebito/airsonic-pulse/discussions)
+  4.  **Be bold!** Without contributions, this project will vanish. If you just want to help out, try [submitting a patch](https://github.com/Airsonic-Pulse/airsonic-pulse/issues?q=is%3Aissue+is%3Aopen+label%3Apatches-welcome) for an open Issue.
+  5.  **Stay relevant** Issues or commentary that is off-topic or tangential to Airsonic-Pulse/airsonic-pulse development is subject to moderation. Questions should be focused on improving documentation to solve a problem. Visit [GitHub Discussions](https://github.com/Airsonic-Pulse/airsonic-pulse/discussions)
   
 
 # Getting a .war
@@ -32,7 +32,7 @@ mvn -DskipTests -Dcheckstyle.skip=true clean package
 
 # Suggesting modifications
 
-Airsonic-Pulse's source code is hosted on [github](https://github.com/litebito/airsonic-pulse/), who provides a [lot of documentation](https://help.github.com/en) on how to contribute to projects hosted there.
+Airsonic-Pulse's source code is hosted on [github](https://github.com/Airsonic-Pulse/airsonic-pulse/), who provides a [lot of documentation](https://help.github.com/en) on how to contribute to projects hosted there.
 
 Keep in mind that this is a non-funded community-driven project maintained by a relatively small group of contributors (today in 2026, just myself) who have many other responsibilities and demands on their time. 
 Development, maintenance, and administration of the project is done on a best-effort basis, as time and other constraints permit.
@@ -85,7 +85,7 @@ And finally:
 
 Once all concerns have been addressed, having a change accepted usually
 requires two (or more, depending on complexity and impact) [core
-contributors](https://github.com/litebito/airsonic-pulse/graphs/contributors): one to
+contributors](https://github.com/Airsonic-Pulse/airsonic-pulse/graphs/contributors): one to
 explicitly approve the pull-request, and another to perform the actual merge.
 
 If you keep sending great code, you might be invited to become a *core

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: General Questions & Discussions
-    url: https://github.com/litebito/airsonic-pulse/discussions
+    url: https://github.com/Airsonic-Pulse/airsonic-pulse/discussions
     about: For general questions, configuration help, or anything that is not a bug or feature request, please use GitHub Discussions.
   - name: Subsonic API Compatibility
     url: https://www.subsonic.org/pages/api.jsp
     about: Reference documentation for the Subsonic REST API that Airsonic-Pulse implements.
   - name: Security Vulnerabilities
-    url: https://github.com/litebito/airsonic-pulse/security/advisories/new
+    url: https://github.com/Airsonic-Pulse/airsonic-pulse/security/advisories/new
     about: All security vulnerabilities must be reported privately via GitHub Security Advisories. Do not open a public issue.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -17,7 +17,7 @@ If you are running an older release, please upgrade before reporting a security 
 
 Use GitHub's private vulnerability reporting feature:
 
-➡️ **[Report a vulnerability](https://github.com/litebito/airsonic-pulse/security/advisories/new)**
+➡️ **[Report a vulnerability](https://github.com/Airsonic-Pulse/airsonic-pulse/security/advisories/new)**
 
 This delivers the report privately to the maintainers; the contents are not visible to the public.
 

--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -278,7 +278,7 @@ trap 'rm -f "${AUTO_CONTENT}"' EXIT
         echo ""
     fi
 
-    echo "**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/${SINCE_TAG}...${RELEASE_TAG}"
+    echo "**Full Changelog**: https://github.com/Airsonic-Pulse/airsonic-pulse/compare/${SINCE_TAG}...${RELEASE_TAG}"
 } > "${AUTO_CONTENT}"
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,10 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAGS="ghcr.io/litebito/airsonic-pulse:${VERSION}"
+          TAGS="ghcr.io/airsonic-pulse/airsonic-pulse:${VERSION}"
           # Add 'latest' tag only for non-prerelease versions (no hyphen in version)
           if [[ "${VERSION}" != *-* ]]; then
-            TAGS="${TAGS},ghcr.io/litebito/airsonic-pulse:latest"
+            TAGS="${TAGS},ghcr.io/airsonic-pulse/airsonic-pulse:latest"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 - Java 21 is now required (Java 17 support dropped)
-- Docker image moved to `ghcr.io/litebito/airsonic-pulse`
+- Docker image moved to `ghcr.io/airsonic-pulse/airsonic-pulse`
 - Docker multi-arch: `linux/amd64` and `linux/arm64` only (`arm/v7` dropped — not supported by Java 21)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://github.com/litebito/airsonic-pulse/actions/workflows/release.yml/badge.svg)](https://github.com/litebito/airsonic-pulse/actions/workflows/release.yml) [![CI - Pull Requests](https://github.com/litebito/airsonic-pulse/actions/workflows/pr_ci.yml/badge.svg)](https://github.com/litebito/airsonic-pulse/actions/workflows/pr_ci.yml)  [![CI - Main](https://github.com/litebito/airsonic-pulse/actions/workflows/pm_ci.yml/badge.svg)](https://github.com/litebito/airsonic-pulse/actions/workflows/pm_ci.yml) [![Trivy](https://github.com/litebito/airsonic-pulse/actions/workflows/any_trivy_scan.yml/badge.svg)](https://github.com/litebito/airsonic-pulse/actions/workflows/any_trivy_scan.yml)
+[![Release](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/release.yml/badge.svg)](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/release.yml) [![CI - Pull Requests](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/pr_ci.yml/badge.svg)](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/pr_ci.yml)  [![CI - Main](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/pm_ci.yml/badge.svg)](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/pm_ci.yml) [![Trivy](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/any_trivy_scan.yml/badge.svg)](https://github.com/Airsonic-Pulse/airsonic-pulse/actions/workflows/any_trivy_scan.yml)
 
 
 # Airsonic-Pulse
@@ -41,7 +41,7 @@ Also note that Airsonic-Pulse versions 13.x and higher (and its snapshots) are *
 
 ### Stand-alone binaries
 Airsonic-Pulse can be downloaded from
-[GitHub](https://github.com/litebito/airsonic-pulse/releases).
+[GitHub](https://github.com/Airsonic-Pulse/airsonic-pulse/releases).
 
 You need a _minimum_ Java Runtime Environment (JRE) of 17 for 12.x onwards (including snapshots).
 - For 12.x releases -> Java 17
@@ -57,13 +57,13 @@ More modern base frameworks and libraries
   - Moving to Java 21, dropping support for Java 17
   - (... more to come...)
 
-For a long (but non-exhaustive) list of features inherited from Airsonic-Advanced, read the "Feature Enhancements" section in [History.md](https://github.com/litebito/airsonic-pulse/blob/main/docs/HISTORY.md)
+For a long (but non-exhaustive) list of features inherited from Airsonic-Advanced, read the "Feature Enhancements" section in [History.md](https://github.com/Airsonic-Pulse/airsonic-pulse/blob/main/docs/HISTORY.md)
 
 ## 4. Docker
 
 The Airsonic-Pulse Docker image is published to the GitHub Container Registry:
 ```
-ghcr.io/litebito/airsonic-pulse
+ghcr.io/airsonic-pulse/airsonic-pulse
 ```
 Supported architectures: `linux/amd64`, `linux/arm64`.
 
@@ -77,7 +77,7 @@ docker run -d \
   -v ./data/music:/var/music \
   -e PUID=1000 \
   -e PGID=1000 \
-  ghcr.io/litebito/airsonic-pulse:latest
+  ghcr.io/airsonic-pulse/airsonic-pulse:latest
 ```
 
 The image runs as root by default and uses `PUID`/`PGID` to create a non-root user at startup. Volume mount points are at `/var/*` to remain consistent with the standalone WAR deployment.
@@ -87,7 +87,7 @@ Docker Compose files for HSQLDB, PostgreSQL, and MariaDB are provided in [`insta
 For full Docker documentation, see [docs/docker/](./docs/docker/README.md).
 
 
-[GHCR](https://ghcr.io/litebito/airsonic-pulse). Docker releases are multiplatform, which means ARM64 is also released to Dockerhub. However, automated testing for those archs is not currently done in the CI/CD pipeline (only Linux platform is tested).
+[GHCR](https://ghcr.io/airsonic-pulse/airsonic-pulse). Docker releases are multiplatform, which means ARM64 is also released to Dockerhub. However, automated testing for those archs is not currently done in the CI/CD pipeline (only Linux platform is tested).
 
 
 Please use the [Airsonic documentation](https://airsonic.github.io/docs/) for instructions on running Airsonic. For the most part (currently) Airsonic-Pulse shares similar running instructions unless stated otherwise. 
@@ -175,6 +175,6 @@ The cover art functionality supporting multiple image file formats is powered by
 
 ## Community
 
-Bugs, feature requests, and discussions for Airsonic-Pulse can be raised as issues on the [Airsonic-Pulse GitHub page](https://github.com/litebito/airsonic-pulse).
+Bugs, feature requests, and discussions for Airsonic-Pulse can be raised as issues on the [Airsonic-Pulse GitHub page](https://github.com/Airsonic-Pulse/airsonic-pulse).
 
-For more historical context, you can read more [here](https://github.com/litebito/airsonic-pulse/blob/main/docs/HISTORY.md), or check out the the upstream project at [kagemomiji/airsonic-advanced](https://github.com/kagemomiji/airsonic-advanced).
+For more historical context, you can read more [here](https://github.com/Airsonic-Pulse/airsonic-pulse/blob/main/docs/HISTORY.md), or check out the the upstream project at [kagemomiji/airsonic-advanced](https://github.com/kagemomiji/airsonic-advanced).

--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -79,10 +79,10 @@ public class VersionService {
 
     public VersionService() throws IOException {
         build = PropertiesLoaderUtils.loadAllProperties("build.properties");
-        projectUrl = build.getProperty("projectUrl", "https://github.com/litebito/airsonic-pulse");
+        projectUrl = build.getProperty("projectUrl", "https://github.com/Airsonic-Pulse/airsonic-pulse");
         String ownerRepo = projectUrl.startsWith(GITHUB_HOST)
                 ? projectUrl.substring(GITHUB_HOST.length())
-                : "litebito/airsonic-pulse";
+                : "Airsonic-Pulse/airsonic-pulse";
         versionUrl = String.format(GITHUB_API_RELEASES_PATH, ownerRepo);
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/VersionServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/VersionServiceTest.java
@@ -55,7 +55,7 @@ public class VersionServiceTest {
         properties.put("revision", COMMIT);
         properties.put("timestamp", TIMESTAMP);
         properties.put("name", NAME);
-        properties.put("projectUrl", "https://github.com/litebito/airsonic-pulse");
+        properties.put("projectUrl", "https://github.com/Airsonic-Pulse/airsonic-pulse");
         propertiesLoaderUtilsMockedStatic.when(() -> PropertiesLoaderUtils.loadAllProperties("build.properties")).thenReturn(properties);
     }
 

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -5,7 +5,7 @@ Airsonic-Pulse is available as a multi-architecture Docker image from the GitHub
 ## Image
 
 ```
-ghcr.io/litebito/airsonic-pulse
+ghcr.io/airsonic-pulse/airsonic-pulse
 ```
 
 Supported architectures: `linux/amd64`, `linux/arm64`
@@ -23,7 +23,7 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
-  ghcr.io/litebito/airsonic-pulse:latest
+  ghcr.io/airsonic-pulse/airsonic-pulse:latest
 ```
 
 Then open `http://localhost:4040` in your browser.

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -101,7 +101,7 @@ Replace `VERSION` with the desired release tag (e.g. `v13.0.0`):
 ```bash
 VERSION=v13.0.0
 sudo curl -L \
-  "https://github.com/litebito/airsonic-pulse/releases/download/${VERSION}/airsonic.war" \
+  "https://github.com/Airsonic-Pulse/airsonic-pulse/releases/download/${VERSION}/airsonic.war" \
   -o /var/airsonic/airsonic.war
 sudo chown airsonic:airsonic /var/airsonic/airsonic.war
 ```
@@ -122,7 +122,7 @@ Replace `VERSION` with the release tag you installed (e.g. `v13.0.0`):
 ```bash
 VERSION=v13.0.0
 sudo curl -fsSL \
-  "https://raw.githubusercontent.com/litebito/airsonic-pulse/${VERSION}/install/systemd/airsonic.service" \
+  "https://raw.githubusercontent.com/Airsonic-Pulse/airsonic-pulse/${VERSION}/install/systemd/airsonic.service" \
   -o /etc/systemd/system/airsonic.service
 sudo systemctl daemon-reload
 ```

--- a/install/centos/install-airsonic.sh
+++ b/install/centos/install-airsonic.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Airsonic-Pulse installer for RHEL / CentOS / AlmaLinux / Rocky Linux / Fedora
 
-GITHUB_REPO="litebito/airsonic-pulse"
+GITHUB_REPO="Airsonic-Pulse/airsonic-pulse"
 AIRSONIC_HOME="/var/airsonic"
 AIRSONIC_USER="airsonic"
 SYSTEMD_UNIT="/etc/systemd/system/airsonic.service"

--- a/install/compose/docker-compose.hsqldb.yaml
+++ b/install/compose/docker-compose.hsqldb.yaml
@@ -1,7 +1,7 @@
 services:
 
   airsonic-pulse:
-    image: ghcr.io/litebito/airsonic-pulse
+    image: ghcr.io/airsonic-pulse/airsonic-pulse
     container_name: airsonic-pulse
     environment:
       - PUID=1000

--- a/install/compose/docker-compose.mariadb.yaml
+++ b/install/compose/docker-compose.mariadb.yaml
@@ -14,7 +14,7 @@ services:
   airsonic-pulse:
     depends_on:
       - mariadb
-    image: ghcr.io/litebito/airsonic-pulse
+    image: ghcr.io/airsonic-pulse/airsonic-pulse
     environment:
       - PUID=1000
       - PGID=1000

--- a/install/compose/docker-compose.postgres.yaml
+++ b/install/compose/docker-compose.postgres.yaml
@@ -13,7 +13,7 @@ services:
   airsonic-pulse:
     depends_on:
       - postgres
-    image: ghcr.io/litebito/airsonic-pulse
+    image: ghcr.io/airsonic-pulse/airsonic-pulse
     environment:
       - PUID=1000
       - PGID=1000

--- a/install/debian/install-airsonic.sh
+++ b/install/debian/install-airsonic.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Airsonic-Pulse installer for Debian / Ubuntu and derivatives
 
-GITHUB_REPO="litebito/airsonic-pulse"
+GITHUB_REPO="Airsonic-Pulse/airsonic-pulse"
 AIRSONIC_HOME="/var/airsonic"
 AIRSONIC_USER="airsonic"
 SYSTEMD_UNIT="/etc/systemd/system/airsonic.service"

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM eclipse-temurin:${IMAGE_JAVA_VERSION}-jre-jammy
 ARG VERSION=dev
 
 LABEL description="Airsonic-Pulse is a free, web-based media streamer, providing ubiquitous access to your music." \
-      url="https://github.com/litebito/airsonic-pulse" \
+      url="https://github.com/Airsonic-Pulse/airsonic-pulse" \
       org.opencontainers.image.version=${VERSION}
 
 ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
     <organization>
         <name>Airsonic-Pulse</name>
-        <url>https://github.com/litebito/airsonic-pulse</url>
+        <url>https://github.com/Airsonic-Pulse/airsonic-pulse</url>
     </organization>
     <inceptionYear>2016</inceptionYear>
 
@@ -29,8 +29,8 @@
         <snakeyaml.version>2.4</snakeyaml.version>
         <lucene.version>10.2.2</lucene.version>
         <logback.version>1.5.25</logback.version>
-        <docker.container.repo>ghcr.io/litebito/airsonic-pulse</docker.container.repo>
-        <airsonic.project.url>https://github.com/litebito/airsonic-pulse</airsonic.project.url>        
+        <docker.container.repo>ghcr.io/airsonic-pulse/airsonic-pulse</docker.container.repo>
+        <airsonic.project.url>https://github.com/Airsonic-Pulse/airsonic-pulse</airsonic.project.url>
     </properties>
 
 
@@ -58,9 +58,9 @@
     </pluginRepositories>
 
     <scm>
-        <connection>scm:git:git://github.com/litebito/airsonic-pulse.git</connection>
-        <developerConnection>scm:git:git@github.com:litebito/airsonic-pulse.git</developerConnection>
-        <url>https://github.com/litebito/airsonic-pulse</url>
+        <connection>scm:git:git://github.com/Airsonic-Pulse/airsonic-pulse.git</connection>
+        <developerConnection>scm:git:git@github.com:Airsonic-Pulse/airsonic-pulse.git</developerConnection>
+        <url>https://github.com/Airsonic-Pulse/airsonic-pulse</url>
     </scm>
 
     <modules>


### PR DESCRIPTION
Mechanical sweep ahead of the repo transfer to the `Airsonic-Pulse` org. See #162 for scope and exclusions.

- 19 files changed, 41 same-line replacements
- Full test suite 819/0/0/0 — BUILD SUCCESS
- VersionService default URL, pom property `airsonic.project.url`, and VersionServiceTest expectation move together
- README badges will display 'unknown' between merge and org transfer — expected
- Excluded as designed: Liquibase changesets, docs/release-notes/v13.1.0-rc.1.md, docs/HISTORY.md, kagemomiji/airsonic-advanced upstream refs, FUNDING.yml, CoC contact email

fixes #162