### PR TITLE
docs: correct Full Changelog URL in v13.1.0-rc.2 notes

### DIFF
--- a/docs/release-notes/v13.1.0-rc.2.md
+++ b/docs/release-notes/v13.1.0-rc.2.md
@@ -93,4 +93,4 @@ Two settings power this behavior:
 * deps: bump net.java.dev.jna:jna from 5.17.0 to 5.18.1 by @app/dependabot in #153
 * deps: bump org.apache.commons:commons-lang3 from 3.18.0 to 3.20.0 by @app/dependabot in #154
 
-**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.1
+**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.2

--- a/docs/release-notes/v13.1.0-rc.2.md
+++ b/docs/release-notes/v13.1.0-rc.2.md
@@ -93,4 +93,4 @@ Two settings power this behavior:
 * deps: bump net.java.dev.jna:jna from 5.17.0 to 5.18.1 by @app/dependabot in #153
 * deps: bump org.apache.commons:commons-lang3 from 3.18.0 to 3.20.0 by @app/dependabot in #154
 
-**Full Changelog**: https://github.com/litebito/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.2
+**Full Changelog**: https://github.com/airsonic-pulse/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.2


### PR DESCRIPTION
Full Changelog URL in docs/release-notes/v13.1.0-rc.2.md fixed