### PR TITLE
chore: bump checkstyle 11.0.0 → 13.4.2 and normalize license headers (fixes #125)

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  This file is part of Airsonic.
 
  Airsonic is free software: you can redistribute it and/or modify

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  This file is part of Airsonic.
 
  Airsonic is free software: you can redistribute it and/or modify

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastEpisodesControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastEpisodesControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  This file is part of Airsonic.
 
  Airsonic is free software: you can redistribute it and/or modify

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>11.0.0</version>
+                            <version>13.4.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
fixes #125

## Summary

- Bump `com.puppycrawl.tools:checkstyle` dependency override from 11.0.0 to 13.4.2 in `maven-checkstyle-plugin` (`pom.xml`). Plugin version (3.6.0) unchanged.
- Normalize license header opener from `/**` to `/*` in three test files (`CoverArtControllerTest`, `PodcastEpisodesControllerTest`, `AvatarControllerTest`).

## Why the test files needed changing

Checkstyle 13.x has stricter Javadoc parsing in `UnusedImports`. The GPL header URL `<http://www.gnu.org/licenses/>` triggers an `HTML_ELEMENT` parse error when the comment is treated as Javadoc. The three affected files were the only ones in the codebase opening their license header with `/**` instead of `/*` — every other Java file already uses `/*`. The fix normalizes the three outliers to the project's prevailing convention rather than working around the parser via config suppression.

## Verification

- `mvnd validate`: clean, exit code 0, no Checkstyle violations
- `mvnd test -pl airsonic-main -am -q`: 819 tests pass (0 failures, 0 errors)
- `mvnd clean package -pl airsonic-main -am -DskipTests -q`: WAR builds clean
- Deployed to dev test instance, manually verified: runtime unaffected (Checkstyle is build-time only)

## Notes

A pre-existing pom configuration bug surfaced during the investigation: the `<configLocation>` for `maven-checkstyle-plugin` is inside `<execution><configuration>` instead of plugin-level, so `mvnd checkstyle:check` from the CLI silently falls back to `sun_checks.xml`. Bound execution paths (`mvnd validate`, `mvnd verify`) work correctly. Tracked separately — not in scope for this PR.