### PR TITLE
chore: move checkstyle plugin configLocation to plugin-level configuration (fixes #185)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,17 +265,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.6.0</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/checkstyle.xml</configLocation>
+                        <encoding>UTF-8</encoding>
+                        <consoleOutput>true</consoleOutput>
+                        <failOnViolation>true</failOnViolation>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>validate</id>
                             <phase>validate</phase>
-                            <configuration>
-                                <configLocation>${project.basedir}/../checkstyle.xml</configLocation>
-                                <encoding>UTF-8</encoding>
-                                <consoleOutput>true</consoleOutput>
-                                <failOnViolation>true</failOnViolation>
-                                <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            </configuration>
                             <goals>
                                 <goal>check</goal>
                             </goals>


### PR DESCRIPTION
fixes #185

## Summary

Lift the `maven-checkstyle-plugin` `<configuration>` block out of the per-execution `<configuration>` and into the plugin's top-level `<configuration>` (sibling to `<executions>`). Five project-wide settings move: `configLocation`, `encoding`, `consoleOutput`, `failOnViolation`, `includeTestSourceDirectory`. Execution-specific elements (`<id>`, `<phase>`, `<goals>`) stay in `<execution>`. The execution's inner `<configuration>` is empty post-move and is dropped.

## Why the path expression also changed

`configLocation` updates from `${project.basedir}/../checkstyle.xml` to `${maven.multiModuleProjectDirectory}/checkstyle.xml`.

With the configuration now sitting at parent-pom plugin level, `${project.basedir}` resolves to the repo root and `${project.basedir}/..` would resolve outside the repo entirely. `${maven.multiModuleProjectDirectory}` is Maven's canonical "top-level project root" variable (Maven 3.3.1+) and resolves consistently regardless of which module is executing. Without this update, the lifted config would silently fail to find `checkstyle.xml`.

## Behavior change

**Before**

```bash
mvnd checkstyle:check         # silently fell back to sun_checks.xml — ~21,600 phantom violations
mvnd validate                 # worked correctly via execution config
```

**After**

```bash
mvnd checkstyle:check                       # uses checkstyle.xml — 0 violations
mvnd validate                               # uses checkstyle.xml — 0 violations
mvnd checkstyle:check -pl airsonic-main     # also works from any submodule — bonus
```

The submodule invocation is a useful side-effect for developers iterating on a single module — previously the per-module checkstyle goal couldn't find the repo-root config even with the workaround.

## Verification

- `mvnd checkstyle:check` (CLI): exit 0, 0 violations (down from ~21,600 sun_checks.xml phantom violations)
- `mvnd validate` (bound): exit 0, 0 violations (no regression)
- `mvnd test -pl airsonic-main -am -q`: 819 tests pass (0 failures, 0 errors)
- `mvnd clean package -pl airsonic-main -am -DskipTests -q`: WAR builds clean
- Deployed to dev test instance, manually verified: runtime unaffected (build-time-only config change)

## Context

Bug discovered during the #125 Checkstyle 11.0.0 → 13.4.2 investigation, when the CLI goal invocation reported ~21,600 violations while the bound path reported 0. Filed separately to keep #125's scope focused on the dependency bump.