### PR TITLE
chore: controller hygiene sweep — error handling, helpers, and consistency follow-ups (fixes #176)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/AbstractSubsonicController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/AbstractSubsonicController.java
@@ -55,6 +55,10 @@ public abstract class AbstractSubsonicController {
         return jaxbWriter.createResponse(true);
     }
 
+    protected void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
+        jaxbWriter.writeResponse(request, response, createResponse());
+    }
+
     protected void error(HttpServletRequest request, HttpServletResponse response,
                          SubsonicRESTController.ErrorCode code, String message) {
         jaxbWriter.writeErrorResponse(request, response, code, message);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicAnnotationController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicAnnotationController.java
@@ -220,7 +220,4 @@ public class SubsonicAnnotationController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicBookmarkController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicBookmarkController.java
@@ -25,6 +25,8 @@ import org.airsonic.player.domain.Player;
 import org.airsonic.player.service.BookmarkService;
 import org.airsonic.player.service.JaxbContentService;
 import org.airsonic.player.service.SecurityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +44,8 @@ import static org.springframework.web.bind.ServletRequestUtils.getRequiredLongPa
 @RequestMapping(value = {"/rest", "/ext"}, method = {RequestMethod.GET, RequestMethod.POST})
 public class SubsonicBookmarkController extends AbstractSubsonicController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SubsonicBookmarkController.class);
+
     @Autowired
     private BookmarkService bookmarkService;
     @Autowired
@@ -57,6 +61,13 @@ public class SubsonicBookmarkController extends AbstractSubsonicController {
 
         Bookmarks result = new Bookmarks();
         for (Bookmark bookmark : bookmarkService.getBookmarks(username)) {
+            MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
+            if (mediaFile == null) {
+                LOG.warn("Skipping bookmark {} — referenced media file {} does not exist",
+                        bookmark.getId(), bookmark.getMediaFileId());
+                continue;
+            }
+
             org.subsonic.restapi.Bookmark b = new org.subsonic.restapi.Bookmark();
             result.getBookmark().add(b);
             b.setPosition(bookmark.getPositionMillis());
@@ -64,8 +75,6 @@ public class SubsonicBookmarkController extends AbstractSubsonicController {
             b.setComment(bookmark.getComment());
             b.setCreated(jaxbWriter.convertDate(bookmark.getCreated()));
             b.setChanged(jaxbWriter.convertDate(bookmark.getChanged()));
-
-            MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
             b.setEntry(jaxbContentService.createJaxbChild(player, mediaFile, username));
         }
 
@@ -98,7 +107,4 @@ public class SubsonicBookmarkController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicBrowsingController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicBrowsingController.java
@@ -320,7 +320,7 @@ public class SubsonicBrowsingController extends AbstractSubsonicController {
         } else if ("random".equals(type)) {
             albums = searchService.getRandomAlbums(size, musicFolders);
         } else {
-            throw new Exception("Invalid list type: " + type);
+            throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.GENERIC, "Invalid list type: " + type);
         }
 
         AlbumList result = new AlbumList();

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicID3Controller.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicID3Controller.java
@@ -203,7 +203,7 @@ public class SubsonicID3Controller extends AbstractSubsonicController {
         } else if ("random".equals(type)) {
             albums = searchService.getRandomAlbumsId3(size, musicFolders);
         } else {
-            throw new Exception("Invalid list type: " + type);
+            throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.GENERIC, "Invalid list type: " + type);
         }
         AlbumList2 result = new AlbumList2();
         for (Album album : albums) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicJukeboxController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicJukeboxController.java
@@ -115,7 +115,7 @@ public class SubsonicJukeboxController extends AbstractSubsonicController {
                 // No action necessary.
                 break;
             default:
-                throw new Exception("Unknown jukebox action: '" + action + "'.");
+                throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.GENERIC, "Unknown jukebox action: '" + action + "'.");
         }
 
         String username = securityService.getCurrentUsername(request);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlayQueueController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlayQueueController.java
@@ -103,7 +103,4 @@ public class SubsonicPlayQueueController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlaylistController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlaylistController.java
@@ -234,7 +234,4 @@ public class SubsonicPlaylistController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPodcastController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPodcastController.java
@@ -238,9 +238,8 @@ public class SubsonicPodcastController extends AbstractSubsonicController {
         request = wrapRequest(request);
         org.airsonic.player.domain.User user = securityService.getCurrentUser(request);
         if (!user.isPodcastRole()) {
-            error(request, response, SubsonicRESTController.ErrorCode.NOT_AUTHORIZED,
+            throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.NOT_AUTHORIZED,
                     user.getUsername() + " is not authorized to administrate podcasts.");
-            return null;
         }
 
         HttpHeaders headers = new HttpHeaders();
@@ -250,7 +249,4 @@ public class SubsonicPodcastController extends AbstractSubsonicController {
         return ResponseEntity.ok().headers(headers).body(podcastPersistenceService.exportAllChannels());
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicShareController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicShareController.java
@@ -177,7 +177,4 @@ public class SubsonicShareController extends AbstractSubsonicController {
         return result;
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSystemController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSystemController.java
@@ -19,9 +19,7 @@
 package org.airsonic.player.controller;
 
 import org.airsonic.player.service.MediaScannerService;
-import org.apache.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -42,8 +40,6 @@ public class SubsonicSystemController extends AbstractSubsonicController {
 
     @Autowired
     private MediaScannerService mediaScannerService;
-
-    private static final String NO_LONGER_SUPPORTED = "No longer supported";
 
     @RequestMapping({"/ping", "/ping.view"})
     public void ping(HttpServletRequest request, HttpServletResponse response) {
@@ -90,13 +86,15 @@ public class SubsonicSystemController extends AbstractSubsonicController {
     }
 
     @RequestMapping({"/getChatMessages", "/getChatMessages.view"})
-    public ResponseEntity<String> getChatMessages(HttpServletRequest request, HttpServletResponse response) {
-        return ResponseEntity.status(HttpStatus.SC_GONE).body(NO_LONGER_SUPPORTED);
+    public void getChatMessages(HttpServletRequest request, HttpServletResponse response) throws SubsonicRESTController.APIException {
+        throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.NOT_FOUND,
+                "Chat messages are not supported on this server");
     }
 
     @RequestMapping({"/addChatMessage", "/addChatMessage.view"})
-    public ResponseEntity<String> addChatMessage(HttpServletRequest request, HttpServletResponse response) {
-        return ResponseEntity.status(HttpStatus.SC_GONE).body(NO_LONGER_SUPPORTED);
+    public void addChatMessage(HttpServletRequest request, HttpServletResponse response) throws SubsonicRESTController.APIException {
+        throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.NOT_FOUND,
+                "Posting chat messages is not supported on this server");
     }
 
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicUserController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicUserController.java
@@ -268,7 +268,4 @@ public class SubsonicUserController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
-    private void writeEmptyResponse(HttpServletRequest request, HttpServletResponse response) {
-        jaxbWriter.writeResponse(request, response, createResponse());
-    }
 }


### PR DESCRIPTION
fixes #176

## Summary

Five small consistency fixes across the Subsonic controllers after the recent refactor wave (#98 ControllerAdvice centralization, #112 AbstractSubsonicController extraction). All share the theme of making controller behavior consistent with the now-centralized patterns. 12 Java files touched; net −11 lines.

## Changes per item

### 1. Wrap unknown/invalid client-input throws as APIException

`SubsonicJukeboxController`, `SubsonicID3Controller`, `SubsonicBrowsingController` each had `throw new Exception(...)` for bad client input, which bypassed the #98 ControllerAdvice and returned HTTP 500 instead of a Subsonic envelope. Replaced with `throw new SubsonicRESTController.APIException(SubsonicRESTController.ErrorCode.GENERIC, ...)`. Message strings preserved exactly.

### 2. Lift `writeEmptyResponse` into `AbstractSubsonicController`

The same private method was duplicated byte-identical across 7 controllers (Annotation, Bookmark, PlayQueue, Playlist, Podcast, Share, User). Moved to `AbstractSubsonicController` as `protected`. Same pattern as the helpers lifted in #112.

### 3. Fix chat endpoint envelope handling

Both `getChatMessages` and `addChatMessage` previously returned plain-text HTTP 410 using `org.apache.http.HttpStatus` (Apache HttpClient, inconsistent with `org.springframework.http.HttpStatus` used everywhere else). Now both throw `SubsonicRESTController.APIException(ErrorCode.NOT_FOUND, ...)` and let the advice produce a Subsonic envelope.

**Note on the error code choice:** issue body references `NO_LONGER_SUPPORTED`, but that's not a Subsonic spec error code — only a local String constant in this controller. The OpenSubsonic spec defines codes 0/10/20/30/40/41/42/43/50/70 (per [error docs](https://opensubsonic.netlify.app/docs/responses/error/)). Using `ErrorCode.NOT_FOUND` (code 70) is spec-compliant and semantically appropriate — it matches the OC Music precedent for unsupported base-Subsonic features ([OpenSubsonic discussion #113](https://github.com/opensubsonic/open-subsonic-api/discussions/113)).

**Signature change:** methods returned `ResponseEntity<String>`; now return `void` since they always throw and the advice handles serialization. This matches every other endpoint in `SubsonicSystemController` (`ping`, `getScanStatus`, etc.). The `org.springframework.http.ResponseEntity` import is removed along with `org.apache.http.HttpStatus`.

### 4. Null-guard `SubsonicBookmarkController.getBookmarks`

When a bookmark referenced a deleted `MediaFile`, `getMediaFile` returned null and the subsequent `createJaxbChild` call dereferenced it with NPE. Restructured the loop: look up `MediaFile` first, skip the orphan with a warning log if null, only add to the response when `MediaFile` is valid. Added an SLF4J logger matching the sibling controllers' declaration pattern. Chose **skip orphan** over **return with null entry** for safer client semantics (no malformed JAXB response; ops gets a warning to investigate orphans).

### 5. Fix `SubsonicPodcastController.exportPodcastOPML` auth failure

The auth-failure branch returned `null` from a `ResponseEntity<...>`-typed method (would have manifested as HTTP 500). Replaced with `throw new SubsonicRESTController.APIException(ErrorCode.NOT_AUTHORIZED, ...)` matching the pattern from `SubsonicMediaController.stream` and `download`.

## Verification

### Static / build
- `mvnd validate` (checkstyle): 0 violations
- `mvnd test -pl airsonic-main -am -q`: 819 tests pass (0 failures, 0 errors)
- `mvnd clean package -pl airsonic-main -am -DskipTests -q`: WAR builds clean

### Runtime smoke (deployed to dev test instance)
Curl battery confirmed all five behaviors:

| Test | Expected | Observed |
|---|---|---|
| `/rest/jukeboxControl.view?action=bogus` | failed envelope, code 0 | ✓ "Unknown jukebox action: 'bogus'." |
| `/rest/getAlbumList.view?type=bogus` | failed envelope, code 0 | ✓ "Invalid list type: bogus" |
| `/rest/getAlbumList2.view?type=bogus` | failed envelope, code 0 | ✓ "Invalid list type: bogus" |
| `/rest/getChatMessages.view` | failed envelope, code 70 | ✓ "Chat messages are not supported on this server" |
| `/rest/addChatMessage.view?message=test` | failed envelope, code 70 | ✓ "Posting chat messages is not supported on this server" |
| `/rest/star.view?id=N` & `/rest/unstar.view?id=N` | ok envelope (refactor smoke) | ✓ status=ok |
| `/rest/getBookmarks.view` | ok envelope, bookmarks intact | ✓ all bookmarks returned correctly |

Item 5's auth-failure path is not exercisable with an admin user (admin has podcast role); the change is mechanical and mirrors the well-established `SubsonicMediaController.stream`/`download` pattern.

