### PR TITLE
ci: bump GitHub Actions major versions across all workflows (fixes #184)

### DIFF
--- a/.github/workflows/any_codeql_scan.yml
+++ b/.github/workflows/any_codeql_scan.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node.js (required for javascript-typescript extractor)
         if: matrix.language == 'javascript-typescript'

--- a/.github/workflows/any_trivy_scan.yml
+++ b/.github/workflows/any_trivy_scan.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:

--- a/.github/workflows/pm_ci.yml
+++ b/.github/workflows/pm_ci.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
     runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Verify environment
         run: |
           java -version

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -65,7 +65,7 @@ jobs:
       spring_datasource_password: ${{ matrix.db != 'hsqldb' && 'airsonic' || '' }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-release:
     runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Verify environment
         run: |
@@ -91,10 +91,10 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -113,7 +113,7 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: install/docker
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -9,7 +9,7 @@ jobs:
   smoke:
     runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Show runtime
         run: |
           id


### PR DESCRIPTION
fixes #184

## Summary

Four major-version bumps held back from #175's SHA-pinning sweep because each required a breaking-change review:

| Action | Old → new | New SHA |
|---|---|---|
| `actions/checkout` | v5.0.1 → v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `docker/setup-buildx-action` | v3.12.0 → v4.0.0 | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` |
| `docker/login-action` | v3.7.0 → v4.1.0 | `4907a6ddec9925e35a0a9e82d7399ccc52663121` |
| `docker/build-push-action` | v6.19.2 → v7.1.0 | `bcafcacb16a39f128d818304e6c9c0c18556b85f` |

Each bump is SHA-pinned to a specific commit with a `# v<N>.x.x` annotation comment, matching the #175 convention. No tag-based references introduced.

## Why one PR for all four

All four bumps share the same dominant change — Node 24 default runtime — and our usage of each action is bare or near-bare (no deprecated inputs, no removed envs, no input renames affecting us). Splitting into four PRs would add CI overhead without isolating any meaningful risk.

## Runtime requirement

All four new majors require Actions Runner ≥ v2.327.1 (or ≥ v2.329.0 for `actions/checkout` v6's `persist-credentials` `$RUNNER_TEMP` change in container-action scenarios — we don't use those). Our self-hosted fleet is at v2.334.0 (rebuilt May 2026 with auto-update enabled). Compatibility risk: very low.

## Per-action review

### `actions/checkout` v5 → v6
- Node 24 default runtime
- `persist-credentials` moved to `$RUNNER_TEMP` — only affects container-action scenarios
- v6.0.1/v6.0.2 fixed submodule auth and tag handling regressions

### `docker/setup-buildx-action` v3 → v4
- Node 24 default runtime
- Deprecated inputs/outputs removed — bare invocation has zero exposure
- ESM switch + dependency bumps

### `docker/login-action` v3 → v4
- Node 24 default runtime
- Misc cleanup (scoped Docker Hub path — irrelevant to `ghcr.io`)
- Our 3 inputs (`registry`, `username`, `password`) unchanged in v4

### `docker/build-push-action` v6 → v7
- Node 24 default runtime
- Removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs (not set anywhere)
- Removed legacy export-build summary tool
- v7.1.0 adds git context query-format support (additive)
- Our 5 inputs (`context`, `platforms`, `push`, `tags`, `build-args`) all stable in v7

This action was flagged as highest-risk in the issue body — verified low-risk for our specific usage.

## Files modified

6 unique workflow files, 9 line edits total:

| File | Changes |
|---|---|
| `.github/workflows/release.yml` | checkout + setup-buildx + login + build-push (4 bumps) |
| `.github/workflows/any_codeql_scan.yml` | checkout |
| `.github/workflows/any_trivy_scan.yml` | checkout |
| `.github/workflows/pm_ci.yml` | checkout |
| `.github/workflows/pr_ci.yml` | checkout |
| `.github/workflows/runner-smoke.yml` | checkout |

9 insertions / 9 deletions. Each edit is a same-shape SHA + comment replacement.

## Verification

CI/infra work — no app code, no Maven, no runtime behavior changes.

- **On this PR:** `pr_ci`, `any_codeql_scan`, `any_trivy_scan` run on push and exercise `actions/checkout` v6 (5 of the 6 affected sites).
- **On next release tag:** `release.yml` exercises the remaining checkout site plus all three Docker action bumps end-to-end. Validated naturally on the next `v13.1.0-*` tag during release prep.