### PR TITLE
ci: sign container images with Cosign on release (keyless OIDC) (fixes #183)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write  # OIDC token for keyless cosign signing
 
 jobs:
   build-and-release:
@@ -113,6 +114,7 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
+        id: build-push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: install/docker
@@ -121,3 +123,12 @@ jobs:
           tags: ${{ steps.docker-tags.outputs.tags }}
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Sign image with Cosign (keyless, via GitHub OIDC)
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: |
+          cosign sign --yes "ghcr.io/airsonic-pulse/airsonic-pulse@${DIGEST}"

--- a/docs/release-notes/v13.1.0-rc.3.md
+++ b/docs/release-notes/v13.1.0-rc.3.md
@@ -1,0 +1,111 @@
+# Airsonic-Pulse v13.1.0-rc.3
+
+## Highlights
+
+No functional / feature changes since v13.1.0-rc.1.
+
+**OpenSubsonic API support.** Airsonic-Pulse 13.1.0 is the first kagemomiji-descended fork to implement the OpenSubsonic API specification. Five OpenSubsonic extensions and endpoints are now supported:
+
+- `transcodeOffset v1` — `/stream` honors `timeOffset` accurately via source-side ffmpeg seek (was a wasteful post-encoding byte skip)
+- `songLyrics v1` — new `/getLyricsBySongId` endpoint returns structured lyrics
+- `/getPodcastEpisode` — new endpoint for per-episode lookup
+- `AlbumID3.playCount` wiring (existing field, never previously populated)
+- New optional fields on Child/AlbumID3/ArtistID3: `played`, `musicBrainzId`, `displayArtist`, `displayAlbumArtist`, `mediaType`
+
+OpenSubsonic-compliant clients (Symfonium, Tempo, others) will now see Pulse declare its supported extensions via `getOpenSubsonicExtensions` and use the extended response shapes automatically.
+
+**SubsonicRESTController refactor.** The monolithic `SubsonicRESTController` has been split into 13 domain-specific controllers (system, browsing, ID3, search, annotation, play queue, bookmark, share, podcast, radio, jukebox, playlist, artist info, user, media). Shared utilities are lifted into a new `AbstractSubsonicController` base class, and exception handling is consolidated via a `@ControllerAdvice`. Result: ~1000 fewer lines of duplicated boilerplate, clearer ownership, and easier future maintenance. No API contract changes for clients.
+
+**Subsonic API 1.16.1.** The server now declares itself as Subsonic API version 1.16.1 (was 1.15.0). Internet radio CRUD endpoints from Subsonic 1.16.0 are implemented (`createInternetRadioStation`, `updateInternetRadioStation`, `deleteInternetRadioStation`). Modern clients sending `v=1.16.1` are no longer rejected.
+
+## Upgrade notes
+
+**Audio transcoding offsets (admins of customized transcoding profiles).**
+
+13.1.0 plumbs the user's `timeOffset` directly into the ffmpeg command via the `-ss` flag, producing a fast, accurate source-side seek for transcoded audio. Previously, audio offsets were applied via a byte-level skip on the transcoded output — wasteful (ffmpeg encoded audio that was then discarded) and imprecise (especially for VBR sources).
+
+Two settings power this behavior:
+
+- The **`mp3 audio` transcoding profile** — updated automatically on upgrade. A Liquibase precondition preserves admin customizations: if you previously changed this profile, your changes are kept intact. To benefit from accurate seek in customized configurations, manually add `-ss %o` immediately after `ffmpeg %S` in your profile's Step 1.
+- The **system Downsample command** — reset to the new default on upgrade. Any customization of the Downsample command will be lost (consistent with how prior Airsonic versions handled forced default upgrades). If you had a custom Downsample command, recreate it post-upgrade and add `-ss %o` after `ffmpeg %S` to benefit from accurate seek.
+
+---
+
+<!-- AUTO-GENERATED-BELOW -->
+## What's Changed
+
+### Features & Enhancements
+* #64 Add OpenSubsonic response envelope fields by @litebito in #65
+* #66 Add getOpenSubsonicExtensions endpoint by @litebito in #68
+* #98 Refactor: extract APIException @ExceptionHandler into @ControllerAdvice by @litebito in #118
+* #112 Refactor: extract AbstractSubsonicController base class for shared utilities by @litebito in #119
+* #67 Clean up version display for non-SNAPSHOT releases by @litebito in #121
+* #123 Implement Subsonic 1.16.0 internet radio CRUD endpoints by @litebito in #128
+* #129 [OpenSubsonic] Wire already-in-XSD response fields (Child.played, AlbumID3.playCount/played) by @litebito in #146
+* #130 [OpenSubsonic] Add musicBrainzId, displayArtist, displayAlbumArtist, mediaType to XSD and wire by @litebito in #147
+* #132 [OpenSubsonic] Verify transcodeOffset extension and declare support by @litebito in #149
+* #133 [OpenSubsonic] Implement getPodcastEpisode endpoint by @litebito in #155
+* #131 [OpenSubsonic] Implement songLyrics extension (unsynced, tag-read-at-request-time) by @litebito in #156
+
+### Documentation
+* docs: correct Full Changelog URL in v13.1.0-rc.2 notes by @litebito in #173
+
+### Bug Fixes
+* #57 [Bug]: updateUser REST endpoint maps streamRole from downloadRole by @litebito in #58
+* #59 [Bug]: getVideoInfo and getCaptions return plain text 501 instead of JAXB error envelope by @litebito in #61
+* #115 [Bug]: /getAvatar returns non-standard Content-Type 'img/png' instead of 'image/png' by @litebito in #120
+* #117 [Bug]: /stream returns empty 200 with application/octet-stream for non-existent media ID by @litebito in #122
+* #113 [Bug]: Server reports Subsonic API version 1.15.0 — modern clients sending v=1.16.1 get rejected by @litebito in #124
+* #126 [Bug]: PodcastRepositoryTest is non-deterministic on HSQLDB due to missing ORDER BY in repository queries by @litebito in #127
+
+### Infrastructure & CI
+* ci: bump docker/setup-qemu-action from 3 to 4 by @app/dependabot in #74
+* chore: rename Trivy job display name to 'Trivy scan' for clarity by @litebito in #148
+* chore: release workflow uses committed release-notes file by @litebito in #159
+* chore: update release workflow by @litebito in #160
+* chore: add gitleaks baseline for inherited findings by @litebito in #161
+* ci: update runner in pr_ci.yml by @litebito in #170
+* docs: release notes for v13.1.0-rc.2 by @litebito in #171
+* docs: release notes for v13.1.0-rc.2 by @litebito in #172
+* ci:update Trivy Scan scope and rename CodeQL workflow file by @litebito in #174
+* ci: SHA-pin third-party actions and finish paths-ignore cleanup by @litebito in #175
+
+### Maintenance
+* #62 [Chore]: Make JAXBWriter a Spring @Component by @litebito in #63
+* #69 [Chore]: Extract SubsonicSystemController from SubsonicRESTController by @litebito in #70
+* #71 [Chore]: Extract SubsonicBrowsingController from SubsonicRESTController by @litebito in #72
+* deps: bump org.codehaus.mojo:buildnumber-maven-plugin from 3.2.1 to 3.3.0 by @app/dependabot in #77
+* deps: bump com.twelvemonkeys.imageio:imageio-webp from 3.12.0 to 3.13.1 by @app/dependabot in #78
+* deps: bump ch.qos.logback:logback-core from 1.5.18 to 1.5.25 in the maven group across 1 directory by @app/dependabot in #81
+* Bump com.github.junrar:junrar from 7.5.5 to 7.5.10 in /airsonic-main in the maven group across 1 directory by @app/dependabot in #82
+* Bump org.bouncycastle:bcprov-jdk18on from 1.81 to 1.84 in /airsonic-main in the maven group across 1 directory by @app/dependabot in #83
+* #80 [Chore]: Extract SubsonicID3Controller from SubsonicRESTController by @litebito in #84
+* #85 [Chore]: Extract SubsonicSearchController from SubsonicRESTController by @litebito in #86
+* #87 [Chore]: Ignore liquibase-core major version updates in Dependabot by @litebito in #88
+* #89 [Chore]: Extract SubsonicAnnotationController from SubsonicRESTController by @litebito in #90
+* #91 [Chore]: Extract SubsonicPlayQueueController from SubsonicRESTController by @litebito in #92
+* #93 [Chore]: Extract SubsonicBookmarkController from SubsonicRESTController by @litebito in #94
+* #95 [Chore]: Extract SubsonicShareController from SubsonicRESTController by @litebito in #96
+* #97 [Chore]: Extract SubsonicPodcastController from SubsonicRESTController by @litebito in #99
+* #100 [Chore]: Extract SubsonicRadioController from SubsonicRESTController by @litebito in #101
+* #102 [Chore]: Extract SubsonicJukeboxController from SubsonicRESTController by @litebito in #103
+* #104 [Chore]: Extract SubsonicPlaylistController from SubsonicRESTController by @litebito in #105
+* #106 [Chore]: Extract SubsonicArtistInfoController from SubsonicRESTController by @litebito in #107
+* #108 [Chore]: Extract SubsonicUserController from SubsonicRESTController by @litebito in #109
+* #110 [Chore]: Extract SubsonicMediaController from SubsonicRESTController by @litebito in #111
+* deps: bump com.google.guava:guava from 33.4.8-jre to 33.6.0-jre by @app/dependabot in #150
+* deps: bump org.apache.commons:commons-configuration2 from 2.12.0 to 2.14.0 by @app/dependabot in #151
+* deps: bump com.google.errorprone:error_prone_annotations from 2.41.0 to 2.49.0 by @app/dependabot in #152
+* deps: bump net.java.dev.jna:jna from 5.17.0 to 5.18.1 by @app/dependabot in #153
+* deps: bump org.apache.commons:commons-lang3 from 3.18.0 to 3.20.0 by @app/dependabot in #154
+* #162 chore: rename in-repo references in preparation for org transfer by @litebito in #163
+* deps: bump org.eclipse.persistence:org.eclipse.persistence.moxy from 4.0.7 to 5.0.0 by @app/dependabot in #165
+* deps: bump lucene.version from 10.2.2 to 10.4.0 by @app/dependabot in #166
+* deps: bump org.apache.commons:commons-configuration2 from 2.14.0 to 2.15.0 by @app/dependabot in #167
+* deps: bump org.apache.maven.plugins:maven-dependency-plugin from 3.8.1 to 3.10.0 by @app/dependabot in #168
+* #125 Update Checkstyle dependency from 11.0.0 to 13.4.2 by @litebito in #186
+* #185 [Chore]: Move maven-checkstyle-plugin configLocation to plugin-level configuration (sun_checks.xml fallback bug) by @litebito in #187
+* #176 [Chore]: Controller hygiene sweep — error handling, helpers, and consistency follow-ups by @litebito in #188
+* #184 [Chore]: Major-version bumps for GitHub Actions held back from #175 SHA-pinning sweep by @litebito in #189
+
+**Full Changelog**: https://github.com/Airsonic-Pulse/airsonic-pulse/compare/v13.0.0...v13.1.0-rc.3

--- a/docs/security/image-verification.md
+++ b/docs/security/image-verification.md
@@ -1,0 +1,86 @@
+# Verifying Container Image Signatures
+
+Starting with the **13.1.0** release, all official Airsonic-Pulse container images published to `ghcr.io/airsonic-pulse/airsonic-pulse` are signed using [Cosign](https://github.com/sigstore/cosign) keyless signing via GitHub Actions OIDC. This page documents how downstream users verify image provenance before deploying.
+
+Images from **13.0.x and earlier are not signed** — verification only applies to 13.1.0 and later.
+
+---
+
+## Prerequisites
+
+Install the `cosign` CLI. Follow the official installation instructions:
+
+- https://docs.sigstore.dev/cosign/system_config/installation/
+
+A minimum of cosign v2.x is required; v3.x is recommended (matches the version we sign with).
+
+---
+
+## Verifying an image
+
+The image digest (or any tag pointing to a signed digest) can be verified with:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "https://github.com/Airsonic-Pulse/airsonic-pulse/\.github/workflows/release\.yml@refs/tags/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/airsonic-pulse/airsonic-pulse:<tag>
+```
+
+Replace `<tag>` with the version you want to verify (for example `13.1.0`, `13.1.0-rc.2`, or `latest`).
+
+### What success looks like
+
+`cosign verify` prints a summary block including the certificate subject (the workflow file URL with the tag ref), the issuer (`https://token.actions.githubusercontent.com`), and the Rekor log entry index. Example abridged output:
+
+```
+Verification for ghcr.io/airsonic-pulse/airsonic-pulse:13.1.0 --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+[
+  {
+    "critical": {...},
+    "optional": {
+      "Subject": "https://github.com/Airsonic-Pulse/airsonic-pulse/.github/workflows/release.yml@refs/tags/v13.1.0",
+      "Issuer": "https://token.actions.githubusercontent.com",
+      ...
+    }
+  }
+]
+```
+
+If you see that block, the image is signed and authentic.
+
+### What failure looks like
+
+- **`no matching signatures`** — the image has no Cosign signature attached (likely an unsigned 13.0.x image or a third-party copy of the image).
+- **`certificate identity does not match`** — a signature exists but was produced by a different workflow / repo / ref than the regex matches. Treat as a tampering signal.
+- **`no matching entries found in transparency log`** — the signature is not recorded in Rekor. Treat as a tampering signal.
+
+In all three cases, do **not** deploy the image.
+
+---
+
+## How verification works
+
+Airsonic-Pulse uses Sigstore's keyless signing model. There are no long-lived keys to manage or rotate. The trust chain rests on three components:
+
+**Fulcio** is Sigstore's certificate authority. During the release workflow, GitHub Actions issues a short-lived OIDC token that proves the signing context — specifically, the repository, workflow file, and tag ref that produced the build. Fulcio exchanges that token for an ephemeral signing certificate whose subject is bound to that exact workflow identity. The certificate expires after a few minutes; the signature it produces is permanent.
+
+**Rekor** is Sigstore's public transparency log. Every signature Cosign produces is also recorded in Rekor along with a hash of the signed artifact. The log is append-only and publicly auditable, which means a tampered or unauthorized signature cannot be made to look legitimate without leaving an entry that contradicts the legitimate one.
+
+`cosign verify` performs two checks: the certificate's subject must match the expected workflow identity (the `--certificate-identity-regexp` argument), and the signature must be recorded in Rekor (verified against an offline copy of the log). Both checks must pass; if either fails, the verification fails. There is no fallback that trusts the image based on the registry alone.
+
+---
+
+## Multi-architecture note
+
+Each release pushes both `linux/amd64` and `linux/arm64` images as a single multi-arch manifest. The signature is attached to the **manifest list digest**, which covers both platform images and every tag pointing to that digest. A single verification call validates the image for the architecture your client will pull.
+
+---
+
+## Reporting verification failures
+
+If `cosign verify` fails for an image that should be signed, please open a security advisory on the GitHub repository rather than a public issue — see the security policy in [`.github/SECURITY.md`](../../.github/SECURITY.md).


### PR DESCRIPTION
fixes #183

## Summary

Complete 13.1.0's supply-chain hardening sequence (following #175 SHA pinning and #184 Actions major bumps) by signing every released container image with Cosign keyless signing via GitHub Actions OIDC. After this lands, downstream users can verify image provenance with `cosign verify` against the GitHub OIDC issuer + this repo's release workflow identity.

## Changes in `release.yml`

| Change | Purpose |
|---|---|
| Top-level `permissions:` gains `id-token: write` | Enables OIDC token issuance for Fulcio certificate exchange |
| `docker/build-push-action` step gains `id: build-push` | Allows the cosign step to reference `steps.build-push.outputs.digest` |
| New "Install Cosign" step | `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6` (v4.1.2), SHA-pinned per #175 convention; bundles Cosign 3.0.6 |
| New "Sign image with Cosign" step | `cosign sign --yes "<image>@${DIGEST}"` against the manifest-list digest |

`+12 / -1` lines in `release.yml`.

## Why sign by digest (not by tag)

`cosign sign` against the manifest-list digest covers:
- **Both tag references in one call** — for finals, both `:<version>` and `:latest` resolve to the same digest, so a single signature covers both. For pre-releases (no `:latest`), the same call still works correctly.
- **Both platform layers** — the multi-platform manifest list references `linux/amd64` and `linux/arm64` images by digest, and Cosign's signature chain reaches both.
- **Immutability** — tags can move; digests cannot. Signing-by-digest binds the signature to immutable content.

## New file: `docs/security/image-verification.md`

89 lines documenting:
- Prerequisites (Cosign installation link, recommends v3.x)
- Verification command (`cosign verify` with the `--certificate-identity-regexp` for this repo's release workflow)
- What success and three named failure modes look like, with consistent "do not deploy" interpretation
- Trust model: Fulcio (ephemeral signing certificates bound to workflow identity via OIDC) + Rekor (public append-only transparency log) + what `cosign verify` actually checks
- Multi-architecture note (single manifest-list digest covers both amd64 and arm64)
- Note that signing starts in 13.1.0 — images from 13.0.x and earlier are unsigned
- Pointer to `.github/SECURITY.md` for reporting verification failures

## Verification

This is CI/infra work — no app code, no Maven changes, no runtime behavior.

**On this PR:** `pr_ci`, `any_codeql_scan`, `any_trivy_scan` run on push but none of them exercise `release.yml` (which only fires on tag push). PR CI provides static-validation only — green checks confirm the YAML parses correctly and no unrelated code regressed, but they don't validate the cosign signing path itself.

**On next alpha/RC tag:** the full release pipeline fires. The first signed image will be `ghcr.io/airsonic-pulse/airsonic-pulse:v13.1.0-alpha.YYYYMMDDHHMM` (or RC.N depending on cadence). Running `cosign verify` against that image per the docs confirms end-to-end correctness before final 13.1.0.

## 13.1.0 close-out

With this PR merged, all six 13.1.0-milestoned issues are resolved:
- #125 Checkstyle 11.0.0 → 13.4.2
- #185 configLocation cleanup
- #176 Controller hygiene sweep
- #182 (closed as already-done in 13.0.0)
- #184 GitHub Actions major bumps
- #183 Cosign signing (this PR)