### PR TITLE
OpenSubsonic: Child.sortName (fixes #135)

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>airsonic-main</artifactId>

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -70,6 +70,9 @@ public class MediaFile {
     @Column(name = "title", nullable = true)
     private String title;
 
+    @Column(name = "sort_name", nullable = true)
+    private String sortName;
+
     @Column(name = "album", nullable = true)
     private String albumName;
 
@@ -282,6 +285,14 @@ public class MediaFile {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getSortName() {
+        return sortName;
+    }
+
+    public void setSortName(String sortName) {
+        this.sortName = sortName;
     }
 
     public String getAlbumName() {
@@ -567,7 +578,7 @@ public class MediaFile {
 
     public static final double NOT_INDEXED = -1.0;
 
-    public static final int VERSION = 4;
+    public static final int VERSION = 5;
 
     public static enum MediaType {
         MUSIC,

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -146,6 +146,7 @@ public class JaxbContentService {
             // Ignored.
         }
         child.setTitle(mediaFile.getName());
+        child.setSortName(mediaFile.getSortName());
         child.setAlbum(mediaFile.getAlbumName());
         child.setArtist(mediaFile.getArtist());
         child.setIsDir(mediaFile.isDirectory());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1014,6 +1014,7 @@ public class MediaFileService {
                 mediaFile.setAlbumArtist(metaData.getAlbumArtist());
                 mediaFile.setAlbumName(metaData.getAlbumName());
                 mediaFile.setTitle(metaData.getTitle());
+                mediaFile.setSortName(metaData.getSortName());
                 mediaFile.setDiscNumber(metaData.getDiscNumber());
                 mediaFile.setTrackNumber(metaData.getTrackNumber());
                 mediaFile.setGenre(metaData.getGenre());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -88,6 +88,7 @@ public class JaudiotaggerParser extends MetaDataParser {
             if (tag != null) {
                 metaData.setAlbumName(getTagField(tag, FieldKey.ALBUM));
                 metaData.setTitle(getTagField(tag, FieldKey.TITLE));
+                metaData.setSortName(getTagField(tag, FieldKey.TITLE_SORT));
                 metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setDiscNumber(parseIntegerPattern(getTagField(tag, FieldKey.DISC_NO), null));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -33,6 +33,7 @@ public class MetaData {
     private Integer discNumber;
     private Integer trackNumber;
     private String title;
+    private String sortName;
     private String artist;
     private String albumArtist;
     private String albumName;
@@ -70,6 +71,14 @@ public class MetaData {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getSortName() {
+        return sortName;
+    }
+
+    public void setSortName(String sortName) {
+        this.sortName = sortName;
     }
 
     public String getAlbumArtist() {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-sort-name.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-sort-name.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-sort-name" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="sort_name" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="sort_name" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-media-file-sort-name.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -23,4 +23,5 @@
     <include file="11.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="11.1/changelog.xml" relativeToChangelogFile="true"/>
     <include file="13.1/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="13.2/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-sonos-api/pom.xml
+++ b/airsonic-sonos-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -1,4 +1,4 @@
-# v13.2.0
+# Airsonic-Pulse v13.2.0
 
 ## Library rescan required
 

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -1,0 +1,10 @@
+# v13.2.0
+
+## Library rescan required
+
+* #135 introduces a `sortName` column on `media_file` populated from `FieldKey.TITLE_SORT`.
+  Existing rows are re-scanned automatically via the `MediaFile.VERSION` bump.
+
+## OpenSubsonic
+
+* #135 OpenSubsonic: Child.sortName from FieldKey.TITLE_SORT

--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../pom.xml</relativePath>
         <artifactId>airsonic</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0-SNAPSHOT</version>
         <groupId>org.airsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.airsonic.player</groupId>
             <artifactId>airsonic-main</artifactId>
-            <version>13.1.0</version>
+            <version>13.2.0-SNAPSHOT</version>
             <type>war</type>
         </dependency>
     </dependencies>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.airsonic.player</groupId>
     <artifactId>airsonic</artifactId>
-    <version>13.1.0</version>
+    <version>13.2.0-SNAPSHOT</version>
     <name>Airsonic-Pulse</name>
     <packaging>pom</packaging>
     <organization>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -269,6 +269,7 @@
         <xs:attribute name="displayArtist" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="displayAlbumArtist" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="mediaType" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
     </xs:complexType>
 
     <xs:simpleType name="MediaType">


### PR DESCRIPTION
First 13.2.x change. Establishes the DB + parser + XSD + JaxbContentService shape pattern that the other shape-similar items in this milestone (#136, #137, #138, #139, #143) follow.

Bumps the root pom + all sub-module parent-version refs from 13.1.0 to 13.2.0-SNAPSHOT.

Library rescan is automatic on upgrade via MediaFile.VERSION 4 → 5.

fixes #135