### PR TITLE
OpenSubsonic: AlbumID3.sortName (fixes #136)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
@@ -51,6 +51,9 @@ public class Album {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "sort_name", nullable = true)
+    private String sortName;
+
     @Column(name = "artist", nullable = false)
     private String artist;
 
@@ -153,6 +156,14 @@ public class Album {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getSortName() {
+        return sortName;
+    }
+
+    public void setSortName(String sortName) {
+        this.sortName = sortName;
     }
 
     public String getArtist() {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -76,6 +76,9 @@ public class MediaFile {
     @Column(name = "album", nullable = true)
     private String albumName;
 
+    @Column(name = "album_sort_name", nullable = true)
+    private String albumSortName;
+
     @Column(name = "artist", nullable = true)
     private String artist;
 
@@ -301,6 +304,14 @@ public class MediaFile {
 
     public void setAlbumName(String album) {
         this.albumName = album;
+    }
+
+    public String getAlbumSortName() {
+        return albumSortName;
+    }
+
+    public void setAlbumSortName(String albumSortName) {
+        this.albumSortName = albumSortName;
     }
 
     public String getArtist() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -110,6 +110,7 @@ public class JaxbContentService {
         jaxbAlbum.setPlayed(jaxbWriter.convertDate(album.getLastPlayed()));
         jaxbAlbum.setMusicBrainzId(album.getMusicBrainzReleaseId());
         jaxbAlbum.setDisplayArtist(album.getArtist());
+        jaxbAlbum.setSortName(album.getSortName());
         return jaxbAlbum;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1013,6 +1013,7 @@ public class MediaFileService {
                 mediaFile.setArtist(metaData.getArtist());
                 mediaFile.setAlbumArtist(metaData.getAlbumArtist());
                 mediaFile.setAlbumName(metaData.getAlbumName());
+                mediaFile.setAlbumSortName(metaData.getAlbumSortName());
                 mediaFile.setTitle(metaData.getTitle());
                 mediaFile.setSortName(metaData.getSortName());
                 mediaFile.setDiscNumber(metaData.getDiscNumber());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -478,6 +478,9 @@ public class MediaScannerService {
         if (file.getGenre() != null) {
             album.setGenre(file.getGenre());
         }
+        if (file.getAlbumSortName() != null) {
+            album.setSortName(file.getAlbumSortName());
+        }
 
         if (album.getArt() == null && parent != null) {
             CoverArt art = coverArtService.getMediaFileArt(parent.getId());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -87,6 +87,7 @@ public class JaudiotaggerParser extends MetaDataParser {
             Tag tag = audioFile.getTag();
             if (tag != null) {
                 metaData.setAlbumName(getTagField(tag, FieldKey.ALBUM));
+                metaData.setAlbumSortName(getTagField(tag, FieldKey.ALBUM_SORT));
                 metaData.setTitle(getTagField(tag, FieldKey.TITLE));
                 metaData.setSortName(getTagField(tag, FieldKey.TITLE_SORT));
                 metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -37,6 +37,7 @@ public class MetaData {
     private String artist;
     private String albumArtist;
     private String albumName;
+    private String albumSortName;
     private String genre;
     private Integer year;
     private Integer bitRate;
@@ -103,6 +104,14 @@ public class MetaData {
 
     public void setAlbumName(String albumName) {
         this.albumName = albumName;
+    }
+
+    public String getAlbumSortName() {
+        return albumSortName;
+    }
+
+    public void setAlbumSortName(String albumSortName) {
+        this.albumSortName = albumSortName;
     }
 
     public String getGenre() {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-album-sort-name.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-album-sort-name.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-album-sort-name" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="album" columnName="sort_name" />
+            </not>
+        </preConditions>
+        <addColumn tableName="album">
+            <column name="sort_name" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-album-sort-name.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-album-sort-name.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-album-sort-name" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="album_sort_name" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="album_sort_name" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -3,4 +3,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <include file="add-media-file-sort-name.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-album-sort-name.xml" relativeToChangelogFile="true"/>
+    <include file="add-album-sort-name.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,8 +36,12 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -253,6 +258,72 @@ public class MediaScannerServiceTestCase {
         assertEquals("0820752d-1043-4572-ab36-2df3b5cc15fa", file.getMusicBrainzReleaseId());
         assertEquals("831586f4-56f9-4785-ac91-447ae20af633", file.getMusicBrainzRecordingId());
         assertEquals(-1.0d, file.getStartPosition(), 0.0d);
+    }
+
+    // The album sort name (FieldKey.ALBUM_SORT) is carried on each track's MediaFile and
+    // aggregated onto the Album in the private updateAlbum(), mirroring the mb_release_id
+    // pattern. These tests drive that aggregation step directly so the set / null-guard /
+    // last-write-wins semantics can be covered without audio fixtures tagged with ALBUM_SORT.
+
+    private static final Instant ALBUM_SORT_SCAN_TIME = Instant.now().truncatedTo(ChronoUnit.MICROS);
+
+    private Album newSortNameTestAlbum() {
+        Album album = new Album();
+        album.setName("TestAlbum");
+        album.setArtist("TestArtist");
+        album.setPath("TestAlbum");
+        // Match the scan time so updateAlbum treats this as a repeat encounter and skips
+        // the persistence/index branch — keeping these tests free of DB side effects.
+        album.setLastScanned(ALBUM_SORT_SCAN_TIME);
+        return album;
+    }
+
+    private void aggregateTrack(Map<String, Album> albums, String albumSortName) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.MUSIC);
+        file.setAlbumName("TestAlbum");
+        file.setArtist("TestArtist");
+        file.setAlbumArtist("TestArtist");
+        file.setParentPath("TestAlbum");
+        file.setAlbumSortName(albumSortName);
+        ReflectionTestUtils.invokeMethod(mediaScannerService, "updateAlbum",
+            null, file, null, ALBUM_SORT_SCAN_TIME,
+            new HashMap<String, AtomicInteger>(), albums, new HashSet<Integer>());
+    }
+
+    @Test
+    public void testAlbumSortNameSetFromTrack() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateTrack(albums, "Beatles, The");
+
+        assertEquals("Beatles, The", album.getSortName());
+    }
+
+    @Test
+    public void testAlbumSortNameNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateTrack(albums, "Beatles, The");
+        aggregateTrack(albums, null);
+
+        assertEquals("Beatles, The", album.getSortName());
+    }
+
+    @Test
+    public void testAlbumSortNameLastWriteWins() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateTrack(albums, "First Sort");
+        aggregateTrack(albums, "Second Sort");
+
+        assertEquals("Second Sort", album.getSortName());
     }
 
     @Test

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -4,7 +4,11 @@
 
 * #135 introduces a `sortName` column on `media_file` populated from `FieldKey.TITLE_SORT`.
   Existing rows are re-scanned automatically via the `MediaFile.VERSION` bump.
+* #136 adds a `sort_name` column on the `album` table (and an internal `album_sort_name`
+  carrier on `media_file`) populated from `FieldKey.ALBUM_SORT`. Both are filled by the
+  same rescan triggered by the #135 `MediaFile.VERSION` bump — no separate rescan needed.
 
 ## OpenSubsonic
 
 * #135 OpenSubsonic: Child.sortName from FieldKey.TITLE_SORT
+* #136 OpenSubsonic: AlbumID3.sortName from FieldKey.ALBUM_SORT

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -175,6 +175,7 @@
         <xs:attribute name="played" type="xs:dateTime" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="musicBrainzId" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="displayArtist" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
     </xs:complexType>
 
     <xs:complexType name="AlbumWithSongsID3">


### PR DESCRIPTION
Second 13.2.x shape item, album side. Follows #135 plus the mb_release_id carrier pattern for album-level tags: media_file.album_sort_name (internal carrier, parser-populated from FieldKey.ALBUM_SORT) aggregates last-write-wins onto album.sort_name in updateAlbum, surfaced as the optional AlbumID3.sortName attribute. Three MediaScannerServiceTestCase tests cover the aggregation, including a discriminating null-guard test. No pom or MediaFile.VERSION bump — #135's 4->5 bump already forces re-parse.

fixes #136