### PR TITLE
OpenSubsonic: ArtistID3.musicBrainzId + sortName (fixes #137, #138)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Artist.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Artist.java
@@ -42,6 +42,10 @@ public class Artist {
     private Integer id;
     @Column(unique = true, nullable = false)
     private String name;
+    @Column(name = "sort_name", nullable = true)
+    private String sortName;
+    @Column(name = "mb_artist_id", nullable = true)
+    private String musicBrainzArtistId;
     @Column(name = "album_count")
     @Convert(converter = AtomicIntegerConverter.class)
     private final AtomicInteger albumCount = new AtomicInteger();
@@ -83,6 +87,22 @@ public class Artist {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getSortName() {
+        return sortName;
+    }
+
+    public void setSortName(String sortName) {
+        this.sortName = sortName;
+    }
+
+    public String getMusicBrainzArtistId() {
+        return musicBrainzArtistId;
+    }
+
+    public void setMusicBrainzArtistId(String musicBrainzArtistId) {
+        this.musicBrainzArtistId = musicBrainzArtistId;
     }
 
     public int getAlbumCount() {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -157,6 +157,12 @@ public class MediaFile {
     @Column(name = "mb_recording_id", nullable = true)
     private String musicBrainzRecordingId;
 
+    @Column(name = "mb_artist_id", nullable = true)
+    private String musicBrainzArtistId;
+
+    @Column(name = "artist_sort_name", nullable = true)
+    private String artistSortName;
+
     @Transient
     private Double averageRating = 0.0;
 
@@ -496,6 +502,22 @@ public class MediaFile {
 
     public void setMusicBrainzRecordingId(String musicBrainzRecordingId) {
         this.musicBrainzRecordingId = musicBrainzRecordingId;
+    }
+
+    public String getMusicBrainzArtistId() {
+        return musicBrainzArtistId;
+    }
+
+    public void setMusicBrainzArtistId(String musicBrainzArtistId) {
+        this.musicBrainzArtistId = musicBrainzArtistId;
+    }
+
+    public String getArtistSortName() {
+        return artistSortName;
+    }
+
+    public void setArtistSortName(String artistSortName) {
+        this.artistSortName = artistSortName;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -74,6 +74,8 @@ public class JaxbContentService {
             jaxbArtist.setCoverArt(CoverArtController.ARTIST_COVERART_PREFIX + artist.getId());
         }
         jaxbArtist.setMediaType("artist");
+        jaxbArtist.setSortName(artist.getSortName());
+        jaxbArtist.setMusicBrainzId(artist.getMusicBrainzArtistId());
         return jaxbArtist;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1027,6 +1027,8 @@ public class MediaFileService {
                 mediaFile.setWidth(metaData.getWidth());
                 mediaFile.setMusicBrainzReleaseId(metaData.getMusicBrainzReleaseId());
                 mediaFile.setMusicBrainzRecordingId(metaData.getMusicBrainzRecordingId());
+                mediaFile.setMusicBrainzArtistId(metaData.getMusicBrainzArtistId());
+                mediaFile.setArtistSortName(metaData.getArtistSortName());
             }
             String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(mediaFile.getPath())));
             mediaFile.setFormat(format);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -543,6 +543,13 @@ public class MediaScannerService {
             return a;
         });
 
+        if (file.getMusicBrainzArtistId() != null) {
+            artist.setMusicBrainzArtistId(file.getMusicBrainzArtistId());
+        }
+        if (file.getArtistSortName() != null) {
+            artist.setSortName(file.getArtistSortName());
+        }
+
         if (firstEncounter.get()) {
             artist.setFolder(musicFolder);
             artistService.save(artist);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -96,6 +96,10 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
                 metaData.setMusicBrainzRecordingId(getTagField(tag, FieldKey.MUSICBRAINZ_TRACK_ID));
+                // The ID3 artist is grouped by album-artist, so source its sort name and MB id
+                // from the release-artist tags rather than the per-track artist tags.
+                metaData.setMusicBrainzArtistId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEARTISTID));
+                metaData.setArtistSortName(getTagField(tag, FieldKey.ALBUM_ARTIST_SORT));
 
                 metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
                 metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -47,6 +47,8 @@ public class MetaData {
     private Integer height;
     private String musicBrainzReleaseId;
     private String musicBrainzRecordingId;
+    private String musicBrainzArtistId;
+    private String artistSortName;
     private final List<Track> tracks = new ArrayList<>();
     private final List<Chapter> chapters = new ArrayList<>();
 
@@ -184,6 +186,22 @@ public class MetaData {
 
     public void setMusicBrainzRecordingId(String musicBrainzRecordingId) {
         this.musicBrainzRecordingId = musicBrainzRecordingId;
+    }
+
+    public String getMusicBrainzArtistId() {
+        return musicBrainzArtistId;
+    }
+
+    public void setMusicBrainzArtistId(String musicBrainzArtistId) {
+        this.musicBrainzArtistId = musicBrainzArtistId;
+    }
+
+    public String getArtistSortName() {
+        return artistSortName;
+    }
+
+    public void setArtistSortName(String artistSortName) {
+        this.artistSortName = artistSortName;
     }
 
     public void addTrack(Track track) {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-artist-mb-artist-id.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-artist-mb-artist-id.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-artist-mb-artist-id" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="artist" columnName="mb_artist_id" />
+            </not>
+        </preConditions>
+        <addColumn tableName="artist">
+            <column name="mb_artist_id" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-artist-sort-name.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-artist-sort-name.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-artist-sort-name" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="artist" columnName="sort_name" />
+            </not>
+        </preConditions>
+        <addColumn tableName="artist">
+            <column name="sort_name" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-artist-sort-name.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-artist-sort-name.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-artist-sort-name" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="artist_sort_name" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="artist_sort_name" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-mb-artist-id.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-mb-artist-id.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-mb-artist-id" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="mb_artist_id" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="mb_artist_id" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -5,4 +5,8 @@
     <include file="add-media-file-sort-name.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-album-sort-name.xml" relativeToChangelogFile="true"/>
     <include file="add-album-sort-name.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-mb-artist-id.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-artist-sort-name.xml" relativeToChangelogFile="true"/>
+    <include file="add-artist-mb-artist-id.xml" relativeToChangelogFile="true"/>
+    <include file="add-artist-sort-name.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -326,6 +326,70 @@ public class MediaScannerServiceTestCase {
         assertEquals("Second Sort", album.getSortName());
     }
 
+    // The artist MB id (FieldKey.MUSICBRAINZ_RELEASEARTISTID) and sort name
+    // (FieldKey.ALBUM_ARTIST_SORT) are carried on each track's MediaFile and aggregated onto
+    // the Artist in the private updateArtist(). These tests drive that aggregation step
+    // directly to cover the set / null-guard / last-write-wins semantics without audio fixtures.
+
+    private static final Instant ARTIST_AGG_SCAN_TIME = Instant.now().truncatedTo(ChronoUnit.MICROS);
+
+    private Artist newFieldsTestArtist() {
+        Artist artist = new Artist("TestArtist");
+        // Match the scan time so updateArtist treats this as a repeat encounter and skips
+        // the persistence/index branch — keeping these tests free of DB side effects.
+        artist.setLastScanned(ARTIST_AGG_SCAN_TIME);
+        return artist;
+    }
+
+    private void aggregateArtistTrack(Map<String, Artist> artists, String mbArtistId, String artistSortName) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.MUSIC);
+        file.setAlbumArtist("TestArtist");
+        file.setMusicBrainzArtistId(mbArtistId);
+        file.setArtistSortName(artistSortName);
+        ReflectionTestUtils.invokeMethod(mediaScannerService, "updateArtist",
+            null, file, null, ARTIST_AGG_SCAN_TIME,
+            new HashMap<String, AtomicInteger>(), artists);
+    }
+
+    @Test
+    public void testArtistFieldsSetFromTrack() {
+        Artist artist = newFieldsTestArtist();
+        Map<String, Artist> artists = new HashMap<>();
+        artists.put("TestArtist", artist);
+
+        aggregateArtistTrack(artists, "mb-artist-1", "Beatles, The");
+
+        assertEquals("mb-artist-1", artist.getMusicBrainzArtistId());
+        assertEquals("Beatles, The", artist.getSortName());
+    }
+
+    @Test
+    public void testArtistFieldsNullDoesNotClobber() {
+        Artist artist = newFieldsTestArtist();
+        Map<String, Artist> artists = new HashMap<>();
+        artists.put("TestArtist", artist);
+
+        aggregateArtistTrack(artists, "mb-artist-1", "Beatles, The");
+        aggregateArtistTrack(artists, null, null);
+
+        assertEquals("mb-artist-1", artist.getMusicBrainzArtistId());
+        assertEquals("Beatles, The", artist.getSortName());
+    }
+
+    @Test
+    public void testArtistFieldsLastWriteWins() {
+        Artist artist = newFieldsTestArtist();
+        Map<String, Artist> artists = new HashMap<>();
+        artists.put("TestArtist", artist);
+
+        aggregateArtistTrack(artists, "mb-first", "First Sort");
+        aggregateArtistTrack(artists, "mb-second", "Second Sort");
+
+        assertEquals("mb-second", artist.getMusicBrainzArtistId());
+        assertEquals("Second Sort", artist.getSortName());
+    }
+
     @Test
     public void testMusicCue() {
         LOG.info("start testMusicCue");

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -7,8 +7,15 @@
 * #136 adds a `sort_name` column on the `album` table (and an internal `album_sort_name`
   carrier on `media_file`) populated from `FieldKey.ALBUM_SORT`. Both are filled by the
   same rescan triggered by the #135 `MediaFile.VERSION` bump — no separate rescan needed.
+* #137 / #138 add `mb_artist_id` and `sort_name` columns on the `artist` table (and internal
+  `mb_artist_id` / `artist_sort_name` carriers on `media_file`) populated from
+  `FieldKey.MUSICBRAINZ_RELEASEARTISTID` and `FieldKey.ALBUM_ARTIST_SORT`. The release-artist
+  tags are used because Airsonic groups the ID3 artist by album-artist. Filled by the same
+  #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
 * #135 OpenSubsonic: Child.sortName from FieldKey.TITLE_SORT
 * #136 OpenSubsonic: AlbumID3.sortName from FieldKey.ALBUM_SORT
+* #137 OpenSubsonic: ArtistID3.musicBrainzId from FieldKey.MUSICBRAINZ_RELEASEARTISTID
+* #138 OpenSubsonic: ArtistID3.sortName from FieldKey.ALBUM_ARTIST_SORT

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -147,6 +147,8 @@
         <xs:attribute name="albumCount" type="xs:int" use="required"/>
         <xs:attribute name="starred" type="xs:dateTime" use="optional"/>
         <xs:attribute name="mediaType" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="musicBrainzId" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
     </xs:complexType>
 
     <xs:complexType name="ArtistWithAlbumsID3">


### PR DESCRIPTION
Bundled artist-side shape items. Follows the #136 carrier-then-aggregate pattern: media_file carriers (mb_artist_id, artist_sort_name) aggregate last-write-wins in updateArtist onto the Artist entity (mb_artist_id, sort_name), surfaced as optional ArtistID3.musicBrainzId and sortName.

Sourced from the album-artist tag variants (MUSICBRAINZ_RELEASEARTISTID, ALBUM_ARTIST_SORT) rather than the track-artist variants the issue text named: the ID3 Artist entity is keyed on album artist, so the release-artist tags are semantically correct and avoid wrong values on compilations. Three MediaScannerServiceTestCase tests cover the aggregation, including a discriminating null-guard test. No pom or MediaFile.VERSION bump.

fixes #137
fixes #138