### PR TITLE
OpenSubsonic: Child.bpm (fixes #139)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -94,6 +94,9 @@ public class MediaFile {
     @Column(name = "year", nullable = true)
     private Integer year;
 
+    @Column(name = "bpm", nullable = true)
+    private Integer bpm;
+
     @Column(name = "genre", nullable = true)
     private String genre;
 
@@ -362,6 +365,14 @@ public class MediaFile {
 
     public void setYear(Integer year) {
         this.year = year;
+    }
+
+    public Integer getBpm() {
+        return bpm;
+    }
+
+    public void setBpm(Integer bpm) {
+        this.bpm = bpm;
     }
 
     public String getGenre() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -155,6 +155,7 @@ public class JaxbContentService {
         child.setIsDir(mediaFile.isDirectory());
         child.setCoverArt(findCoverArt(mediaFile, parent));
         child.setYear(mediaFile.getYear());
+        child.setBpm(mediaFile.getBpm());
         child.setGenre(mediaFile.getGenre());
         child.setCreated(jaxbWriter.convertDate(mediaFile.getCreated()));
         child.setStarred(jaxbWriter.convertDate(mediaFileService.getMediaFileStarredDate(mediaFile, username)));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1020,6 +1020,7 @@ public class MediaFileService {
                 mediaFile.setTrackNumber(metaData.getTrackNumber());
                 mediaFile.setGenre(metaData.getGenre());
                 mediaFile.setYear(metaData.getYear());
+                mediaFile.setBpm(metaData.getBpm());
                 mediaFile.setDuration(metaData.getDuration());
                 mediaFile.setBitRate(metaData.getBitRate());
                 mediaFile.setVariableBitRate(metaData.getVariableBitRate());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -91,6 +91,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setTitle(getTagField(tag, FieldKey.TITLE));
                 metaData.setSortName(getTagField(tag, FieldKey.TITLE_SORT));
                 metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
+                metaData.setBpm(parseBpm(getTagField(tag, FieldKey.BPM)));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setDiscNumber(parseIntegerPattern(getTagField(tag, FieldKey.DISC_NO), null));
                 metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -40,6 +40,7 @@ public class MetaData {
     private String albumSortName;
     private String genre;
     private Integer year;
+    private Integer bpm;
     private Integer bitRate;
     private boolean variableBitRate;
     private Double duration;
@@ -130,6 +131,14 @@ public class MetaData {
 
     public void setYear(Integer year) {
         this.year = year;
+    }
+
+    public Integer getBpm() {
+        return bpm;
+    }
+
+    public void setBpm(Integer bpm) {
+        this.bpm = bpm;
     }
 
     public Integer getBitRate() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
@@ -280,6 +280,25 @@ public abstract class MetaDataParser {
         return result;
     }
 
+    Integer parseBpm(String str) {
+        str = StringUtils.trimToNull(str);
+
+        if (str == null) {
+            return null;
+        }
+
+        try {
+            double d = Double.parseDouble(str);
+            long r = Math.round(d);
+            if (!Double.isFinite(d) || r <= 0 || r > Integer.MAX_VALUE) {
+                return null;
+            }
+            return (int) r;
+        } catch (NumberFormatException x) {
+            return null;
+        }
+    }
+
     /**
      * Removes any prefixed track number from the given title string.
      *

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-bpm.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-bpm.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-bpm" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="bpm" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="bpm" type="int">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -9,4 +9,5 @@
     <include file="add-media-file-artist-sort-name.xml" relativeToChangelogFile="true"/>
     <include file="add-artist-mb-artist-id.xml" relativeToChangelogFile="true"/>
     <include file="add-artist-sort-name.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-bpm.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit test of {@link MetaDataParser}.
@@ -102,5 +103,49 @@ public class MetaDataParserTestCase {
         assertEquals("01", parser.removeTrackNumberFromTitle("01 ", 2));
         assertEquals("01", parser.removeTrackNumberFromTitle(" 01 ", 2));
         assertEquals("01", parser.removeTrackNumberFromTitle(" 01", 2));
+    }
+
+    @Test
+    public void testParseBpm() {
+
+        MetaDataParser parser = new MetaDataParser() {
+            @Override
+            public MetaData getRawMetaData(Path file) {
+                return null;
+            }
+
+            @Override
+            public void setMetaData(MediaFile file, MetaData metaData) {
+            }
+
+            @Override
+            public boolean isEditingSupported() {
+                return false;
+            }
+
+            @Override
+            MediaFolderService getMediaFolderService() {
+                return null;
+            }
+
+            @Override
+            public boolean isApplicable(Path path) {
+                return false;
+            }
+        };
+
+        assertEquals(Integer.valueOf(120), parser.parseBpm("120"));
+        assertEquals(Integer.valueOf(121), parser.parseBpm("120.6"));
+        assertEquals(Integer.valueOf(120), parser.parseBpm("120.4"));
+        assertEquals(Integer.valueOf(98), parser.parseBpm(" 98 "));
+        assertNull(parser.parseBpm(""));
+        assertNull(parser.parseBpm("   "));
+        assertNull(parser.parseBpm("fast"));
+        assertNull(parser.parseBpm(null));
+        assertNull(parser.parseBpm("0"));
+        assertNull(parser.parseBpm("-5"));
+        assertNull(parser.parseBpm("NaN"));
+        assertNull(parser.parseBpm("Infinity"));
+        assertNull(parser.parseBpm("99999999999"));
     }
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -12,6 +12,8 @@
   `FieldKey.MUSICBRAINZ_RELEASEARTISTID` and `FieldKey.ALBUM_ARTIST_SORT`. The release-artist
   tags are used because Airsonic groups the ID3 artist by album-artist. Filled by the same
   #135 rescan — no separate rescan needed.
+* #139 adds an integer `bpm` column on `media_file` populated from `FieldKey.BPM`. Filled by
+  the same #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
@@ -19,3 +21,4 @@
 * #136 OpenSubsonic: AlbumID3.sortName from FieldKey.ALBUM_SORT
 * #137 OpenSubsonic: ArtistID3.musicBrainzId from FieldKey.MUSICBRAINZ_RELEASEARTISTID
 * #138 OpenSubsonic: ArtistID3.sortName from FieldKey.ALBUM_ARTIST_SORT
+* #139 OpenSubsonic: Child.bpm from FieldKey.BPM

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -244,6 +244,7 @@
         <xs:attribute name="artist" type="xs:string" use="optional"/>
         <xs:attribute name="track" type="xs:int" use="optional"/>
         <xs:attribute name="year" type="xs:int" use="optional"/>
+        <xs:attribute name="bpm" type="xs:int" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="genre" type="xs:string" use="optional"/>
         <xs:attribute name="coverArt" type="xs:string" use="optional"/>
         <xs:attribute name="size" type="xs:long" use="optional"/>


### PR DESCRIPTION
Track-level shape item mirroring #135 with a numeric type. media_file.bpm (INTEGER) is parsed from FieldKey.BPM and surfaced as the optional Child.bpm (xs:int). parseBpm rounds decimals to nearest and returns null for blank / non-numeric / non-finite / non-positive values, aligning with the existing integer-parser convention. MetaDataParserTestCase.testParseBpm covers the conversion including edge cases. No pom or MediaFile.VERSION bump.

fixes #139