### PR TITLE
OpenSubsonic: Artist userRating/averageRating wiring (fixes #179)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -85,7 +85,8 @@ public class JaxbContentService {
         result.setName(artist.getTitle() != null ? artist.getTitle() : artist.getArtist());
         Instant starred = mediaFileService.getMediaFileStarredDate(artist, username);
         result.setStarred(jaxbWriter.convertDate(starred));
-        // TODO: add rating. https://opensubsonic.netlify.app/docs/responses/artist/
+        result.setUserRating(ratingService.getRatingForUser(username, artist));
+        result.setAverageRating(ratingService.getAverageRating(artist));
         return result;
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -371,6 +371,21 @@ class JaxbContentServiceTest {
             assertEquals("Artist Name", result.getName());
             assertNull(result.getStarred());
         }
+
+        @Test
+        void createJaxbArtist_fromMediaFile_setsRatings() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFile.getId()).thenReturn(125);
+            when(mediaFile.getTitle()).thenReturn("Rated Artist");
+            when(mediaFileService.getMediaFileStarredDate(mediaFile, "user")).thenReturn(null);
+            when(ratingService.getRatingForUser("user", mediaFile)).thenReturn(5);
+            when(ratingService.getAverageRating(mediaFile)).thenReturn(4.2);
+
+            org.subsonic.restapi.Artist result = service.createJaxbArtist(mediaFile, "user");
+
+            assertEquals(5, result.getUserRating());
+            assertEquals(4.2, result.getAverageRating());
+        }
     }
 
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -22,3 +22,4 @@
 * #137 OpenSubsonic: ArtistID3.musicBrainzId from FieldKey.MUSICBRAINZ_RELEASEARTISTID
 * #138 OpenSubsonic: ArtistID3.sortName from FieldKey.ALBUM_ARTIST_SORT
 * #139 OpenSubsonic: Child.bpm from FieldKey.BPM
+* #179 OpenSubsonic: populate userRating/averageRating on artist responses built from a MediaFile (JaxbContentService.createJaxbArtist)


### PR DESCRIPTION
Wiring-only. createJaxbArtist(MediaFile, username) now populates userRating and averageRating from RatingService, mirroring createJaxbChild. No XSD change (the legacy Artist type has carried these attributes since Subsonic 1.13.0); no DB/Liquibase/parser/VERSION change. A JaxbContentServiceTest case covers the ratings round-trip.

fixes #179