### PR TITLE
OpenSubsonic: Child.replayGain (fixes #143)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -166,6 +166,18 @@ public class MediaFile {
     @Column(name = "artist_sort_name", nullable = true)
     private String artistSortName;
 
+    @Column(name = "rg_track_gain", nullable = true)
+    private Double replayGainTrackGain;
+
+    @Column(name = "rg_album_gain", nullable = true)
+    private Double replayGainAlbumGain;
+
+    @Column(name = "rg_track_peak", nullable = true)
+    private Double replayGainTrackPeak;
+
+    @Column(name = "rg_album_peak", nullable = true)
+    private Double replayGainAlbumPeak;
+
     @Transient
     private Double averageRating = 0.0;
 
@@ -529,6 +541,38 @@ public class MediaFile {
 
     public void setArtistSortName(String artistSortName) {
         this.artistSortName = artistSortName;
+    }
+
+    public Double getReplayGainTrackGain() {
+        return replayGainTrackGain;
+    }
+
+    public void setReplayGainTrackGain(Double replayGainTrackGain) {
+        this.replayGainTrackGain = replayGainTrackGain;
+    }
+
+    public Double getReplayGainAlbumGain() {
+        return replayGainAlbumGain;
+    }
+
+    public void setReplayGainAlbumGain(Double replayGainAlbumGain) {
+        this.replayGainAlbumGain = replayGainAlbumGain;
+    }
+
+    public Double getReplayGainTrackPeak() {
+        return replayGainTrackPeak;
+    }
+
+    public void setReplayGainTrackPeak(Double replayGainTrackPeak) {
+        this.replayGainTrackPeak = replayGainTrackPeak;
+    }
+
+    public Double getReplayGainAlbumPeak() {
+        return replayGainAlbumPeak;
+    }
+
+    public void setReplayGainAlbumPeak(Double replayGainAlbumPeak) {
+        this.replayGainAlbumPeak = replayGainAlbumPeak;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.ReplayGain;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -167,6 +168,7 @@ public class JaxbContentService {
         child.setMusicBrainzId(mediaFile.getMusicBrainzRecordingId());
         child.setDisplayArtist(mediaFile.getArtist());
         child.setDisplayAlbumArtist(mediaFile.getAlbumArtist());
+        child.setReplayGain(buildReplayGain(mediaFile));
         if (mediaFile.getMediaType() != null) {
             child.setMediaType(mediaFile.getMediaType().name().toLowerCase());
         }
@@ -212,6 +214,22 @@ public class JaxbContentService {
             }
         }
         return child;
+    }
+
+    private ReplayGain buildReplayGain(MediaFile mediaFile) {
+        Double trackGain = mediaFile.getReplayGainTrackGain();
+        Double albumGain = mediaFile.getReplayGainAlbumGain();
+        Double trackPeak = mediaFile.getReplayGainTrackPeak();
+        Double albumPeak = mediaFile.getReplayGainAlbumPeak();
+        if (trackGain == null && albumGain == null && trackPeak == null && albumPeak == null) {
+            return null;
+        }
+        ReplayGain replayGain = new ReplayGain();
+        replayGain.setTrackGain(trackGain);
+        replayGain.setAlbumGain(albumGain);
+        replayGain.setTrackPeak(trackPeak);
+        replayGain.setAlbumPeak(albumPeak);
+        return replayGain;
     }
 
     private String findCoverArt(MediaFile mediaFile, MediaFile parent) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1030,6 +1030,10 @@ public class MediaFileService {
                 mediaFile.setMusicBrainzRecordingId(metaData.getMusicBrainzRecordingId());
                 mediaFile.setMusicBrainzArtistId(metaData.getMusicBrainzArtistId());
                 mediaFile.setArtistSortName(metaData.getArtistSortName());
+                mediaFile.setReplayGainTrackGain(metaData.getReplayGainTrackGain());
+                mediaFile.setReplayGainAlbumGain(metaData.getReplayGainAlbumGain());
+                mediaFile.setReplayGainTrackPeak(metaData.getReplayGainTrackPeak());
+                mediaFile.setReplayGainAlbumPeak(metaData.getReplayGainAlbumPeak());
             }
             String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(mediaFile.getPath())));
             mediaFile.setFormat(format);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -30,6 +30,10 @@ import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
+import org.jaudiotagger.tag.TagField;
+import org.jaudiotagger.tag.id3.AbstractID3v2Frame;
+import org.jaudiotagger.tag.id3.AbstractID3v2Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.PictureTypes;
 import org.slf4j.Logger;
@@ -40,6 +44,7 @@ import org.springframework.stereotype.Service;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.LogManager;
@@ -55,6 +60,12 @@ import java.util.logging.LogManager;
 public class JaudiotaggerParser extends MetaDataParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(JaudiotaggerParser.class);
+
+    static final String RG_TRACK_GAIN = "REPLAYGAIN_TRACK_GAIN";
+    static final String RG_ALBUM_GAIN = "REPLAYGAIN_ALBUM_GAIN";
+    static final String RG_TRACK_PEAK = "REPLAYGAIN_TRACK_PEAK";
+    static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
+
     @Autowired
     private MediaFolderService mediaFolderService;
 
@@ -101,6 +112,10 @@ public class JaudiotaggerParser extends MetaDataParser {
                 // from the release-artist tags rather than the per-track artist tags.
                 metaData.setMusicBrainzArtistId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEARTISTID));
                 metaData.setArtistSortName(getTagField(tag, FieldKey.ALBUM_ARTIST_SORT));
+                metaData.setReplayGainTrackGain(parseReplayGain(getReplayGainField(tag, RG_TRACK_GAIN)));
+                metaData.setReplayGainAlbumGain(parseReplayGain(getReplayGainField(tag, RG_ALBUM_GAIN)));
+                metaData.setReplayGainTrackPeak(parseReplayGain(getReplayGainField(tag, RG_TRACK_PEAK)));
+                metaData.setReplayGainAlbumPeak(parseReplayGain(getReplayGainField(tag, RG_ALBUM_PEAK)));
 
                 metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
                 metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));
@@ -132,6 +147,33 @@ public class JaudiotaggerParser extends MetaDataParser {
     private static String getTagField(Tag tag, FieldKey fieldKey) {
         try {
             return StringUtils.replace(StringUtils.trimToNull(tag.getFirst(fieldKey)), "\0", " ");
+        } catch (Exception x) {
+            // Ignored.
+            return null;
+        }
+    }
+
+    /**
+     * Reads a ReplayGain value by name. ReplayGain has no jaudiotagger {@link FieldKey}, so it is
+     * read directly: from ID3v2 it lives in a TXXX frame keyed by a (case-insensitive) description,
+     * while Vorbis comments (FLAC/Ogg/Opus) expose it as a plain keyed field.
+     */
+    static String getReplayGainField(Tag tag, String name) {
+        try {
+            if (tag instanceof AbstractID3v2Tag id3v2) {
+                List<TagField> frames = id3v2.getFrame("TXXX");
+                if (frames != null) {
+                    for (TagField field : frames) {
+                        if (field instanceof AbstractID3v2Frame frame
+                                && frame.getBody() instanceof FrameBodyTXXX txxx
+                                && name.equalsIgnoreCase(txxx.getDescription())) {
+                            return StringUtils.trimToNull(txxx.getText());
+                        }
+                    }
+                }
+                return null;
+            }
+            return StringUtils.trimToNull(tag.getFirst(name));
         } catch (Exception x) {
             // Ignored.
             return null;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -50,6 +50,10 @@ public class MetaData {
     private String musicBrainzRecordingId;
     private String musicBrainzArtistId;
     private String artistSortName;
+    private Double replayGainTrackGain;
+    private Double replayGainAlbumGain;
+    private Double replayGainTrackPeak;
+    private Double replayGainAlbumPeak;
     private final List<Track> tracks = new ArrayList<>();
     private final List<Chapter> chapters = new ArrayList<>();
 
@@ -211,6 +215,38 @@ public class MetaData {
 
     public void setArtistSortName(String artistSortName) {
         this.artistSortName = artistSortName;
+    }
+
+    public Double getReplayGainTrackGain() {
+        return replayGainTrackGain;
+    }
+
+    public void setReplayGainTrackGain(Double replayGainTrackGain) {
+        this.replayGainTrackGain = replayGainTrackGain;
+    }
+
+    public Double getReplayGainAlbumGain() {
+        return replayGainAlbumGain;
+    }
+
+    public void setReplayGainAlbumGain(Double replayGainAlbumGain) {
+        this.replayGainAlbumGain = replayGainAlbumGain;
+    }
+
+    public Double getReplayGainTrackPeak() {
+        return replayGainTrackPeak;
+    }
+
+    public void setReplayGainTrackPeak(Double replayGainTrackPeak) {
+        this.replayGainTrackPeak = replayGainTrackPeak;
+    }
+
+    public Double getReplayGainAlbumPeak() {
+        return replayGainAlbumPeak;
+    }
+
+    public void setReplayGainAlbumPeak(Double replayGainAlbumPeak) {
+        this.replayGainAlbumPeak = replayGainAlbumPeak;
     }
 
     public void addTrack(Track track) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
@@ -299,6 +299,29 @@ public abstract class MetaDataParser {
         }
     }
 
+    Double parseReplayGain(String str) {
+        str = StringUtils.trimToNull(str);
+
+        if (str == null) {
+            return null;
+        }
+
+        // Gain tags carry a trailing "dB" unit (e.g. "-6.50 dB"); peaks do not. Strip it if present.
+        if (str.length() >= 2 && "db".equalsIgnoreCase(str.substring(str.length() - 2))) {
+            str = StringUtils.trimToNull(str.substring(0, str.length() - 2));
+            if (str == null) {
+                return null;
+            }
+        }
+
+        try {
+            double d = Double.parseDouble(str);
+            return Double.isFinite(d) ? d : null;
+        } catch (NumberFormatException x) {
+            return null;
+        }
+    }
+
     /**
      * Removes any prefixed track number from the given title string.
      *

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-replaygain.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-replaygain.xml
@@ -1,0 +1,26 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-replaygain" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="rg_track_gain" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="rg_track_gain" type="double">
+                <constraints nullable="true" />
+            </column>
+            <column name="rg_album_gain" type="double">
+                <constraints nullable="true" />
+            </column>
+            <column name="rg_track_peak" type="double">
+                <constraints nullable="true" />
+            </column>
+            <column name="rg_album_peak" type="double">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -10,4 +10,5 @@
     <include file="add-artist-mb-artist-id.xml" relativeToChangelogFile="true"/>
     <include file="add-artist-sort-name.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-bpm.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-replaygain.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -1,0 +1,66 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.airsonic.player.service.metadata;
+
+import org.jaudiotagger.tag.id3.ID3v24Frame;
+import org.jaudiotagger.tag.id3.ID3v24Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
+import org.jaudiotagger.tag.id3.valuepair.TextEncoding;
+import org.jaudiotagger.tag.vorbiscomment.VorbisCommentTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit test of the ReplayGain extraction in {@link JaudiotaggerParser}.
+ */
+public class JaudiotaggerParserTestCase {
+
+    private static ID3v24Tag tagWithTxxx(String description, String value) {
+        ID3v24Tag tag = new ID3v24Tag();
+        ID3v24Frame frame = new ID3v24Frame("TXXX");
+        frame.setBody(new FrameBodyTXXX(TextEncoding.ISO_8859_1, description, value));
+        tag.addFrame(frame);
+        return tag;
+    }
+
+    @Test
+    public void testGetReplayGainFieldFromId3v2Txxx() {
+        ID3v24Tag tag = tagWithTxxx("REPLAYGAIN_TRACK_GAIN", "-7.20 dB");
+        assertEquals("-7.20 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+
+    @Test
+    public void testGetReplayGainFieldDescriptionMatchIsCaseInsensitive() {
+        ID3v24Tag tag = tagWithTxxx("replaygain_track_gain", "-6.50 dB");
+        assertEquals("-6.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+
+    @Test
+    public void testGetReplayGainFieldMissingFrameReturnsNull() {
+        ID3v24Tag tag = tagWithTxxx("REPLAYGAIN_TRACK_GAIN", "-7.20 dB");
+        assertNull(JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_ALBUM_PEAK));
+    }
+
+    @Test
+    public void testGetReplayGainFieldFromVorbisComment() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.setField("REPLAYGAIN_TRACK_GAIN", "-7.50 dB");
+        assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
@@ -148,4 +148,47 @@ public class MetaDataParserTestCase {
         assertNull(parser.parseBpm("Infinity"));
         assertNull(parser.parseBpm("99999999999"));
     }
+
+    @Test
+    public void testParseReplayGain() {
+
+        MetaDataParser parser = new MetaDataParser() {
+            @Override
+            public MetaData getRawMetaData(Path file) {
+                return null;
+            }
+
+            @Override
+            public void setMetaData(MediaFile file, MetaData metaData) {
+            }
+
+            @Override
+            public boolean isEditingSupported() {
+                return false;
+            }
+
+            @Override
+            MediaFolderService getMediaFolderService() {
+                return null;
+            }
+
+            @Override
+            public boolean isApplicable(Path path) {
+                return false;
+            }
+        };
+
+        assertEquals(Double.valueOf(-6.5), parser.parseReplayGain("-6.50 dB"));
+        assertEquals(Double.valueOf(-7.2), parser.parseReplayGain("-7.20"));
+        assertEquals(Double.valueOf(3.4), parser.parseReplayGain("3.40 DB"));
+        assertEquals(Double.valueOf(0.988553), parser.parseReplayGain("0.988553"));
+        assertNull(parser.parseReplayGain("NaN"));
+        assertNull(parser.parseReplayGain("Infinity"));
+        assertNull(parser.parseReplayGain(""));
+        assertNull(parser.parseReplayGain("   "));
+        assertNull(parser.parseReplayGain("loud"));
+        assertNull(parser.parseReplayGain(null));
+        assertNull(parser.parseReplayGain("dB"));
+        assertNull(parser.parseReplayGain(" dB "));
+    }
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -14,6 +14,9 @@
   #135 rescan — no separate rescan needed.
 * #139 adds an integer `bpm` column on `media_file` populated from `FieldKey.BPM`. Filled by
   the same #135 rescan — no separate rescan needed.
+* #143 adds `rg_track_gain`, `rg_album_gain`, `rg_track_peak`, `rg_album_peak` (DOUBLE) columns
+  on `media_file` for ReplayGain, read from each track's own tags (ID3v2 TXXX frames and Vorbis
+  comments). Filled by the same #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
@@ -23,3 +26,4 @@
 * #138 OpenSubsonic: ArtistID3.sortName from FieldKey.ALBUM_ARTIST_SORT
 * #139 OpenSubsonic: Child.bpm from FieldKey.BPM
 * #179 OpenSubsonic: populate userRating/averageRating on artist responses built from a MediaFile (JaxbContentService.createJaxbArtist)
+* #143 OpenSubsonic: Child.replayGain (trackGain/albumGain/trackPeak/albumPeak) from track ReplayGain tags

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -236,6 +236,9 @@
     </xs:complexType>
 
     <xs:complexType name="Child">
+        <xs:sequence>
+            <xs:element name="replayGain" type="sub:ReplayGain" minOccurs="0"/>  <!-- Added in OpenSubsonic -->
+        </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="parent" type="xs:string" use="optional"/>
         <xs:attribute name="isDir" type="xs:boolean" use="required"/>
@@ -274,6 +277,13 @@
         <xs:attribute name="displayAlbumArtist" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="mediaType" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+    </xs:complexType>
+
+    <xs:complexType name="ReplayGain">  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="trackGain" type="xs:double" use="optional"/>
+        <xs:attribute name="albumGain" type="xs:double" use="optional"/>
+        <xs:attribute name="trackPeak" type="xs:double" use="optional"/>
+        <xs:attribute name="albumPeak" type="xs:double" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="MediaType">


### PR DESCRIPTION
Surfaces ReplayGain as the nested Child.replayGain object. Values are read from each track's own tags -- ID3v2 TXXX frames (matched by replaygain_* description, case-insensitive) for MP3, Vorbis comment keys for FLAC/Ogg/Opus -- since jaudiotagger 3.0.1 has no ReplayGain FieldKey constants. parseReplayGain strips a trailing dB from gains, parses to a finite double, and returns null for non-numeric/non-finite input; the replayGain element is omitted when all four are absent. Four DOUBLE columns on media_file, a new ReplayGain XSD complexType + nested Child element, no MediaFile.VERSION bump. Out of scope (follow-ups): MP4 freeform atoms, Opus R128, baseGain, fallbackGain, AlbumID3.replayGain.

fixes #143