### PR TITLE
OpenSubsonic: Child.genres[] multi-genre (fixes #134)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #
 # .gitignore
-# airsonic/airsonic
+# airsonic-pulse/airsonic-pulse
 #
 # Project-wide gitignores
 #
@@ -14,6 +14,7 @@
 # AI assistant files
 CLAUDE.md
 .claude/
+analysis/
 
 #
 ## Windows.gitignore

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
@@ -68,4 +68,24 @@ public class Genres {
     public List<Genre> getGenres() {
         return new ArrayList<Genre>(genres.values());
     }
+
+    /**
+     * Splits a (possibly multi-valued) genre string into individual, trimmed, de-duplicated
+     * genre names using the given separator characters. Mirrors the splitting the count-table
+     * builder applies, so a single separator setting governs both counts and the genres list.
+     * <p>
+     * The internal {@code .distinct()} dedups within a single input string; callers that flatMap
+     * this across multiple raw tag values typically apply another {@code .distinct()} downstream
+     * to dedup across frames as well.
+     */
+    public static List<String> split(String genre, String separators) {
+        if (StringUtils.isBlank(genre)) {
+            return List.of();
+        }
+        return Stream.of(StringUtils.split(genre, separators))
+                .map(StringUtils::trim)
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .toList();
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -100,6 +100,9 @@ public class MediaFile {
     @Column(name = "genre", nullable = true)
     private String genre;
 
+    @Column(name = "genres", nullable = true)
+    private String genres;
+
     @Column(name = "bit_rate", nullable = true)
     private Integer bitRate;
 
@@ -393,6 +396,14 @@ public class MediaFile {
 
     public void setGenre(String genre) {
         this.genre = genre;
+    }
+
+    public String getGenres() {
+        return genres;
+    }
+
+    public void setGenres(String genres) {
+        this.genres = genres;
     }
 
     public Integer getBitRate() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -22,6 +22,7 @@ import org.airsonic.player.controller.CoverArtController;
 import org.airsonic.player.controller.JAXBWriter;
 import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.CoverArt;
+import org.airsonic.player.domain.Genres;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.Player;
 import org.airsonic.player.domain.Playlist;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.ItemGenre;
 import org.subsonic.restapi.ReplayGain;
 
 import java.time.Instant;
@@ -46,6 +48,7 @@ public class JaxbContentService {
     private final MediaFileService mediaFileService;
     private final TranscodingService transcodingService;
     private final RatingService ratingService;
+    private final SettingsService settingsService;
 
     JaxbContentService(
             JAXBWriter jaxbWriter,
@@ -55,7 +58,8 @@ public class JaxbContentService {
             AlbumService albumService,
             MediaFileService mediaFileService,
             TranscodingService transcodingService,
-            RatingService ratingService) {
+            RatingService ratingService,
+            SettingsService settingsService) {
         this.jaxbWriter = jaxbWriter;
         this.artistService = artistService;
         this.coverArtService = coverArtService;
@@ -64,6 +68,7 @@ public class JaxbContentService {
         this.mediaFileService = mediaFileService;
         this.transcodingService = transcodingService;
         this.ratingService = ratingService;
+        this.settingsService = settingsService;
     }
 
     public <T extends ArtistID3> T createJaxbArtist(T jaxbArtist, org.airsonic.player.domain.Artist artist, String username) {
@@ -159,6 +164,11 @@ public class JaxbContentService {
         child.setYear(mediaFile.getYear());
         child.setBpm(mediaFile.getBpm());
         child.setGenre(mediaFile.getGenre());
+        for (String genreName : Genres.split(mediaFile.getGenres(), settingsService.getGenreSeparators())) {
+            ItemGenre itemGenre = new ItemGenre();
+            itemGenre.setName(genreName);
+            child.getGenres().add(itemGenre);
+        }
         child.setCreated(jaxbWriter.convertDate(mediaFile.getCreated()));
         child.setStarred(jaxbWriter.convertDate(mediaFileService.getMediaFileStarredDate(mediaFile, username)));
         child.setUserRating(ratingService.getRatingForUser(username, mediaFile));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1019,6 +1019,7 @@ public class MediaFileService {
                 mediaFile.setDiscNumber(metaData.getDiscNumber());
                 mediaFile.setTrackNumber(metaData.getTrackNumber());
                 mediaFile.setGenre(metaData.getGenre());
+                mediaFile.setGenres(packGenres(metaData.getGenres()));
                 mediaFile.setYear(metaData.getYear());
                 mediaFile.setBpm(metaData.getBpm());
                 mediaFile.setDuration(metaData.getDuration());
@@ -1737,5 +1738,29 @@ public class MediaFileService {
     @Transactional
     public void expunge() {
         mediaFileRepository.deleteAllByPresentFalse();
+    }
+
+    /**
+     * Splits every raw GENRE tag value by the configured separators, maps each token through
+     * {@link MetaDataParser#mapGenre(String)} (so ID3v1 numeric codes like {@code "(17)"} become
+     * {@code "Rock"}, matching the single-genre column's behaviour), de-duplicates preserving
+     * order, and joins with the primary separator into a packed column value. Returns null when
+     * the input yields no genres so the column stays null for tagless tracks.
+     */
+    String packGenres(List<String> rawGenres) {
+        if (rawGenres == null || rawGenres.isEmpty()) {
+            return null;
+        }
+        String separators = settingsService.getGenreSeparators();
+        List<String> clean = rawGenres.stream()
+                .flatMap(g -> Genres.split(g, separators).stream())
+                .map(MetaDataParser::mapGenre)
+                .distinct()
+                .toList();
+        if (clean.isEmpty()) {
+            return null;
+        }
+        String separator = (separators == null || separators.isEmpty()) ? ";" : separators.substring(0, 1);
+        return String.join(separator, clean);
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -104,6 +104,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
                 metaData.setBpm(parseBpm(getTagField(tag, FieldKey.BPM)));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
+                metaData.setGenres(getAllTagFields(tag, FieldKey.GENRE));
                 metaData.setDiscNumber(parseIntegerPattern(getTagField(tag, FieldKey.DISC_NO), null));
                 metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
@@ -150,6 +151,22 @@ public class JaudiotaggerParser extends MetaDataParser {
         } catch (Exception x) {
             // Ignored.
             return null;
+        }
+    }
+
+    static List<String> getAllTagFields(Tag tag, FieldKey fieldKey) {
+        try {
+            List<String> values = tag.getAll(fieldKey);
+            if (values == null || values.isEmpty()) {
+                return List.of();
+            }
+            return values.stream()
+                    .map(v -> StringUtils.replace(StringUtils.trimToNull(v), "\0", " "))
+                    .filter(v -> v != null)
+                    .toList();
+        } catch (Exception x) {
+            // Ignored.
+            return List.of();
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -39,6 +39,7 @@ public class MetaData {
     private String albumName;
     private String albumSortName;
     private String genre;
+    private List<String> genres = Collections.emptyList();
     private Integer year;
     private Integer bpm;
     private Integer bitRate;
@@ -127,6 +128,14 @@ public class MetaData {
 
     public void setGenre(String genre) {
         this.genre = genre;
+    }
+
+    public List<String> getGenres() {
+        return genres;
+    }
+
+    public void setGenres(List<String> genres) {
+        this.genres = genres != null ? genres : Collections.emptyList();
     }
 
     public Integer getYear() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
@@ -163,7 +163,7 @@ public abstract class MetaDataParser {
      * Sometimes the genre is returned as "(17)" or "(17)Rock", instead of "Rock".  This method
      * maps the genre ID to the corresponding text.
      */
-    String mapGenre(String genre) {
+    public static String mapGenre(String genre) {
         if (genre == null) {
             return null;
         }

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-genres.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-genres.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-genres" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="genres" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="genres" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -11,4 +11,5 @@
     <include file="add-artist-sort-name.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-bpm.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-replaygain.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-genres.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
@@ -1,0 +1,71 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.airsonic.player.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test of {@link Genres#split(String, String)} — the shared splitter used by both the
+ * media_file.genres packing path and the Child.genres[] response wiring.
+ */
+public class GenresTest {
+
+    @Test
+    public void testSplitMultiValueWithSemicolon() {
+        assertEquals(List.of("Rock", "Metal"), Genres.split("Rock; Metal", ";"));
+    }
+
+    @Test
+    public void testSplitTrimsAndFiltersBlanks() {
+        assertEquals(List.of("Rock", "Metal"), Genres.split("Rock;  ; Metal;", ";"));
+    }
+
+    @Test
+    public void testSplitDeduplicatesPreservingOrder() {
+        assertEquals(List.of("Rock", "Metal"), Genres.split("Rock; Metal; Rock", ";"));
+    }
+
+    @Test
+    public void testSplitSingleValueReturnsSingleton() {
+        assertEquals(List.of("Pop"), Genres.split("Pop", ";"));
+    }
+
+    @Test
+    public void testSplitHonoursMultipleSeparatorChars() {
+        assertEquals(List.of("Rock", "Metal", "Jazz"), Genres.split("Rock; Metal,Jazz", ";,"));
+    }
+
+    @Test
+    public void testSplitNullOrBlankReturnsEmpty() {
+        assertTrue(Genres.split(null, ";").isEmpty());
+        assertTrue(Genres.split("", ";").isEmpty());
+        assertTrue(Genres.split("   ", ";").isEmpty());
+        assertTrue(Genres.split(";;;", ";").isEmpty());
+    }
+
+    @Test
+    public void testJoinThenSplitRoundTrip() {
+        List<String> source = List.of("Rock", "Metal", "Jazz");
+        String packed = String.join(";", source);
+        assertEquals(source, Genres.split(packed, ";"));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -67,6 +67,8 @@ class JaxbContentServiceTest {
     private TranscodingService transcodingService;
     @Mock
     private RatingService ratingService;
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private JaxbContentService service;
@@ -337,6 +339,69 @@ class JaxbContentServiceTest {
             Child child = service.createJaxbChild(player, mediaFile, "user");
 
             assertNull(child.getCoverArt());
+        }
+
+        @Test
+        void createJaxbChild_populatesGenresArrayAndKeepsSingleGenre() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(400);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(400)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getGenre()).thenReturn("Rock; Metal");
+            when(mediaFile.getGenres()).thenReturn("Rock; Metal");
+            when(settingsService.getGenreSeparators()).thenReturn(";");
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertEquals("Rock; Metal", child.getGenre());
+            assertEquals(2, child.getGenres().size());
+            assertEquals("Rock", child.getGenres().get(0).getName());
+            assertEquals("Metal", child.getGenres().get(1).getName());
+            verify(settingsService).getGenreSeparators();
+        }
+
+        @Test
+        void createJaxbChild_id3v1MappedNameMatchesBetweenGenreAndGenresArray() {
+            // packGenres now maps each token through mapGenre, so the canonical column value for
+            // an ID3v1 "(17)" file is "Rock" — the same name that mediaFile.getGenre() already
+            // returns via the existing mapGenre(getFirst(GENRE)) path. Asserting both come out
+            // equal locks in the symmetry the prior asymmetry-bug violated.
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(600);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(600)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getGenre()).thenReturn("Rock");
+            when(mediaFile.getGenres()).thenReturn("Rock");
+            when(settingsService.getGenreSeparators()).thenReturn(";");
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertEquals("Rock", child.getGenre());
+            assertEquals(1, child.getGenres().size());
+            assertEquals("Rock", child.getGenres().get(0).getName());
+            assertEquals(child.getGenre(), child.getGenres().get(0).getName());
+        }
+
+        @Test
+        void createJaxbChild_noGenresWhenAbsent() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(500);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(500)).thenReturn(CoverArt.NULL_ART);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertNull(child.getGenre());
+            assertTrue(child.getGenres().isEmpty());
         }
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -36,9 +36,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,6 +57,8 @@ public class MediaFileServiceTest {
     private MediaFileCache mediaFileCache;
     @Mock
     private MediaFolderService mediaFolderService;
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private MediaFileService mediaFileService;
@@ -70,7 +74,7 @@ public class MediaFileServiceTest {
 
     @BeforeEach
     public void setUp() {
-        when(mockedFolder.getPath()).thenReturn(CLASS_PATH.resolve("MEDIAS"));
+        lenient().when(mockedFolder.getPath()).thenReturn(CLASS_PATH.resolve("MEDIAS"));
     }
 
     @Test
@@ -97,5 +101,22 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    @Test
+    public void packGenresMapsId3v1NumericCodesPerToken() {
+        when(settingsService.getGenreSeparators()).thenReturn(";");
+
+        // A raw ID3v1 numeric-code value: getAll typically returns one entry "(17)" which
+        // mapGenre resolves to "Rock", matching what the single `genre` column already stores.
+        assertEquals("Rock", mediaFileService.packGenres(List.of("(17)")));
+
+        // A packed delimited value with one numeric token mixed in is split first, then each
+        // token mapped individually — never mapGenre-d as a whole packed string.
+        assertEquals("Rock;Pop", mediaFileService.packGenres(List.of("(17); Pop")));
+
+        // Cross-frame multi-value: two frames, one numeric, one text → both mapped, deduped,
+        // joined with the primary separator.
+        assertEquals("Rock;Metal", mediaFileService.packGenres(List.of("(17)", "Metal")));
     }
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.airsonic.player.service.metadata;
 
+import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.id3.ID3v24Frame;
 import org.jaudiotagger.tag.id3.ID3v24Tag;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
@@ -23,11 +24,13 @@ import org.jaudiotagger.tag.id3.valuepair.TextEncoding;
 import org.jaudiotagger.tag.vorbiscomment.VorbisCommentTag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Unit test of the ReplayGain extraction in {@link JaudiotaggerParser}.
+ * Unit test of the ReplayGain and multi-value tag-field extraction in {@link JaudiotaggerParser}.
  */
 public class JaudiotaggerParserTestCase {
 
@@ -62,5 +65,19 @@ public class JaudiotaggerParserTestCase {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
         tag.setField("REPLAYGAIN_TRACK_GAIN", "-7.50 dB");
         assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+
+    @Test
+    public void testGetAllTagFieldsReturnsMultipleGenreValues() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.GENRE, "Rock");
+        tag.addField(FieldKey.GENRE, "Metal");
+        assertEquals(List.of("Rock", "Metal"), JaudiotaggerParser.getAllTagFields(tag, FieldKey.GENRE));
+    }
+
+    @Test
+    public void testGetAllTagFieldsAbsentReturnsEmpty() {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        assertEquals(List.of(), JaudiotaggerParser.getAllTagFields(tag, FieldKey.GENRE));
     }
 }

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -238,6 +238,7 @@
     <xs:complexType name="Child">
         <xs:sequence>
             <xs:element name="replayGain" type="sub:ReplayGain" minOccurs="0"/>  <!-- Added in OpenSubsonic -->
+            <xs:element name="genres" type="sub:ItemGenre" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
         </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="parent" type="xs:string" use="optional"/>
@@ -284,6 +285,10 @@
         <xs:attribute name="albumGain" type="xs:double" use="optional"/>
         <xs:attribute name="trackPeak" type="xs:double" use="optional"/>
         <xs:attribute name="albumPeak" type="xs:double" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="ItemGenre">  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:simpleType name="MediaType">


### PR DESCRIPTION
Adds the OpenSubsonic genres[] array to Child alongside the existing single genre.

Storage: a new packed media_file.genres column (Option C) -- per-track genre is never queried off media_file (the genre count table serves browse-by-genre), so a denormalized column avoids the hot-path fetch cost a collection table would add. One getGenreSeparators() setting governs both packing and splitting.

Extraction reads all GENRE frames (Tag.getAll), splits each by the separators, maps each token through the genre mapping (so genres[] matches the single genre on ID3v1 numeric codes), dedups preserving order, and packs. The single genre attribute (getFirst) and the genre count table are untouched. New ItemGenre XSD complexType + the first repeated element on Child. No MediaFile.VERSION bump.

Follow-up noted: multi-frame secondary genres don't yet reach the count table (browse-by-genre), since it still derives from the single genre column.

fixes #134