### PR TITLE
OpenSubsonic: indexBasedQueue extension (fixes #141)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlayQueueController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicPlayQueueController.java
@@ -103,4 +103,62 @@ public class SubsonicPlayQueueController extends AbstractSubsonicController {
         writeEmptyResponse(request, response);
     }
 
+    @RequestMapping({"/getPlayQueueByIndex", "/getPlayQueueByIndex.view"})
+    public void getPlayQueueByIndex(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        request = wrapRequest(request);
+        String username = securityService.getCurrentUsername(request);
+        Player player = playerService.getPlayer(request, response, username);
+
+        SavedPlayQueue playQueue = playQueueService.loadSavedPlayQueueForRest(username);
+        if (playQueue == null) {
+            writeEmptyResponse(request, response);
+            return;
+        }
+
+        org.subsonic.restapi.PlayQueueByIndex restPlayQueue = new org.subsonic.restapi.PlayQueueByIndex();
+        restPlayQueue.setUsername(playQueue.getUsername());
+        // Prefer the explicitly stored currentIndex (savePlayQueueByIndex path); for queues
+        // saved id-based via the legacy savePlayQueue, fall back to indexOf(currentMediaFile)
+        // — first occurrence, the same imprecision id-based saves inherently have.
+        Integer currentIndex = playQueue.getCurrentIndex();
+        if (currentIndex == null && playQueue.getCurrentMediaFile() != null) {
+            int idx = playQueue.getMediaFiles().indexOf(playQueue.getCurrentMediaFile());
+            currentIndex = idx >= 0 ? idx : null;
+        }
+        restPlayQueue.setCurrentIndex(currentIndex);
+        restPlayQueue.setPosition(playQueue.getPositionMillis());
+        restPlayQueue.setChanged(jaxbWriter.convertDate(playQueue.getChanged()));
+        restPlayQueue.setChangedBy(playQueue.getChangedBy());
+
+        for (MediaFile mediaFile : playQueue.getMediaFiles()) {
+            if (mediaFile != null) {
+                restPlayQueue.getEntry().add(jaxbContentService.createJaxbChild(player, mediaFile, username));
+            }
+        }
+
+        Response res = createResponse();
+        res.setPlayQueueByIndex(restPlayQueue);
+        jaxbWriter.writeResponse(request, response, res);
+    }
+
+    @RequestMapping({"/savePlayQueueByIndex", "/savePlayQueueByIndex.view"})
+    public void savePlayQueueByIndex(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        request = wrapRequest(request);
+        String username = securityService.getCurrentUsername(request);
+        List<Integer> mediaFileIds = Arrays.stream(getIntParameters(request, "id")).boxed().toList();
+        Integer currentIndex = getIntParameter(request, "currentIndex");
+        Long position = getLongParameter(request, "position");
+        String changedBy = getRequiredStringParameter(request, "c");
+
+        boolean indexOutOfRange = currentIndex != null && (currentIndex < 0 || currentIndex >= mediaFileIds.size());
+        if (indexOutOfRange) {
+            error(request, response, SubsonicRESTController.ErrorCode.GENERIC, "currentIndex is out of range");
+            return;
+        }
+
+        playQueueService.savePlayQueueByIndex(username, mediaFileIds, currentIndex, position, changedBy);
+
+        writeEmptyResponse(request, response);
+    }
+
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -64,7 +64,8 @@ public class SubsonicRESTController extends AbstractSubsonicController {
         return List.of(
             buildExtension("formPost", 1),
             buildExtension("transcodeOffset", 1),
-            buildExtension("songLyrics", 1)
+            buildExtension("songLyrics", 1),
+            buildExtension("indexBasedQueue", 1)
         );
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/SavedPlayQueue.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/SavedPlayQueue.java
@@ -53,6 +53,8 @@ public class SavedPlayQueue {
     @OneToOne
     @JoinColumn(name = "current_media_file_id", referencedColumnName = "id")
     private MediaFile currentMediaFile;
+    @Column(name = "current_index")
+    private Integer currentIndex;
     @Column(name = "position_millis")
     private Long positionMillis;
     @Column(name = "changed")
@@ -108,6 +110,14 @@ public class SavedPlayQueue {
 
     public void setCurrentMediaFile(MediaFile currentMediaFile) {
         this.currentMediaFile = currentMediaFile;
+    }
+
+    public Integer getCurrentIndex() {
+        return currentIndex;
+    }
+
+    public void setCurrentIndex(Integer currentIndex) {
+        this.currentIndex = currentIndex;
     }
 
     public Long getPositionMillis() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
@@ -161,6 +161,47 @@ public class PlayQueueService {
         return savedPlayQueue.getId();
     }
 
+    /**
+     * Saves the play queue indexed by position rather than by media file id, so callers can
+     * disambiguate the duplicate-track case the legacy savePlayQueue cannot express.
+     * <p>
+     * The stored {@code current_index} is recomputed against the FILTERED queue: it is the count
+     * of valid (resolvable) media file ids preceding the requested position. The derived
+     * {@code current_media_file_id} is the media file resolved at the requested position, so the
+     * legacy getPlayQueue endpoint continues to return a valid current track. If the entry AT
+     * the requested position itself fails to resolve (unknown id), both {@code current_index}
+     * and {@code current_media_file_id} are stored as null — no valid current track to address.
+     */
+    @Transactional
+    public int savePlayQueueByIndex(String username, List<Integer> mediaFileIds, Integer currentIndex, Long position, String changedBy) {
+        SavedPlayQueue savedPlayQueue = savedPlayQueueRepository.findByUsername(username).orElse(new SavedPlayQueue(username));
+
+        List<MediaFile> mediaFiles = new ArrayList<>();
+        Integer adjustedIndex = null;
+        MediaFile adjustedCurrent = null;
+        for (int i = 0; i < mediaFileIds.size(); i++) {
+            MediaFile mf = mediaFileService.getMediaFile(mediaFileIds.get(i), true);
+            if (mf == null) {
+                continue;
+            }
+            if (currentIndex != null && i == currentIndex) {
+                adjustedIndex = mediaFiles.size();
+                adjustedCurrent = mf;
+            }
+            mediaFiles.add(mf);
+        }
+
+        savedPlayQueue.setMediaFiles(mediaFiles);
+        savedPlayQueue.setCurrentIndex(adjustedIndex);
+        savedPlayQueue.setCurrentMediaFile(adjustedCurrent);
+        savedPlayQueue.setPositionMillis(position);
+        savedPlayQueue.setChanged(Instant.now());
+        savedPlayQueue.setChangedBy(changedBy);
+        savedPlayQueueRepository.save(savedPlayQueue);
+
+        return savedPlayQueue.getId();
+    }
+
     @Transactional
     public void loadSavedPlayQueue(Player player, String sessionId) {
         SavedPlayQueue savedPlayQueue = savedPlayQueueRepository.findByUsername(player.getUsername()).orElse(null);

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-play-queue-current-index.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-play-queue-current-index.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-play-queue-current-index" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="play_queue" columnName="current_index" />
+            </not>
+        </preConditions>
+        <addColumn tableName="play_queue">
+            <column name="current_index" type="int">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -12,4 +12,5 @@
     <include file="add-media-file-bpm.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-replaygain.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-genres.xml" relativeToChangelogFile="true"/>
+    <include file="add-play-queue-current-index.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/api/IndexBasedQueueApiTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/IndexBasedQueueApiTest.java
@@ -1,0 +1,141 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.airsonic.player.api;
+
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.Player;
+import org.airsonic.player.domain.SavedPlayQueue;
+import org.airsonic.player.service.PlayQueueService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.subsonic.restapi.Child;
+
+import jakarta.transaction.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc coverage for the indexBasedQueue extension's read-side fallback contract:
+ * when a queue is saved id-based (current_index NULL on the entity), getPlayQueueByIndex
+ * must derive currentIndex from indexOf(currentMediaFile) — first-occurrence, the same
+ * imprecision id-based saves inherently have. The explicit-currentIndex path is also
+ * exercised here to lock the preference of the stored value.
+ */
+@Transactional
+public class IndexBasedQueueApiTest extends AbstractRESTTest {
+
+    private static final String CLIENT_NAME = "indexBasedQueueApiTest";
+
+    @MockitoBean
+    private PlayQueueService playQueueService;
+
+    @BeforeEach
+    public void setUp() {
+        // The controller maps each MediaFile through jaxbContentService.createJaxbChild for
+        // the response's <entry> elements. The parent test mocks jaxbContentService, so an
+        // unstubbed call returns null and JAXB marshalling of null entries fails. Stub the
+        // 3-arg (Player, MediaFile, String) overload explicitly to disambiguate from the
+        // 4-arg one, and return a minimal valid Child. lenient() because not every test path
+        // necessarily reaches the createJaxbChild call.
+        lenient().when(jaxbContentService.createJaxbChild(any(Player.class), any(MediaFile.class), anyString()))
+            .thenAnswer(inv -> {
+                Child c = new Child();
+                c.setId(String.valueOf(inv.getArgument(1, MediaFile.class).getId()));
+                c.setIsDir(false);
+                c.setTitle("test");
+                return c;
+            });
+    }
+
+    private MediaFile mediaFile(int id) {
+        MediaFile mf = new MediaFile();
+        mf.setId(id);
+        // MediaFile.equals dereferences folder unconditionally; the parent test provides a
+        // non-null testFolder so indexOf-walking does not NPE.
+        mf.setFolder(testFolder);
+        mf.setPath("track-" + id + ".mp3");
+        return mf;
+    }
+
+    private static SavedPlayQueue savedQueue(List<MediaFile> files, MediaFile current, Integer currentIndex) {
+        SavedPlayQueue q = new SavedPlayQueue();
+        q.setUsername(AIRSONIC_USER);
+        q.setMediaFiles(new ArrayList<>(files));
+        q.setCurrentMediaFile(current);
+        q.setCurrentIndex(currentIndex);
+        q.setPositionMillis(5000L);
+        q.setChanged(Instant.parse("2026-05-01T12:00:00Z"));
+        q.setChangedBy("legacy-client");
+        return q;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getPlayQueueByIndex", "/rest/getPlayQueueByIndex.view"})
+    void getPlayQueueByIndex_fallsBackToIndexOfWhenCurrentIndexIsNull(String endpoint) throws Exception {
+        // Queue saved via the LEGACY savePlayQueue path: current_index is null, but
+        // currentMediaFile is set. The read must derive currentIndex via indexOf.
+        List<MediaFile> files = List.of(mediaFile(10), mediaFile(11), mediaFile(12), mediaFile(13));
+        SavedPlayQueue q = savedQueue(files, files.get(2), null);
+        when(playQueueService.loadSavedPlayQueueForRest(AIRSONIC_USER)).thenReturn(q);
+
+        mvc.perform(get(endpoint)
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("p", AIRSONIC_PASSWORD)
+                .param("f", EXPECTED_FORMAT))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+            .andExpect(jsonPath("$.subsonic-response.playQueueByIndex.currentIndex").value(2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getPlayQueueByIndex", "/rest/getPlayQueueByIndex.view"})
+    void getPlayQueueByIndex_prefersStoredCurrentIndexOverIndexOf(String endpoint) throws Exception {
+        // Duplicate-track queue [A, B, A, C] saved via savePlayQueueByIndex with
+        // currentIndex=2 (the second A). The stored index MUST be returned even though
+        // indexOf(currentMediaFile) would yield 0 (first occurrence).
+        MediaFile a = mediaFile(100);
+        MediaFile b = mediaFile(200);
+        MediaFile c = mediaFile(300);
+        List<MediaFile> files = List.of(a, b, a, c);
+        SavedPlayQueue q = savedQueue(files, a, 2);
+        when(playQueueService.loadSavedPlayQueueForRest(AIRSONIC_USER)).thenReturn(q);
+
+        mvc.perform(get(endpoint)
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("p", AIRSONIC_PASSWORD)
+                .param("f", EXPECTED_FORMAT))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+            .andExpect(jsonPath("$.subsonic-response.playQueueByIndex.currentIndex").value(2));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/api/OpenSubsonicExtensionsApiTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/OpenSubsonicExtensionsApiTest.java
@@ -53,6 +53,22 @@ public class OpenSubsonicExtensionsApiTest extends AbstractRESTTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"/rest/getOpenSubsonicExtensions", "/rest/getOpenSubsonicExtensions.view"})
+    void getOpenSubsonicExtensions_returnsIndexBasedQueueExtension(String endpoint) throws Exception {
+        mvc.perform(get(endpoint)
+            .param("v", AIRSONIC_API_VERSION)
+            .param("c", CLIENT_NAME)
+            .param("u", AIRSONIC_USER)
+            .param("p", AIRSONIC_PASSWORD)
+            .param("f", EXPECTED_FORMAT)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+            .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[*].name").value(hasItem("indexBasedQueue")))
+            .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[?(@.name=='indexBasedQueue')].versions[0]").value(hasItem(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getOpenSubsonicExtensions", "/rest/getOpenSubsonicExtensions.view"})
     void getOpenSubsonicExtensions_accessibleWithoutAuth(String endpoint) throws Exception {
         mvc.perform(get(endpoint)
             .param("f", EXPECTED_FORMAT)

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlayQueueServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlayQueueServiceTest.java
@@ -52,6 +52,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -247,5 +248,162 @@ public class PlayQueueServiceTest {
 
     // TODO: test methods include broadcastPlayQueue
 
+    @Test
+    public void testSavePlayQueueByIndexWritesIndexAndDerivedCurrentMediaFile() throws Exception {
+        // given a queue of 5 files, save with currentIndex=2 → currentMediaFile = file[2]
+        List<Integer> mediaFileIds = List.of(10, 11, 12, 13, 14);
+        for (Integer id : mediaFileIds) {
+            MediaFile mf = new MediaFile();
+            mf.setId(id);
+            when(mediaFileService.getMediaFile(id, true)).thenReturn(mf);
+        }
+        when(savedPlayQueueRepository.findByUsername("testuser")).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("testuser", mediaFileIds, 2, 5000L, "testclient");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository).save(captor.capture());
+        SavedPlayQueue saved = captor.getValue();
+        assertEquals(Integer.valueOf(2), saved.getCurrentIndex());
+        assertEquals(Integer.valueOf(12), saved.getCurrentMediaFile().getId());
+        assertEquals(5L, (long) saved.getMediaFiles().size());
+        assertEquals(5000L, saved.getPositionMillis());
+        assertEquals("testclient", saved.getChangedBy());
+    }
+
+    @Test
+    public void testSavePlayQueueByIndexDisambiguatesDuplicateTracks() throws Exception {
+        // given the same track at indices 0 and 2 of [A, B, A, C], saving index 0 vs index 2
+        // must round-trip distinctly even though the legacy currentMediaFile FK is identical.
+        List<Integer> mediaFileIds = List.of(100, 200, 100, 300);
+        for (Integer id : List.of(100, 200, 300)) {
+            MediaFile mf = new MediaFile();
+            mf.setId(id);
+            when(mediaFileService.getMediaFile(id, true)).thenReturn(mf);
+        }
+        when(savedPlayQueueRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("u1", mediaFileIds, 0, 0L, "c");
+        playQueueService.savePlayQueueByIndex("u2", mediaFileIds, 2, 0L, "c");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository, times(2)).save(captor.capture());
+        List<SavedPlayQueue> saves = captor.getAllValues();
+        assertEquals(Integer.valueOf(0), saves.get(0).getCurrentIndex());
+        assertEquals(Integer.valueOf(2), saves.get(1).getCurrentIndex());
+        // both resolve to the same media_file_id (100), but currentIndex distinguishes them.
+        assertEquals(Integer.valueOf(100), saves.get(0).getCurrentMediaFile().getId());
+        assertEquals(Integer.valueOf(100), saves.get(1).getCurrentMediaFile().getId());
+    }
+
+    @Test
+    public void testSavePlayQueueByIndexNullIndexLeavesCurrentNull() throws Exception {
+        List<Integer> mediaFileIds = List.of(10, 11);
+        for (Integer id : mediaFileIds) {
+            MediaFile mf = new MediaFile();
+            mf.setId(id);
+            when(mediaFileService.getMediaFile(id, true)).thenReturn(mf);
+        }
+        when(savedPlayQueueRepository.findByUsername("u")).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("u", mediaFileIds, null, 0L, "c");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository).save(captor.capture());
+        SavedPlayQueue saved = captor.getValue();
+        assertNull(saved.getCurrentIndex());
+        assertNull(saved.getCurrentMediaFile());
+    }
+
+    @Test
+    public void testSavePlayQueueByIndexAdjustsIndexWhenInvalidIdPrecedesCurrent() throws Exception {
+        // given [10, 99, 11, 12, 13] where 99 is unknown and currentIndex=3 (file 12)
+        // → filtered queue is [10, 11, 12, 13]; adjusted currentIndex must be 2 (file 12's
+        // position in the filtered list).
+        List<Integer> mediaFileIds = List.of(10, 99, 11, 12, 13);
+        for (Integer id : List.of(10, 11, 12, 13)) {
+            MediaFile mf = new MediaFile();
+            mf.setId(id);
+            when(mediaFileService.getMediaFile(id, true)).thenReturn(mf);
+        }
+        when(mediaFileService.getMediaFile(99, true)).thenReturn(null);
+        when(savedPlayQueueRepository.findByUsername("u")).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("u", mediaFileIds, 3, 0L, "c");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository).save(captor.capture());
+        SavedPlayQueue saved = captor.getValue();
+        assertEquals(4, saved.getMediaFiles().size());
+        assertEquals(Integer.valueOf(2), saved.getCurrentIndex());
+        assertEquals(Integer.valueOf(12), saved.getCurrentMediaFile().getId());
+    }
+
+    @Test
+    public void testSavePlayQueueByIndexNullsCurrentWhenCurrentEntryIsInvalid() throws Exception {
+        // given [10, 99, 11] where 99 is unknown and currentIndex=1 (points at the invalid entry)
+        // → both currentIndex and currentMediaFile must be null (no valid current to address).
+        List<Integer> mediaFileIds = List.of(10, 99, 11);
+        for (Integer id : List.of(10, 11)) {
+            MediaFile mf = new MediaFile();
+            mf.setId(id);
+            when(mediaFileService.getMediaFile(id, true)).thenReturn(mf);
+        }
+        when(mediaFileService.getMediaFile(99, true)).thenReturn(null);
+        when(savedPlayQueueRepository.findByUsername("u")).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("u", mediaFileIds, 1, 0L, "c");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository).save(captor.capture());
+        SavedPlayQueue saved = captor.getValue();
+        assertEquals(2, saved.getMediaFiles().size());
+        assertNull(saved.getCurrentIndex());
+        assertNull(saved.getCurrentMediaFile());
+    }
+
+    @Test
+    public void testSavePlayQueueByIndexEmptyQueueWithNullIndex() throws Exception {
+        when(savedPlayQueueRepository.findByUsername("u")).thenReturn(Optional.empty());
+        doAnswer(invocation -> {
+            SavedPlayQueue saved = invocation.getArgument(0, SavedPlayQueue.class);
+            saved.setId(1);
+            return saved;
+        }).when(savedPlayQueueRepository).save(any());
+
+        playQueueService.savePlayQueueByIndex("u", List.of(), null, 0L, "c");
+
+        ArgumentCaptor<SavedPlayQueue> captor = ArgumentCaptor.forClass(SavedPlayQueue.class);
+        verify(savedPlayQueueRepository).save(captor.capture());
+        SavedPlayQueue saved = captor.getValue();
+        assertEquals(0, saved.getMediaFiles().size());
+        assertNull(saved.getCurrentIndex());
+        assertNull(saved.getCurrentMediaFile());
+    }
 
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -32,3 +32,4 @@
 * #179 OpenSubsonic: populate userRating/averageRating on artist responses built from a MediaFile (JaxbContentService.createJaxbArtist)
 * #143 OpenSubsonic: Child.replayGain (trackGain/albumGain/trackPeak/albumPeak) from track ReplayGain tags
 * #134 OpenSubsonic: Child.genres[] populated from all GENRE tag values, split by the GenreSeparators setting (single `genre` and genre browsing unchanged)
+* #141 OpenSubsonic: `indexBasedQueue` extension v1 — new `getPlayQueueByIndex` / `savePlayQueueByIndex` endpoints addressing the current track in the saved play queue by its queue index instead of by media file id, disambiguating the case where the same track appears multiple times. The existing `getPlayQueue` / `savePlayQueue` are unchanged. Adds a `current_index` column on `play_queue`.

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -46,6 +46,8 @@
             <xs:element name="internetRadioStations" type="sub:InternetRadioStations" minOccurs="1" maxOccurs="1"/>
             <xs:element name="bookmarks" type="sub:Bookmarks" minOccurs="1" maxOccurs="1"/>
             <xs:element name="playQueue" type="sub:PlayQueue" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="playQueueByIndex" type="sub:PlayQueueByIndex" minOccurs="1" maxOccurs="1"/>  <!-- Added in OpenSubsonic -->
+
             <xs:element name="shares" type="sub:Shares" minOccurs="1" maxOccurs="1"/>
             <xs:element name="starred" type="sub:Starred" minOccurs="1" maxOccurs="1"/>
             <xs:element name="starred2" type="sub:Starred2" minOccurs="1" maxOccurs="1"/>
@@ -550,6 +552,17 @@
         <xs:attribute name="username" type="xs:string" use="required"/>
         <xs:attribute name="changed" type="xs:dateTime" use="required"/>
         <xs:attribute name="changedBy" type="xs:string" use="required"/> <!-- Name of client app -->
+    </xs:complexType>
+
+    <xs:complexType name="PlayQueueByIndex">  <!-- Added in OpenSubsonic: indexBasedQueue extension -->
+        <xs:sequence>
+            <xs:element name="entry" type="sub:Child" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="currentIndex" type="xs:int" use="optional"/> <!-- Index of currently playing track in the queue -->
+        <xs:attribute name="position" type="xs:long" use="optional"/>    <!-- Position in milliseconds of currently playing track -->
+        <xs:attribute name="username" type="xs:string" use="required"/>
+        <xs:attribute name="changed" type="xs:dateTime" use="required"/>
+        <xs:attribute name="changedBy" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="Shares">


### PR DESCRIPTION
Adds the OpenSubsonic indexBasedQueue extension: getPlayQueueByIndex and savePlayQueueByIndex.

The standard play-queue endpoints mark the current track by id, which is ambiguous when a track appears in the queue more than once. The index-based variants mark it by queue position instead.

Storage (Option A): a new nullable play_queue.current_index column. savePlayQueueByIndex writes the index and derives current_media_file_id from the indexed track, so legacy getPlayQueue still returns a valid current track on byIndex-saved queues. getPlayQueueByIndex prefers the stored index and falls back to the first occurrence of the current track for queues saved id-based; the index is adjusted to the stored queue when unknown ids are dropped. The legacy getPlayQueue/savePlayQueue paths are byte-unchanged.

New PlayQueueByIndex XSD type (PlayQueue plus a currentIndex attribute). Registered as indexBasedQueue version 1 in the OpenSubsonic extensions list. No MediaFile.VERSION bump.

Follow-up noted separately: play_queue_file has no explicit @OrderColumn (order relies on auto-increment id).

fixes #141