### PR TITLE
OpenSubsonic: AlbumID3 isCompilation + original/release dates (#142 batch A)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
@@ -68,6 +68,15 @@ public class Album {
     @Column(name = "year", nullable = true)
     private Integer year;
 
+    @Column(name = "release_date", nullable = true)
+    private String releaseDate;
+
+    @Column(name = "original_release_date", nullable = true)
+    private String originalReleaseDate;
+
+    @Column(name = "is_compilation", nullable = true)
+    private Boolean compilation;
+
     @Column(name = "genre", nullable = true)
     private String genre;
 
@@ -204,6 +213,30 @@ public class Album {
 
     public void setYear(Integer year) {
         this.year = year;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(String releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public String getOriginalReleaseDate() {
+        return originalReleaseDate;
+    }
+
+    public void setOriginalReleaseDate(String originalReleaseDate) {
+        this.originalReleaseDate = originalReleaseDate;
+    }
+
+    public Boolean getCompilation() {
+        return compilation;
+    }
+
+    public void setCompilation(Boolean compilation) {
+        this.compilation = compilation;
     }
 
     public String getGenre() {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -94,6 +94,15 @@ public class MediaFile {
     @Column(name = "year", nullable = true)
     private Integer year;
 
+    @Column(name = "release_date", nullable = true)
+    private String releaseDate;
+
+    @Column(name = "original_release_date", nullable = true)
+    private String originalReleaseDate;
+
+    @Column(name = "is_compilation", nullable = true)
+    private Boolean compilation;
+
     @Column(name = "bpm", nullable = true)
     private Integer bpm;
 
@@ -380,6 +389,30 @@ public class MediaFile {
 
     public void setYear(Integer year) {
         this.year = year;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(String releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public String getOriginalReleaseDate() {
+        return originalReleaseDate;
+    }
+
+    public void setOriginalReleaseDate(String originalReleaseDate) {
+        this.originalReleaseDate = originalReleaseDate;
+    }
+
+    public Boolean getCompilation() {
+        return compilation;
+    }
+
+    public void setCompilation(Boolean compilation) {
+        this.compilation = compilation;
     }
 
     public Integer getBpm() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.ItemDate;
 import org.subsonic.restapi.ItemGenre;
 import org.subsonic.restapi.ReplayGain;
 
@@ -120,7 +121,53 @@ public class JaxbContentService {
         jaxbAlbum.setMusicBrainzId(album.getMusicBrainzReleaseId());
         jaxbAlbum.setDisplayArtist(album.getArtist());
         jaxbAlbum.setSortName(album.getSortName());
+        jaxbAlbum.setIsCompilation(album.getCompilation());
+        jaxbAlbum.setOriginalReleaseDate(parseItemDate(album.getOriginalReleaseDate()));
+        jaxbAlbum.setReleaseDate(parseItemDate(album.getReleaseDate()));
         return jaxbAlbum;
+    }
+
+    private static final java.util.regex.Pattern ITEM_DATE_PATTERN =
+            java.util.regex.Pattern.compile("^(\\d{4})(?:-(\\d{1,2})(?:-(\\d{1,2}))?)?$");
+
+    /**
+     * Parses a raw tag date string into an {@link ItemDate}. Accepts {@code YYYY},
+     * {@code YYYY-MM}, or {@code YYYY-MM-DD}; tolerates a trailing time component by taking
+     * only the date part before {@code T} or whitespace. Returns {@code null} when the input
+     * is blank or doesn't match the expected shape, so the element is omitted from the
+     * response rather than emitted with an empty/garbage date.
+     */
+    static ItemDate parseItemDate(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String s = raw.trim();
+        if (s.isEmpty()) {
+            return null;
+        }
+        // Strip an optional trailing time component: "2003-10-12T00:00:00" -> "2003-10-12".
+        int splitAt = s.length();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == 'T' || c == ' ') {
+                splitAt = i;
+                break;
+            }
+        }
+        s = s.substring(0, splitAt);
+        java.util.regex.Matcher m = ITEM_DATE_PATTERN.matcher(s);
+        if (!m.matches()) {
+            return null;
+        }
+        ItemDate date = new ItemDate();
+        date.setYear(Integer.valueOf(m.group(1)));
+        if (m.group(2) != null) {
+            date.setMonth(Integer.valueOf(m.group(2)));
+        }
+        if (m.group(3) != null) {
+            date.setDay(Integer.valueOf(m.group(3)));
+        }
+        return date;
     }
 
     public <T extends org.subsonic.restapi.Playlist> T createJaxbPlaylist(T jaxbPlaylist, Playlist playlist) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1021,6 +1021,9 @@ public class MediaFileService {
                 mediaFile.setGenre(metaData.getGenre());
                 mediaFile.setGenres(packGenres(metaData.getGenres()));
                 mediaFile.setYear(metaData.getYear());
+                mediaFile.setReleaseDate(metaData.getReleaseDate());
+                mediaFile.setOriginalReleaseDate(metaData.getOriginalReleaseDate());
+                mediaFile.setCompilation(metaData.getCompilation());
                 mediaFile.setBpm(metaData.getBpm());
                 mediaFile.setDuration(metaData.getDuration());
                 mediaFile.setBitRate(metaData.getBitRate());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -481,6 +481,15 @@ public class MediaScannerService {
         if (file.getAlbumSortName() != null) {
             album.setSortName(file.getAlbumSortName());
         }
+        if (file.getReleaseDate() != null) {
+            album.setReleaseDate(file.getReleaseDate());
+        }
+        if (file.getOriginalReleaseDate() != null) {
+            album.setOriginalReleaseDate(file.getOriginalReleaseDate());
+        }
+        if (file.getCompilation() != null) {
+            album.setCompilation(file.getCompilation());
+        }
 
         if (album.getArt() == null && parent != null) {
             CoverArt art = coverArtService.getMediaFileArt(parent.getId());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -102,6 +102,15 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setTitle(getTagField(tag, FieldKey.TITLE));
                 metaData.setSortName(getTagField(tag, FieldKey.TITLE_SORT));
                 metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
+                // releaseDate keeps the raw YEAR tag value (may be YYYY / YYYY-MM / YYYY-MM-DD)
+                // so the response can surface month/day when the tag carries them; the existing
+                // integer year above is unchanged.
+                metaData.setReleaseDate(getTagField(tag, FieldKey.YEAR));
+                // originalReleaseDate: prefer the full ORIGINALRELEASEDATE tag, fall back to the
+                // year-only ORIGINAL_YEAR. parseItemDate at response time handles either form.
+                String originalRelease = getTagField(tag, FieldKey.ORIGINALRELEASEDATE);
+                metaData.setOriginalReleaseDate(originalRelease != null ? originalRelease : getTagField(tag, FieldKey.ORIGINAL_YEAR));
+                metaData.setCompilation(parseCompilation(getTagField(tag, FieldKey.IS_COMPILATION)));
                 metaData.setBpm(parseBpm(getTagField(tag, FieldKey.BPM)));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setGenres(getAllTagFields(tag, FieldKey.GENRE));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -41,6 +41,9 @@ public class MetaData {
     private String genre;
     private List<String> genres = Collections.emptyList();
     private Integer year;
+    private Boolean compilation;
+    private String originalReleaseDate;
+    private String releaseDate;
     private Integer bpm;
     private Integer bitRate;
     private boolean variableBitRate;
@@ -144,6 +147,30 @@ public class MetaData {
 
     public void setYear(Integer year) {
         this.year = year;
+    }
+
+    public Boolean getCompilation() {
+        return compilation;
+    }
+
+    public void setCompilation(Boolean compilation) {
+        this.compilation = compilation;
+    }
+
+    public String getOriginalReleaseDate() {
+        return originalReleaseDate;
+    }
+
+    public void setOriginalReleaseDate(String originalReleaseDate) {
+        this.originalReleaseDate = originalReleaseDate;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(String releaseDate) {
+        this.releaseDate = releaseDate;
     }
 
     public Integer getBpm() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
@@ -323,6 +323,25 @@ public abstract class MetaDataParser {
     }
 
     /**
+     * Parses an {@code IS_COMPILATION}-style tag value into a tri-state {@link Boolean}:
+     * {@code "1"}/{@code "true"} → {@code TRUE}, {@code "0"}/{@code "false"} → {@code FALSE},
+     * absent/blank/unparseable → {@code null}. Comparison is case-insensitive after trim.
+     */
+    static Boolean parseCompilation(String str) {
+        str = StringUtils.trimToNull(str);
+        if (str == null) {
+            return null;
+        }
+        if ("1".equals(str) || "true".equalsIgnoreCase(str)) {
+            return Boolean.TRUE;
+        }
+        if ("0".equals(str) || "false".equalsIgnoreCase(str)) {
+            return Boolean.FALSE;
+        }
+        return null;
+    }
+
+    /**
      * Removes any prefixed track number from the given title string.
      *
      * @param title       The title with or without a prefixed track number, e.g., "02 - Back In Black".

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-album-scalars-dates.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-album-scalars-dates.xml
@@ -1,0 +1,41 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-album-scalars-dates" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="is_compilation" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="is_compilation" type="boolean">
+                <constraints nullable="true" />
+            </column>
+            <column name="original_release_date" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+            <column name="release_date" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-album-scalars-dates" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="album" columnName="is_compilation" />
+            </not>
+        </preConditions>
+        <addColumn tableName="album">
+            <column name="is_compilation" type="boolean">
+                <constraints nullable="true" />
+            </column>
+            <column name="original_release_date" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+            <column name="release_date" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -13,4 +13,5 @@
     <include file="add-media-file-replaygain.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-genres.xml" relativeToChangelogFile="true"/>
     <include file="add-play-queue-current-index.xml" relativeToChangelogFile="true"/>
+    <include file="add-album-scalars-dates.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -185,6 +185,57 @@ class JaxbContentServiceTest {
             assertNull(result.getArtistId());
             assertNull(result.getCoverArt());
         }
+
+        @Test
+        void createJaxbAlbum_setsCompilationAndDates() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(20);
+            when(album.getName()).thenReturn("Comp");
+            when(album.getArtist()).thenReturn("Various Artists");
+            when(album.getSongCount()).thenReturn(12);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(20)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(20, "user")).thenReturn(null);
+            when(artistService.getArtist("Various Artists")).thenReturn(null);
+            when(album.getCompilation()).thenReturn(Boolean.TRUE);
+            when(album.getOriginalReleaseDate()).thenReturn("2003-10-12");
+            when(album.getReleaseDate()).thenReturn("2020-05");
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertEquals(Boolean.TRUE, result.isIsCompilation());
+            assertNotNull(result.getOriginalReleaseDate());
+            assertEquals(Integer.valueOf(2003), result.getOriginalReleaseDate().getYear());
+            assertEquals(Integer.valueOf(10), result.getOriginalReleaseDate().getMonth());
+            assertEquals(Integer.valueOf(12), result.getOriginalReleaseDate().getDay());
+            assertNotNull(result.getReleaseDate());
+            assertEquals(Integer.valueOf(2020), result.getReleaseDate().getYear());
+            assertEquals(Integer.valueOf(5), result.getReleaseDate().getMonth());
+            assertNull(result.getReleaseDate().getDay());
+        }
+
+        @Test
+        void createJaxbAlbum_omitsCompilationAndDatesWhenAbsent() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(21);
+            when(album.getName()).thenReturn("Plain");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(21)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(21, "user")).thenReturn(null);
+            // Mockito's default for a Boolean-returning method is Boolean.FALSE, not null,
+            // so the absent case needs an explicit null stub to model "tag missing".
+            when(album.getCompilation()).thenReturn(null);
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertNull(result.isIsCompilation());
+            assertNull(result.getOriginalReleaseDate());
+            assertNull(result.getReleaseDate());
+        }
     }
 
     @Nested
@@ -450,6 +501,64 @@ class JaxbContentServiceTest {
 
             assertEquals(5, result.getUserRating());
             assertEquals(4.2, result.getAverageRating());
+        }
+    }
+
+    @Nested
+    class ParseItemDateTest {
+        @Test
+        void parseItemDate_fullDate() {
+            org.subsonic.restapi.ItemDate d = JaxbContentService.parseItemDate("2003-10-12");
+            assertNotNull(d);
+            assertEquals(Integer.valueOf(2003), d.getYear());
+            assertEquals(Integer.valueOf(10), d.getMonth());
+            assertEquals(Integer.valueOf(12), d.getDay());
+        }
+
+        @Test
+        void parseItemDate_yearAndMonth() {
+            org.subsonic.restapi.ItemDate d = JaxbContentService.parseItemDate("2020-05");
+            assertNotNull(d);
+            assertEquals(Integer.valueOf(2020), d.getYear());
+            assertEquals(Integer.valueOf(5), d.getMonth());
+            assertNull(d.getDay());
+        }
+
+        @Test
+        void parseItemDate_yearOnly() {
+            org.subsonic.restapi.ItemDate d = JaxbContentService.parseItemDate("1999");
+            assertNotNull(d);
+            assertEquals(Integer.valueOf(1999), d.getYear());
+            assertNull(d.getMonth());
+            assertNull(d.getDay());
+        }
+
+        @Test
+        void parseItemDate_tolerateTrailingTime() {
+            org.subsonic.restapi.ItemDate d = JaxbContentService.parseItemDate("2003-10-12T00:00:00");
+            assertNotNull(d);
+            assertEquals(Integer.valueOf(2003), d.getYear());
+            assertEquals(Integer.valueOf(10), d.getMonth());
+            assertEquals(Integer.valueOf(12), d.getDay());
+        }
+
+        @Test
+        void parseItemDate_tolerateTrailingSpaceDelimitedTime() {
+            org.subsonic.restapi.ItemDate d = JaxbContentService.parseItemDate("2003-10-12 12:30");
+            assertNotNull(d);
+            assertEquals(Integer.valueOf(2003), d.getYear());
+            assertEquals(Integer.valueOf(10), d.getMonth());
+            assertEquals(Integer.valueOf(12), d.getDay());
+        }
+
+        @Test
+        void parseItemDate_blankOrNullOrMalformedReturnsNull() {
+            assertNull(JaxbContentService.parseItemDate(null));
+            assertNull(JaxbContentService.parseItemDate(""));
+            assertNull(JaxbContentService.parseItemDate("   "));
+            assertNull(JaxbContentService.parseItemDate("not-a-date"));
+            assertNull(JaxbContentService.parseItemDate("20"));
+            assertNull(JaxbContentService.parseItemDate("99999"));
         }
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -326,6 +326,66 @@ public class MediaScannerServiceTestCase {
         assertEquals("Second Sort", album.getSortName());
     }
 
+    // The isCompilation flag and the two raw-string date carriers
+    // (original_release_date, release_date) follow the same carrier-then-aggregate pattern
+    // as album_sort_name: last-write-wins, null-guarded so a later track with no value does
+    // not clobber a previously-set one.
+
+    private void aggregateScalarsAndDates(Map<String, Album> albums, Boolean compilation,
+                                          String originalReleaseDate, String releaseDate) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.MUSIC);
+        file.setAlbumName("TestAlbum");
+        file.setArtist("TestArtist");
+        file.setAlbumArtist("TestArtist");
+        file.setParentPath("TestAlbum");
+        file.setCompilation(compilation);
+        file.setOriginalReleaseDate(originalReleaseDate);
+        file.setReleaseDate(releaseDate);
+        ReflectionTestUtils.invokeMethod(mediaScannerService, "updateAlbum",
+            null, file, null, ALBUM_SORT_SCAN_TIME,
+            new HashMap<String, AtomicInteger>(), albums, new HashSet<Integer>());
+    }
+
+    @Test
+    public void testAlbumIsCompilationSetAndNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateScalarsAndDates(albums, Boolean.TRUE, null, null);
+        assertEquals(Boolean.TRUE, album.getCompilation());
+
+        aggregateScalarsAndDates(albums, null, null, null);
+        assertEquals(Boolean.TRUE, album.getCompilation());
+    }
+
+    @Test
+    public void testAlbumOriginalReleaseDateSetAndNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateScalarsAndDates(albums, null, "2003-10-12", null);
+        assertEquals("2003-10-12", album.getOriginalReleaseDate());
+
+        aggregateScalarsAndDates(albums, null, null, null);
+        assertEquals("2003-10-12", album.getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testAlbumReleaseDateSetAndNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateScalarsAndDates(albums, null, null, "2020-05");
+        assertEquals("2020-05", album.getReleaseDate());
+
+        aggregateScalarsAndDates(albums, null, null, null);
+        assertEquals("2020-05", album.getReleaseDate());
+    }
+
     // The artist MB id (FieldKey.MUSICBRAINZ_RELEASEARTISTID) and sort name
     // (FieldKey.ALBUM_ARTIST_SORT) are carried on each track's MediaFile and aggregated onto
     // the Artist in the private updateArtist(). These tests drive that aggregation step

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
@@ -191,4 +191,21 @@ public class MetaDataParserTestCase {
         assertNull(parser.parseReplayGain("dB"));
         assertNull(parser.parseReplayGain(" dB "));
     }
+
+    @Test
+    public void testParseCompilation() {
+        assertEquals(Boolean.TRUE, MetaDataParser.parseCompilation("1"));
+        assertEquals(Boolean.TRUE, MetaDataParser.parseCompilation("true"));
+        assertEquals(Boolean.TRUE, MetaDataParser.parseCompilation("TRUE"));
+        assertEquals(Boolean.TRUE, MetaDataParser.parseCompilation(" True "));
+        assertEquals(Boolean.FALSE, MetaDataParser.parseCompilation("0"));
+        assertEquals(Boolean.FALSE, MetaDataParser.parseCompilation("false"));
+        assertEquals(Boolean.FALSE, MetaDataParser.parseCompilation("FALSE"));
+        assertNull(MetaDataParser.parseCompilation(null));
+        assertNull(MetaDataParser.parseCompilation(""));
+        assertNull(MetaDataParser.parseCompilation("   "));
+        assertNull(MetaDataParser.parseCompilation("yes"));
+        assertNull(MetaDataParser.parseCompilation("2"));
+        assertNull(MetaDataParser.parseCompilation("compilation"));
+    }
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -21,6 +21,11 @@
   `GenreSeparators` setting — default `;`) populated from `tag.getAll(FieldKey.GENRE)`. The single
   `genre` column and the genre count table are unchanged. Filled by the same #135 rescan — no
   separate rescan needed.
+* #142 (Batch A) adds `is_compilation` (BOOLEAN), `original_release_date` and `release_date`
+  (VARCHAR) columns on both `media_file` (carriers) and `album` (aggregates). Populated from
+  `FieldKey.IS_COMPILATION`, `FieldKey.ORIGINALRELEASEDATE` (fallback `ORIGINAL_YEAR`), and
+  `FieldKey.YEAR` respectively; aggregated onto Album via null-guarded last-write-wins.
+  Filled by the same #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
@@ -33,3 +38,4 @@
 * #143 OpenSubsonic: Child.replayGain (trackGain/albumGain/trackPeak/albumPeak) from track ReplayGain tags
 * #134 OpenSubsonic: Child.genres[] populated from all GENRE tag values, split by the GenreSeparators setting (single `genre` and genre browsing unchanged)
 * #141 OpenSubsonic: `indexBasedQueue` extension v1 — new `getPlayQueueByIndex` / `savePlayQueueByIndex` endpoints addressing the current track in the saved play queue by its queue index instead of by media file id, disambiguating the case where the same track appears multiple times. The existing `getPlayQueue` / `savePlayQueue` are unchanged. Adds a `current_index` column on `play_queue`.
+* #142 (Batch A) OpenSubsonic: AlbumID3.isCompilation (boolean), AlbumID3.originalReleaseDate and AlbumID3.releaseDate (ItemDate{year,month,day}, parsed from raw tag values). New ItemDate complexType. Other #142 fields (releaseTypes, recordLabels, discTitles) are deferred to follow-up batches.

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -164,6 +164,10 @@
     </xs:complexType>
 
     <xs:complexType name="AlbumID3">
+        <xs:sequence>
+            <xs:element name="originalReleaseDate" type="sub:ItemDate" minOccurs="0"/>  <!-- Added in OpenSubsonic -->
+            <xs:element name="releaseDate" type="sub:ItemDate" minOccurs="0"/>          <!-- Added in OpenSubsonic -->
+        </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="artist" type="xs:string" use="optional"/>
@@ -180,6 +184,13 @@
         <xs:attribute name="musicBrainzId" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="displayArtist" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="isCompilation" type="xs:boolean" use="optional"/>  <!-- Added in OpenSubsonic -->
+    </xs:complexType>
+
+    <xs:complexType name="ItemDate">  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="year" type="xs:int" use="optional"/>
+        <xs:attribute name="month" type="xs:int" use="optional"/>
+        <xs:attribute name="day" type="xs:int" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="AlbumWithSongsID3">


### PR DESCRIPTION
Batch A of the #142 AlbumID3 metadata bundle (of three: A scalars+dates, B releaseTypes+recordLabels, C discTitles). #142 stays open until C.

Adds three album-level AlbumID3 fields, carrier-then-aggregate per the #136 reference (parser fills a media_file carrier, aggregated onto Album, wired onto AlbumID3 via createJaxbAlbum):

- isCompilation: from IS_COMPILATION, tri-state -- true/false, or null when untagged. BOOLEAN column, null-guarded last-write-wins so an untagged track never clobbers a tagged sibling.
- originalReleaseDate / releaseDate: the raw tag string is stored (ORIGINALRELEASEDATE with an ORIGINAL_YEAR fallback for the original; the release-date source for releaseDate) and parsed at response time into the new ItemDate type. parseItemDate handles YYYY / YYYY-MM / YYYY-MM-DD, emitting only the components present.

New ItemDate XSD complexType (year/month/day, all optional), shared by both date fields. Fields omitted from AlbumID3 when absent. No MediaFile.VERSION bump.

Part of #142.