### PR TITLE
OpenSubsonic: AlbumID3 releaseTypes + recordLabels (#142 batch B)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Album.java
@@ -77,6 +77,12 @@ public class Album {
     @Column(name = "is_compilation", nullable = true)
     private Boolean compilation;
 
+    @Column(name = "release_types", nullable = true)
+    private String releaseTypes;
+
+    @Column(name = "record_labels", nullable = true)
+    private String recordLabels;
+
     @Column(name = "genre", nullable = true)
     private String genre;
 
@@ -237,6 +243,22 @@ public class Album {
 
     public void setCompilation(Boolean compilation) {
         this.compilation = compilation;
+    }
+
+    public String getReleaseTypes() {
+        return releaseTypes;
+    }
+
+    public void setReleaseTypes(String releaseTypes) {
+        this.releaseTypes = releaseTypes;
+    }
+
+    public String getRecordLabels() {
+        return recordLabels;
+    }
+
+    public void setRecordLabels(String recordLabels) {
+        this.recordLabels = recordLabels;
     }
 
     public String getGenre() {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -103,6 +103,12 @@ public class MediaFile {
     @Column(name = "is_compilation", nullable = true)
     private Boolean compilation;
 
+    @Column(name = "release_types", nullable = true)
+    private String releaseTypes;
+
+    @Column(name = "record_labels", nullable = true)
+    private String recordLabels;
+
     @Column(name = "bpm", nullable = true)
     private Integer bpm;
 
@@ -413,6 +419,22 @@ public class MediaFile {
 
     public void setCompilation(Boolean compilation) {
         this.compilation = compilation;
+    }
+
+    public String getReleaseTypes() {
+        return releaseTypes;
+    }
+
+    public void setReleaseTypes(String releaseTypes) {
+        this.releaseTypes = releaseTypes;
+    }
+
+    public String getRecordLabels() {
+        return recordLabels;
+    }
+
+    public void setRecordLabels(String recordLabels) {
+        this.recordLabels = recordLabels;
     }
 
     public Integer getBpm() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -33,9 +33,12 @@ import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
 import org.subsonic.restapi.ItemDate;
 import org.subsonic.restapi.ItemGenre;
+import org.subsonic.restapi.RecordLabel;
 import org.subsonic.restapi.ReplayGain;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -124,7 +127,40 @@ public class JaxbContentService {
         jaxbAlbum.setIsCompilation(album.getCompilation());
         jaxbAlbum.setOriginalReleaseDate(parseItemDate(album.getOriginalReleaseDate()));
         jaxbAlbum.setReleaseDate(parseItemDate(album.getReleaseDate()));
+        for (String releaseType : splitMultiValue(album.getReleaseTypes())) {
+            jaxbAlbum.getReleaseTypes().add(releaseType);
+        }
+        for (String labelName : splitMultiValue(album.getRecordLabels())) {
+            RecordLabel label = new RecordLabel();
+            label.setName(labelName);
+            jaxbAlbum.getRecordLabels().add(label);
+        }
         return jaxbAlbum;
+    }
+
+    /**
+     * Internal delimiter for packed multi-value AlbumID3 columns (releaseTypes, recordLabels).
+     * Must match the constant of the same name in {@link MediaFileService}.
+     */
+    static final String MULTI_VALUE_DELIMITER = "\n";
+
+    /**
+     * Splits a packed multi-value column back into a list of trimmed, non-blank values for
+     * response emission. Returns an empty list (not null) so callers can iterate without
+     * null-checking; an empty list naturally omits the repeated element entirely.
+     */
+    static List<String> splitMultiValue(String packed) {
+        if (packed == null || packed.isEmpty()) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (String token : packed.split(MULTI_VALUE_DELIMITER, -1)) {
+            String trimmed = token.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
     }
 
     private static final java.util.regex.Pattern ITEM_DATE_PATTERN =

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1024,6 +1024,8 @@ public class MediaFileService {
                 mediaFile.setReleaseDate(metaData.getReleaseDate());
                 mediaFile.setOriginalReleaseDate(metaData.getOriginalReleaseDate());
                 mediaFile.setCompilation(metaData.getCompilation());
+                mediaFile.setReleaseTypes(packMultiValue(metaData.getReleaseTypes()));
+                mediaFile.setRecordLabels(packMultiValue(metaData.getRecordLabels()));
                 mediaFile.setBpm(metaData.getBpm());
                 mediaFile.setDuration(metaData.getDuration());
                 mediaFile.setBitRate(metaData.getBitRate());
@@ -1765,5 +1767,31 @@ public class MediaFileService {
         }
         String separator = (separators == null || separators.isEmpty()) ? ";" : separators.substring(0, 1);
         return String.join(separator, clean);
+    }
+
+    /**
+     * Internal delimiter for packed multi-value AlbumID3 columns (releaseTypes, recordLabels).
+     * Newline is collision-resistant: release-type controlled vocab and record-label names never
+     * contain it, so a label like {@code "Sony/BMG; Columbia"} round-trips unmangled even though
+     * the genre separator setting may include {@code ';'} or {@code ','}. Must match the constant
+     * by the same name in {@link JaxbContentService}.
+     */
+    static final String MULTI_VALUE_DELIMITER = "\n";
+
+    /**
+     * Packs a multi-value tag list into a single column string for storage. The input is expected
+     * to be already trimmed and blank-filtered by {@link org.airsonic.player.service.metadata.JaudiotaggerParser#getAllTagFields};
+     * this helper de-duplicates preserving order and joins with {@link #MULTI_VALUE_DELIMITER}.
+     * Returns null when the result is empty so the column stays null for tagless tracks.
+     */
+    String packMultiValue(List<String> rawValues) {
+        if (rawValues == null || rawValues.isEmpty()) {
+            return null;
+        }
+        List<String> clean = rawValues.stream().distinct().toList();
+        if (clean.isEmpty()) {
+            return null;
+        }
+        return String.join(MULTI_VALUE_DELIMITER, clean);
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -490,6 +490,12 @@ public class MediaScannerService {
         if (file.getCompilation() != null) {
             album.setCompilation(file.getCompilation());
         }
+        if (file.getReleaseTypes() != null) {
+            album.setReleaseTypes(file.getReleaseTypes());
+        }
+        if (file.getRecordLabels() != null) {
+            album.setRecordLabels(file.getRecordLabels());
+        }
 
         if (album.getArt() == null && parent != null) {
             CoverArt art = coverArtService.getMediaFileArt(parent.getId());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -111,6 +111,8 @@ public class JaudiotaggerParser extends MetaDataParser {
                 String originalRelease = getTagField(tag, FieldKey.ORIGINALRELEASEDATE);
                 metaData.setOriginalReleaseDate(originalRelease != null ? originalRelease : getTagField(tag, FieldKey.ORIGINAL_YEAR));
                 metaData.setCompilation(parseCompilation(getTagField(tag, FieldKey.IS_COMPILATION)));
+                metaData.setReleaseTypes(getAllTagFields(tag, FieldKey.MUSICBRAINZ_RELEASE_TYPE));
+                metaData.setRecordLabels(getAllTagFields(tag, FieldKey.RECORD_LABEL));
                 metaData.setBpm(parseBpm(getTagField(tag, FieldKey.BPM)));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setGenres(getAllTagFields(tag, FieldKey.GENRE));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -44,6 +44,8 @@ public class MetaData {
     private Boolean compilation;
     private String originalReleaseDate;
     private String releaseDate;
+    private List<String> releaseTypes = Collections.emptyList();
+    private List<String> recordLabels = Collections.emptyList();
     private Integer bpm;
     private Integer bitRate;
     private boolean variableBitRate;
@@ -171,6 +173,22 @@ public class MetaData {
 
     public void setReleaseDate(String releaseDate) {
         this.releaseDate = releaseDate;
+    }
+
+    public List<String> getReleaseTypes() {
+        return releaseTypes;
+    }
+
+    public void setReleaseTypes(List<String> releaseTypes) {
+        this.releaseTypes = releaseTypes != null ? releaseTypes : Collections.emptyList();
+    }
+
+    public List<String> getRecordLabels() {
+        return recordLabels;
+    }
+
+    public void setRecordLabels(List<String> recordLabels) {
+        this.recordLabels = recordLabels != null ? recordLabels : Collections.emptyList();
     }
 
     public Integer getBpm() {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-album-multivalue.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-album-multivalue.xml
@@ -1,0 +1,35 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-album-multivalue" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="release_types" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="release_types" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+            <column name="record_labels" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-album-multivalue" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="album" columnName="release_types" />
+            </not>
+        </preConditions>
+        <addColumn tableName="album">
+            <column name="release_types" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+            <column name="record_labels" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -14,4 +14,5 @@
     <include file="add-media-file-genres.xml" relativeToChangelogFile="true"/>
     <include file="add-play-queue-current-index.xml" relativeToChangelogFile="true"/>
     <include file="add-album-scalars-dates.xml" relativeToChangelogFile="true"/>
+    <include file="add-album-multivalue.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -236,6 +236,71 @@ class JaxbContentServiceTest {
             assertNull(result.getOriginalReleaseDate());
             assertNull(result.getReleaseDate());
         }
+
+        @Test
+        void createJaxbAlbum_populatesReleaseTypesAndRecordLabels() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(30);
+            when(album.getName()).thenReturn("Multi");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(30)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(30, "user")).thenReturn(null);
+            when(album.getReleaseTypes()).thenReturn("Album\nCompilation");
+            when(album.getRecordLabels()).thenReturn("Sony Music\nWarner");
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertEquals(java.util.List.of("Album", "Compilation"), result.getReleaseTypes());
+            assertEquals(2, result.getRecordLabels().size());
+            assertEquals("Sony Music", result.getRecordLabels().get(0).getName());
+            assertEquals("Warner", result.getRecordLabels().get(1).getName());
+        }
+
+        @Test
+        void createJaxbAlbum_recordLabelNameWithGenreSeparatorRoundsTripIntact() {
+            // Locks in that the pack delimiter is collision-resistant: a label name containing
+            // ';' and '/' (e.g. the kind of characters the genre-separator setting often
+            // includes) must NOT be split into multiple labels at response time.
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(31);
+            when(album.getName()).thenReturn("Punct");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(31)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(31, "user")).thenReturn(null);
+            when(album.getRecordLabels()).thenReturn("Sony/BMG; Columbia\nWarner");
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertEquals(2, result.getRecordLabels().size());
+            assertEquals("Sony/BMG; Columbia", result.getRecordLabels().get(0).getName());
+            assertEquals("Warner", result.getRecordLabels().get(1).getName());
+        }
+
+        @Test
+        void createJaxbAlbum_omitsMultiValueWhenAbsent() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(32);
+            when(album.getName()).thenReturn("Plain");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(32)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(32, "user")).thenReturn(null);
+            // releaseTypes / recordLabels unstubbed → null on the mock → split yields empty
+            // → no <releaseTypes>/<recordLabels> elements emitted (list stays empty).
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertTrue(result.getReleaseTypes().isEmpty());
+            assertTrue(result.getRecordLabels().isEmpty());
+        }
     }
 
     @Nested

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -101,6 +102,35 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    @Test
+    public void packMultiValueDedupsAndJoinsWithNewline() {
+        // Single value → no trailing delimiter.
+        assertEquals("Album", mediaFileService.packMultiValue(List.of("Album")));
+        // Multiple values → joined by \n in order.
+        assertEquals("Album\nCompilation", mediaFileService.packMultiValue(List.of("Album", "Compilation")));
+        // Duplicates collapse, original order preserved.
+        assertEquals("Album\nCompilation", mediaFileService.packMultiValue(List.of("Album", "Compilation", "Album")));
+    }
+
+    @Test
+    public void packMultiValueReturnsNullForEmptyOrNull() {
+        assertNull(mediaFileService.packMultiValue(null));
+        assertNull(mediaFileService.packMultiValue(List.of()));
+    }
+
+    @Test
+    public void packMultiValuePreservesPunctuationWithinValues() {
+        // A record-label name with ';' and '/' must round-trip intact — proving the genre
+        // separator was NOT reused as the pack delimiter (genre-separator default ';' would
+        // mangle this name into two false labels).
+        String packed = mediaFileService.packMultiValue(List.of("Sony/BMG; Columbia", "Warner"));
+        // Round-trip through the response-side splitter must give back both originals verbatim.
+        java.util.List<String> roundTripped = JaxbContentService.splitMultiValue(packed);
+        assertEquals(2, roundTripped.size());
+        assertEquals("Sony/BMG; Columbia", roundTripped.get(0));
+        assertEquals("Warner", roundTripped.get(1));
     }
 
     @Test

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -386,6 +386,49 @@ public class MediaScannerServiceTestCase {
         assertEquals("2020-05", album.getReleaseDate());
     }
 
+    // The releaseTypes and recordLabels packed carriers follow the same null-guarded
+    // last-write-wins pattern as the Batch A scalars / #136 album_sort_name.
+
+    private void aggregateMultiValue(Map<String, Album> albums, String releaseTypes, String recordLabels) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.MUSIC);
+        file.setAlbumName("TestAlbum");
+        file.setArtist("TestArtist");
+        file.setAlbumArtist("TestArtist");
+        file.setParentPath("TestAlbum");
+        file.setReleaseTypes(releaseTypes);
+        file.setRecordLabels(recordLabels);
+        ReflectionTestUtils.invokeMethod(mediaScannerService, "updateAlbum",
+            null, file, null, ALBUM_SORT_SCAN_TIME,
+            new HashMap<String, AtomicInteger>(), albums, new HashSet<Integer>());
+    }
+
+    @Test
+    public void testAlbumReleaseTypesSetAndNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateMultiValue(albums, "Album\nCompilation", null);
+        assertEquals("Album\nCompilation", album.getReleaseTypes());
+
+        aggregateMultiValue(albums, null, null);
+        assertEquals("Album\nCompilation", album.getReleaseTypes());
+    }
+
+    @Test
+    public void testAlbumRecordLabelsSetAndNullDoesNotClobber() {
+        Album album = newSortNameTestAlbum();
+        Map<String, Album> albums = new HashMap<>();
+        albums.put("TestAlbum|TestArtist", album);
+
+        aggregateMultiValue(albums, null, "Sony/BMG; Columbia\nWarner");
+        assertEquals("Sony/BMG; Columbia\nWarner", album.getRecordLabels());
+
+        aggregateMultiValue(albums, null, null);
+        assertEquals("Sony/BMG; Columbia\nWarner", album.getRecordLabels());
+    }
+
     // The artist MB id (FieldKey.MUSICBRAINZ_RELEASEARTISTID) and sort name
     // (FieldKey.ALBUM_ARTIST_SORT) are carried on each track's MediaFile and aggregated onto
     // the Artist in the private updateArtist(). These tests drive that aggregation step

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -26,6 +26,12 @@
   `FieldKey.IS_COMPILATION`, `FieldKey.ORIGINALRELEASEDATE` (fallback `ORIGINAL_YEAR`), and
   `FieldKey.YEAR` respectively; aggregated onto Album via null-guarded last-write-wins.
   Filled by the same #135 rescan — no separate rescan needed.
+* #142 (Batch B) adds `release_types` and `record_labels` (packed VARCHAR) columns on both
+  `media_file` (carriers) and `album` (aggregates). Populated via `tag.getAll(...)` from
+  `FieldKey.MUSICBRAINZ_RELEASE_TYPE` and `FieldKey.RECORD_LABEL` (multi-frame, no
+  intra-frame splitting). Packed with a collision-resistant newline delimiter so label names
+  containing `;` or `/` round-trip intact. Filled by the same #135 rescan — no separate
+  rescan needed.
 
 ## OpenSubsonic
 
@@ -39,3 +45,4 @@
 * #134 OpenSubsonic: Child.genres[] populated from all GENRE tag values, split by the GenreSeparators setting (single `genre` and genre browsing unchanged)
 * #141 OpenSubsonic: `indexBasedQueue` extension v1 — new `getPlayQueueByIndex` / `savePlayQueueByIndex` endpoints addressing the current track in the saved play queue by its queue index instead of by media file id, disambiguating the case where the same track appears multiple times. The existing `getPlayQueue` / `savePlayQueue` are unchanged. Adds a `current_index` column on `play_queue`.
 * #142 (Batch A) OpenSubsonic: AlbumID3.isCompilation (boolean), AlbumID3.originalReleaseDate and AlbumID3.releaseDate (ItemDate{year,month,day}, parsed from raw tag values). New ItemDate complexType. Other #142 fields (releaseTypes, recordLabels, discTitles) are deferred to follow-up batches.
+* #142 (Batch B) OpenSubsonic: AlbumID3.releaseTypes (repeated string) and AlbumID3.recordLabels (repeated RecordLabel{name}) populated from `tag.getAll(FieldKey.MUSICBRAINZ_RELEASE_TYPE)` and `tag.getAll(FieldKey.RECORD_LABEL)`. New RecordLabel complexType. discTitles is the remaining #142 follow-up batch.

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -167,6 +167,8 @@
         <xs:sequence>
             <xs:element name="originalReleaseDate" type="sub:ItemDate" minOccurs="0"/>  <!-- Added in OpenSubsonic -->
             <xs:element name="releaseDate" type="sub:ItemDate" minOccurs="0"/>          <!-- Added in OpenSubsonic -->
+            <xs:element name="releaseTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
+            <xs:element name="recordLabels" type="sub:RecordLabel" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
         </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
@@ -191,6 +193,10 @@
         <xs:attribute name="year" type="xs:int" use="optional"/>
         <xs:attribute name="month" type="xs:int" use="optional"/>
         <xs:attribute name="day" type="xs:int" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="RecordLabel">  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="AlbumWithSongsID3">


### PR DESCRIPTION
Batch B of the #142 AlbumID3 metadata bundle (of three: A scalars+dates [merged], B releaseTypes+recordLabels, C discTitles). #142 stays open until C.

Adds two album-level multi-valued AlbumID3 fields, carrier-then-aggregate per #136, multi-valued per #134:

- releaseTypes: from MUSICBRAINZ_RELEASE_TYPE (primary + secondary).
- recordLabels: from RECORD_LABEL.

Both extract via getAll (multi-frame) with NO intra-frame splitting, so multi-word/punctuated values (e.g. "Sony/BMG; Columbia") stay intact. Values are deduped (order preserved) and packed into a media_file carrier with a newline delimiter -- collision-resistant and deliberately not the configurable genre separator, which label names can contain. Aggregated last-write-wins null-guarded onto Album; createJaxbAlbum splits the packed columns into repeated releaseTypes (string) / recordLabels (RecordLabel{name}) elements, omitted when absent.

New RecordLabel XSD complexType (name), structurally like #134's ItemGenre. No MediaFile.VERSION bump.

Part of #142.