### PR TITLE
OpenSubsonic: AlbumID3 discTitles (fixes #142)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicID3Controller.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicID3Controller.java
@@ -138,8 +138,12 @@ public class SubsonicID3Controller extends AbstractSubsonicController {
             return;
         }
 
-        AlbumWithSongsID3 result = jaxbContentService.createJaxbAlbum(new AlbumWithSongsID3(), album, username);
-        for (MediaFile mediaFile : mediaFileService.getSongsForAlbum(album.getArtist(), album.getName())) {
+        // Load the album's songs once, reuse them for both discTitles (built inside the 4-arg
+        // createJaxbAlbum overload) and the <song> entries below — single getSongsForAlbum
+        // fetch, no per-album duplicate.
+        List<MediaFile> albumSongs = mediaFileService.getSongsForAlbum(album.getArtist(), album.getName());
+        AlbumWithSongsID3 result = jaxbContentService.createJaxbAlbum(new AlbumWithSongsID3(), album, username, albumSongs);
+        for (MediaFile mediaFile : albumSongs) {
             result.getSong().add(jaxbContentService.createJaxbChild(player, mediaFile, username));
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -88,6 +88,9 @@ public class MediaFile {
     @Column(name = "disc_number", nullable = true)
     private Integer discNumber;
 
+    @Column(name = "disc_subtitle", nullable = true)
+    private String discSubtitle;
+
     @Column(name = "track_number", nullable = true)
     private Integer trackNumber;
 
@@ -379,6 +382,14 @@ public class MediaFile {
 
     public void setDiscNumber(Integer discNumber) {
         this.discNumber = discNumber;
+    }
+
+    public String getDiscSubtitle() {
+        return discSubtitle;
+    }
+
+    public void setDiscSubtitle(String discSubtitle) {
+        this.discSubtitle = discSubtitle;
     }
 
     public Integer getTrackNumber() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.DiscTitle;
 import org.subsonic.restapi.ItemDate;
 import org.subsonic.restapi.ItemGenre;
 import org.subsonic.restapi.RecordLabel;
@@ -39,7 +40,9 @@ import org.subsonic.restapi.ReplayGain;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 @Service
 public class JaxbContentService {
@@ -101,6 +104,13 @@ public class JaxbContentService {
     }
 
     public <T extends AlbumID3> T createJaxbAlbum(T jaxbAlbum, Album album, String username) {
+        // The 3-arg overload is used by list endpoints (getAlbumList2, getStarred2, getArtist,
+        // search). Passing null tracks here keeps those paths free of per-album track fetches —
+        // discTitles only populates when the caller already has the album's songs in hand.
+        return createJaxbAlbum(jaxbAlbum, album, username, null);
+    }
+
+    public <T extends AlbumID3> T createJaxbAlbum(T jaxbAlbum, Album album, String username, List<MediaFile> albumTracks) {
         jaxbAlbum.setId(String.valueOf(album.getId()));
         jaxbAlbum.setName(album.getName());
         if (album.getArtist() != null) {
@@ -135,7 +145,49 @@ public class JaxbContentService {
             label.setName(labelName);
             jaxbAlbum.getRecordLabels().add(label);
         }
+        for (DiscTitle discTitle : buildDiscTitles(albumTracks)) {
+            jaxbAlbum.getDiscTitles().add(discTitle);
+        }
         return jaxbAlbum;
+    }
+
+    /**
+     * Builds the album's disc-title list by grouping its tracks by disc number and taking the
+     * first non-blank {@code disc_subtitle} per disc, sorted by disc ascending. Discs without
+     * any subtitled track are skipped. Returns an empty list when no tracks are provided or
+     * none carry subtitles — callers naturally omit the {@code <discTitles>} elements then.
+     * <p>
+     * Called only by the 4-arg {@code createJaxbAlbum} overload, so list endpoints never pay
+     * for the grouping (they pass {@code null} via the 3-arg overload).
+     */
+    static List<DiscTitle> buildDiscTitles(List<MediaFile> albumTracks) {
+        if (albumTracks == null || albumTracks.isEmpty()) {
+            return List.of();
+        }
+        Map<Integer, String> subtitleByDisc = new TreeMap<>();
+        for (MediaFile track : albumTracks) {
+            Integer disc = track.getDiscNumber();
+            if (disc == null || subtitleByDisc.containsKey(disc)) {
+                continue;
+            }
+            String subtitle = track.getDiscSubtitle();
+            if (subtitle == null) {
+                continue;
+            }
+            String trimmed = subtitle.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            subtitleByDisc.put(disc, trimmed);
+        }
+        List<DiscTitle> result = new ArrayList<>(subtitleByDisc.size());
+        for (Map.Entry<Integer, String> entry : subtitleByDisc.entrySet()) {
+            DiscTitle dt = new DiscTitle();
+            dt.setDisc(entry.getKey());
+            dt.setTitle(entry.getValue());
+            result.add(dt);
+        }
+        return result;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1017,6 +1017,7 @@ public class MediaFileService {
                 mediaFile.setTitle(metaData.getTitle());
                 mediaFile.setSortName(metaData.getSortName());
                 mediaFile.setDiscNumber(metaData.getDiscNumber());
+                mediaFile.setDiscSubtitle(metaData.getDiscSubtitle());
                 mediaFile.setTrackNumber(metaData.getTrackNumber());
                 mediaFile.setGenre(metaData.getGenre());
                 mediaFile.setGenres(packGenres(metaData.getGenres()));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -117,6 +117,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setGenres(getAllTagFields(tag, FieldKey.GENRE));
                 metaData.setDiscNumber(parseIntegerPattern(getTagField(tag, FieldKey.DISC_NO), null));
+                metaData.setDiscSubtitle(getTagField(tag, FieldKey.DISC_SUBTITLE));
                 metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
                 metaData.setMusicBrainzRecordingId(getTagField(tag, FieldKey.MUSICBRAINZ_TRACK_ID));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class MetaData {
 
     private Integer discNumber;
+    private String discSubtitle;
     private Integer trackNumber;
     private String title;
     private String sortName;
@@ -69,6 +70,14 @@ public class MetaData {
 
     public void setDiscNumber(Integer discNumber) {
         this.discNumber = discNumber;
+    }
+
+    public String getDiscSubtitle() {
+        return discSubtitle;
+    }
+
+    public void setDiscSubtitle(String discSubtitle) {
+        this.discSubtitle = discSubtitle;
     }
 
     public Integer getTrackNumber() {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-disc-subtitle.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-disc-subtitle.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-disc-subtitle" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="disc_subtitle" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="disc_subtitle" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -15,4 +15,5 @@
     <include file="add-play-queue-current-index.xml" relativeToChangelogFile="true"/>
     <include file="add-album-scalars-dates.xml" relativeToChangelogFile="true"/>
     <include file="add-album-multivalue.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-disc-subtitle.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/api/AlbumApiTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/AlbumApiTest.java
@@ -148,7 +148,7 @@ public class AlbumApiTest {
             .thenReturn(List.of(testSong));
 
         AlbumWithSongsID3 testAlbumWithSongs = TestApiUtil.createTestAlbumWithSongsID3Full(testAlbumId);
-        when(jaxbContentService.createJaxbAlbum(any(), eq(testAlbum), eq(AIRSONIC_USER)))
+        when(jaxbContentService.createJaxbAlbum(any(), eq(testAlbum), eq(AIRSONIC_USER), any()))
             .thenReturn(testAlbumWithSongs);
         Child testSongChild = TestApiUtil.createTestMusicChild();
         when(jaxbContentService.createJaxbChild(any(), eq(testSong), eq(AIRSONIC_USER)))
@@ -204,7 +204,7 @@ public class AlbumApiTest {
             .thenReturn(List.of()); // No songs for this album
 
         AlbumWithSongsID3 testAlbumWithSongs = TestApiUtil.createTestAlbumWithSongsID3Minimum(testAlbumId);
-        when(jaxbContentService.createJaxbAlbum(any(), eq(testAlbum), eq(AIRSONIC_USER)))
+        when(jaxbContentService.createJaxbAlbum(any(), eq(testAlbum), eq(AIRSONIC_USER), any()))
             .thenReturn(testAlbumWithSongs);
 
         String response = mvc.perform(get(endpoint)

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -301,6 +301,111 @@ class JaxbContentServiceTest {
             assertTrue(result.getReleaseTypes().isEmpty());
             assertTrue(result.getRecordLabels().isEmpty());
         }
+
+        @Test
+        void createJaxbAlbum_threeArgOverloadEmitsNoDiscTitlesAndDoesNotFetchSongs() {
+            // The 3-arg overload is the list-endpoint path. It must NOT trigger a per-album
+            // mediaFileService.getSongsForAlbum call — the firm N+1 constraint — and must
+            // emit no <discTitles> elements (no songs available to build them from).
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(40);
+            when(album.getName()).thenReturn("ListPath");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(40)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(40, "user")).thenReturn(null);
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertTrue(result.getDiscTitles().isEmpty());
+            verify(mediaFileService, never()).getSongsForAlbum(org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        void createJaxbAlbum_fourArgOverloadPopulatesDiscTitlesFromTracks() {
+            // Realistic multi-disc album: disc 1 "Bonus" + disc 2 "Live in Tokyo", multiple
+            // tracks per disc, first non-blank subtitle per disc wins, sorted ascending.
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(41);
+            when(album.getName()).thenReturn("DetailPath");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(41)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(41, "user")).thenReturn(null);
+
+            java.util.List<MediaFile> tracks = new java.util.ArrayList<>();
+            tracks.add(track(1, "Bonus"));
+            tracks.add(track(1, "Bonus"));
+            tracks.add(track(2, "Live in Tokyo"));
+            tracks.add(track(2, "Live in Tokyo"));
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user", tracks);
+
+            assertEquals(2, result.getDiscTitles().size());
+            assertEquals(1, result.getDiscTitles().get(0).getDisc());
+            assertEquals("Bonus", result.getDiscTitles().get(0).getTitle());
+            assertEquals(2, result.getDiscTitles().get(1).getDisc());
+            assertEquals("Live in Tokyo", result.getDiscTitles().get(1).getTitle());
+        }
+
+        @Test
+        void createJaxbAlbum_fourArgOverloadOmitsDiscsWithoutSubtitle() {
+            // Discs 1/2/3 where only disc 2 carries a subtitle → one DiscTitle for disc 2;
+            // discs 1 and 3 are skipped, not emitted with empty titles.
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(42);
+            when(album.getName()).thenReturn("PartialSubtitles");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(42)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(42, "user")).thenReturn(null);
+
+            java.util.List<MediaFile> tracks = new java.util.ArrayList<>();
+            tracks.add(track(1, null));
+            tracks.add(track(2, "Live"));
+            tracks.add(track(3, ""));
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user", tracks);
+
+            assertEquals(1, result.getDiscTitles().size());
+            assertEquals(2, result.getDiscTitles().get(0).getDisc());
+            assertEquals("Live", result.getDiscTitles().get(0).getTitle());
+        }
+
+        @Test
+        void createJaxbAlbum_fourArgOverloadEmitsNothingWhenNoTracksHaveSubtitles() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(43);
+            when(album.getName()).thenReturn("NoSubtitles");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(coverArtService.getAlbumArt(43)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(43, "user")).thenReturn(null);
+
+            java.util.List<MediaFile> tracks = new java.util.ArrayList<>();
+            tracks.add(track(1, null));
+            tracks.add(track(2, null));
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user", tracks);
+
+            assertTrue(result.getDiscTitles().isEmpty());
+        }
+
+        private MediaFile track(int discNumber, String discSubtitle) {
+            MediaFile mf = new MediaFile();
+            mf.setDiscNumber(discNumber);
+            mf.setDiscSubtitle(discSubtitle);
+            return mf;
+        }
     }
 
     @Nested

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -32,6 +32,10 @@
   intra-frame splitting). Packed with a collision-resistant newline delimiter so label names
   containing `;` or `/` round-trip intact. Filled by the same #135 rescan — no separate
   rescan needed.
+* #142 (Batch C) adds a `disc_subtitle` column on `media_file` populated from
+  `FieldKey.DISC_SUBTITLE`. No album-side column — `AlbumID3.discTitles` is built at response
+  time in `getAlbum` by grouping the album's already-loaded tracks. Filled by the same #135
+  rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
@@ -46,3 +50,4 @@
 * #141 OpenSubsonic: `indexBasedQueue` extension v1 — new `getPlayQueueByIndex` / `savePlayQueueByIndex` endpoints addressing the current track in the saved play queue by its queue index instead of by media file id, disambiguating the case where the same track appears multiple times. The existing `getPlayQueue` / `savePlayQueue` are unchanged. Adds a `current_index` column on `play_queue`.
 * #142 (Batch A) OpenSubsonic: AlbumID3.isCompilation (boolean), AlbumID3.originalReleaseDate and AlbumID3.releaseDate (ItemDate{year,month,day}, parsed from raw tag values). New ItemDate complexType. Other #142 fields (releaseTypes, recordLabels, discTitles) are deferred to follow-up batches.
 * #142 (Batch B) OpenSubsonic: AlbumID3.releaseTypes (repeated string) and AlbumID3.recordLabels (repeated RecordLabel{name}) populated from `tag.getAll(FieldKey.MUSICBRAINZ_RELEASE_TYPE)` and `tag.getAll(FieldKey.RECORD_LABEL)`. New RecordLabel complexType. discTitles is the remaining #142 follow-up batch.
+* #142 (Batch C, closes #142) OpenSubsonic: AlbumID3.discTitles (repeated DiscTitle{disc,title}) built at response time on `getAlbum` by grouping the album's tracks by disc number and taking the first non-blank `disc_subtitle` per disc. New DiscTitle complexType. The list endpoints (`getAlbumList2`, `getStarred2`, etc.) emit no discTitles and incur no per-album track fetch.

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -169,6 +169,7 @@
             <xs:element name="releaseDate" type="sub:ItemDate" minOccurs="0"/>          <!-- Added in OpenSubsonic -->
             <xs:element name="releaseTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
             <xs:element name="recordLabels" type="sub:RecordLabel" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
+            <xs:element name="discTitles" type="sub:DiscTitle" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
         </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
@@ -197,6 +198,11 @@
 
     <xs:complexType name="RecordLabel">  <!-- Added in OpenSubsonic -->
         <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="DiscTitle">  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="disc" type="xs:int" use="required"/>
+        <xs:attribute name="title" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="AlbumWithSongsID3">


### PR DESCRIPTION
Final batch (C) of the #142 AlbumID3 metadata bundle, closing it. Batches A (isCompilation + dates) and B (releaseTypes + recordLabels) are merged.

discTitles is the bundle's outlier -- per-disc, built at response time rather than aggregated onto the album:

- A track-level media_file.disc_subtitle carrier (from DISC_SUBTITLE, scalar, no album column).
- createJaxbAlbum groups the album's tracks by disc number, takes the first non-blank subtitle per disc, sorts by disc, and emits a DiscTitle{disc, title} per subtitled disc (omitted entirely when none).

No N+1 on list endpoints: a new 4-arg createJaxbAlbum overload takes the already-loaded tracks, and getAlbum reorders to fetch songs first and reuse that one List for both discTitles and its <song> entries. The five list call sites (getAlbumList2, getStarred2, getArtist albums, search x2) keep the unchanged 3-arg overload, which delegates with null tracks so discTitles is naturally omitted there -- matching the spec's detail-view intent.

New DiscTitle XSD complexType (disc int + title). No MediaFile.VERSION bump.

fixes #142