### PR TITLE
OpenSubsonic: Child.contributors[] clean-FieldKey roles (#144 batch 1)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Contributor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Contributor.java
@@ -1,0 +1,32 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.domain;
+
+/**
+ * A single OpenSubsonic contributor extracted from a track's tags: a {@code role} (e.g.
+ * {@code "composer"}, {@code "lyricist"}, {@code "performer"}), an optional {@code subRole}
+ * (the instrument for performer credits, sourced from TMCL pairs), and the contributor's
+ * {@code name} as it appears in the tag.
+ * <p>
+ * Used as the internal carrier shape between {@code JaudiotaggerParser}, the packed
+ * {@code media_file.contributors} column (see {@link Contributors}), and {@code JaxbContentService}
+ * which builds the JAXB {@code Contributor} response element from this record.
+ */
+public record Contributor(String role, String subRole, String name) {
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Contributors.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Contributors.java
@@ -1,0 +1,104 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.domain;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Packing and splitting for the {@code media_file.contributors} column: a structured multi-value
+ * representation of the per-track OpenSubsonic contributor list. Each contributor is a
+ * (role, optional subRole, name) triple; records are joined by {@link #RECORD_SEPARATOR}
+ * ({@code \n}) and the three fields within a record by {@link #FIELD_SEPARATOR} ({@code U+001F}).
+ * <p>
+ * Both separators are ASCII control characters that should never occur in legitimate tag text,
+ * but {@link #pack} defensively replaces either character with a space inside any field so the
+ * encoding stays self-delimiting even against pathological inputs.
+ */
+public final class Contributors {
+
+    public static final char FIELD_SEPARATOR = '';
+    public static final char RECORD_SEPARATOR = '\n';
+
+    private Contributors() {
+    }
+
+    public static String pack(List<Contributor> contributors) {
+        if (contributors == null || contributors.isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Contributor c : contributors) {
+            if (c == null) {
+                continue;
+            }
+            String role = sanitize(c.role());
+            String name = sanitize(c.name());
+            if (role == null || name == null) {
+                continue;
+            }
+            String subRole = sanitize(c.subRole());
+            if (!first) {
+                sb.append(RECORD_SEPARATOR);
+            }
+            sb.append(role).append(FIELD_SEPARATOR)
+                    .append(subRole == null ? "" : subRole)
+                    .append(FIELD_SEPARATOR)
+                    .append(name);
+            first = false;
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    public static List<Contributor> split(String packed) {
+        if (StringUtils.isBlank(packed)) {
+            return List.of();
+        }
+        String[] records = StringUtils.split(packed, RECORD_SEPARATOR);
+        List<Contributor> result = new ArrayList<>(records.length);
+        for (String record : records) {
+            if (record == null || record.isEmpty()) {
+                continue;
+            }
+            String[] fields = StringUtils.splitPreserveAllTokens(record, FIELD_SEPARATOR);
+            if (fields.length != 3) {
+                continue;
+            }
+            String role = StringUtils.trimToNull(fields[0]);
+            String name = StringUtils.trimToNull(fields[2]);
+            if (role == null || name == null) {
+                continue;
+            }
+            String subRole = StringUtils.trimToNull(fields[1]);
+            result.add(new Contributor(role, subRole, name));
+        }
+        return result;
+    }
+
+    private static String sanitize(String value) {
+        String trimmed = StringUtils.trimToNull(value);
+        if (trimmed == null) {
+            return null;
+        }
+        return trimmed.replace(FIELD_SEPARATOR, ' ').replace(RECORD_SEPARATOR, ' ');
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -121,6 +121,9 @@ public class MediaFile {
     @Column(name = "genres", nullable = true)
     private String genres;
 
+    @Column(name = "contributors", nullable = true)
+    private String contributors;
+
     @Column(name = "bit_rate", nullable = true)
     private Integer bitRate;
 
@@ -470,6 +473,14 @@ public class MediaFile {
 
     public void setGenres(String genres) {
         this.genres = genres;
+    }
+
+    public String getContributors() {
+        return contributors;
+    }
+
+    public void setContributors(String contributors) {
+        this.contributors = contributors;
     }
 
     public Integer getBitRate() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -21,6 +21,7 @@ package org.airsonic.player.service;
 import org.airsonic.player.controller.CoverArtController;
 import org.airsonic.player.controller.JAXBWriter;
 import org.airsonic.player.domain.Album;
+import org.airsonic.player.domain.Contributors;
 import org.airsonic.player.domain.CoverArt;
 import org.airsonic.player.domain.Genres;
 import org.airsonic.player.domain.MediaFile;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.Contributor;
 import org.subsonic.restapi.DiscTitle;
 import org.subsonic.restapi.ItemDate;
 import org.subsonic.restapi.ItemGenre;
@@ -314,6 +316,9 @@ public class JaxbContentService {
         child.setDisplayArtist(mediaFile.getArtist());
         child.setDisplayAlbumArtist(mediaFile.getAlbumArtist());
         child.setReplayGain(buildReplayGain(mediaFile));
+        for (Contributor contributor : buildContributors(mediaFile)) {
+            child.getContributors().add(contributor);
+        }
         if (mediaFile.getMediaType() != null) {
             child.setMediaType(mediaFile.getMediaType().name().toLowerCase());
         }
@@ -359,6 +364,41 @@ public class JaxbContentService {
             }
         }
         return child;
+    }
+
+    List<Contributor> buildContributors(MediaFile mediaFile) {
+        List<org.airsonic.player.domain.Contributor> records = Contributors.split(mediaFile.getContributors());
+        if (records.isEmpty()) {
+            return List.of();
+        }
+        List<Contributor> result = new ArrayList<>(records.size());
+        for (org.airsonic.player.domain.Contributor record : records) {
+            Contributor jaxb = new Contributor();
+            jaxb.setRole(record.role());
+            jaxb.setSubRole(record.subRole());
+            jaxb.setArtist(createJaxbArtistByName(record.name()));
+            result.add(jaxb);
+        }
+        return result;
+    }
+
+    ArtistID3 createJaxbArtistByName(String name) {
+        org.airsonic.player.domain.Artist artist = artistService.getArtist(name);
+        if (artist != null) {
+            ArtistID3 jaxb = new ArtistID3();
+            jaxb.setId(String.valueOf(artist.getId()));
+            jaxb.setName(artist.getName());
+            return jaxb;
+        }
+        // Uncatalogued tag-derived contributor: no Airsonic Artist record matches this name,
+        // so there is no resolvable id under the local XSD's required-id rule. Emit a "" id
+        // sentinel with the raw tag name; a stable synthetic id is a possible future refinement
+        // if clients struggle with the empty value.
+        ArtistID3 jaxb = new ArtistID3();
+        jaxb.setId("");
+        jaxb.setName(name);
+        jaxb.setAlbumCount(0);
+        return jaxb;
     }
 
     private ReplayGain buildReplayGain(MediaFile mediaFile) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1027,6 +1027,7 @@ public class MediaFileService {
                 mediaFile.setCompilation(metaData.getCompilation());
                 mediaFile.setReleaseTypes(packMultiValue(metaData.getReleaseTypes()));
                 mediaFile.setRecordLabels(packMultiValue(metaData.getRecordLabels()));
+                mediaFile.setContributors(Contributors.pack(metaData.getContributors()));
                 mediaFile.setBpm(metaData.getBpm());
                 mediaFile.setDuration(metaData.getDuration());
                 mediaFile.setBitRate(metaData.getBitRate());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -21,6 +21,7 @@
 package org.airsonic.player.service.metadata;
 
 import com.google.common.collect.ImmutableSet;
+import org.airsonic.player.domain.Contributor;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.MediaFolderService;
 import org.apache.commons.io.FilenameUtils;
@@ -44,7 +45,9 @@ import org.springframework.stereotype.Service;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.LogManager;
@@ -65,6 +68,24 @@ public class JaudiotaggerParser extends MetaDataParser {
     static final String RG_ALBUM_GAIN = "REPLAYGAIN_ALBUM_GAIN";
     static final String RG_TRACK_PEAK = "REPLAYGAIN_TRACK_PEAK";
     static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
+
+    // Clean-FieldKey contributor roles — each FieldKey is read via tag.getAll(...) and every
+    // returned value becomes one Contributor with the given role label and no subRole. The
+    // performer-with-instrument credits in TMCL/TIPL frames (which carry the subRole) are not
+    // covered here; that frame-access work is the planned Batch 2 follow-up for #144.
+    private static final List<Map.Entry<FieldKey, String>> CONTRIBUTOR_ROLES = List.of(
+            Map.entry(FieldKey.COMPOSER, "composer"),
+            Map.entry(FieldKey.LYRICIST, "lyricist"),
+            Map.entry(FieldKey.CONDUCTOR, "conductor"),
+            Map.entry(FieldKey.ARRANGER, "arranger"),
+            Map.entry(FieldKey.PRODUCER, "producer"),
+            Map.entry(FieldKey.ENGINEER, "engineer"),
+            Map.entry(FieldKey.MIXER, "mixer"),
+            Map.entry(FieldKey.REMIXER, "remixer"),
+            Map.entry(FieldKey.DJMIXER, "djmixer"),
+            Map.entry(FieldKey.ORCHESTRA, "orchestra"),
+            Map.entry(FieldKey.CHOIR, "choir"),
+            Map.entry(FieldKey.ENSEMBLE, "ensemble"));
 
     @Autowired
     private MediaFolderService mediaFolderService;
@@ -113,6 +134,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setCompilation(parseCompilation(getTagField(tag, FieldKey.IS_COMPILATION)));
                 metaData.setReleaseTypes(getAllTagFields(tag, FieldKey.MUSICBRAINZ_RELEASE_TYPE));
                 metaData.setRecordLabels(getAllTagFields(tag, FieldKey.RECORD_LABEL));
+                metaData.setContributors(getContributors(tag));
                 metaData.setBpm(parseBpm(getTagField(tag, FieldKey.BPM)));
                 metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
                 metaData.setGenres(getAllTagFields(tag, FieldKey.GENRE));
@@ -180,6 +202,24 @@ public class JaudiotaggerParser extends MetaDataParser {
             // Ignored.
             return List.of();
         }
+    }
+
+    /**
+     * Builds the per-track contributor list from clean-FieldKey roles only. Walks
+     * {@link #CONTRIBUTOR_ROLES} in declaration order and turns every non-blank tag value into
+     * a {@link Contributor} with the corresponding lowercase role label and no subRole.
+     * Performer-with-instrument credits (ID3 TMCL / TIPL paired frames, Vorbis
+     * {@code "Name (Instrument)"}) are out of scope here and will be added in a follow-up batch
+     * that mirrors {@link #getReplayGainField}'s frame-access pattern.
+     */
+    static List<Contributor> getContributors(Tag tag) {
+        List<Contributor> result = new ArrayList<>();
+        for (Map.Entry<FieldKey, String> entry : CONTRIBUTOR_ROLES) {
+            for (String name : getAllTagFields(tag, entry.getKey())) {
+                result.add(new Contributor(entry.getValue(), null, name));
+            }
+        }
+        return result;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -20,6 +20,8 @@
  */
 package org.airsonic.player.service.metadata;
 
+import org.airsonic.player.domain.Contributor;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +49,7 @@ public class MetaData {
     private String releaseDate;
     private List<String> releaseTypes = Collections.emptyList();
     private List<String> recordLabels = Collections.emptyList();
+    private List<Contributor> contributors = Collections.emptyList();
     private Integer bpm;
     private Integer bitRate;
     private boolean variableBitRate;
@@ -198,6 +201,14 @@ public class MetaData {
 
     public void setRecordLabels(List<String> recordLabels) {
         this.recordLabels = recordLabels != null ? recordLabels : Collections.emptyList();
+    }
+
+    public List<Contributor> getContributors() {
+        return contributors;
+    }
+
+    public void setContributors(List<Contributor> contributors) {
+        this.contributors = contributors != null ? contributors : Collections.emptyList();
     }
 
     public Integer getBpm() {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-contributors.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-media-file-contributors.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-contributors" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="contributors" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="contributors" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -16,4 +16,5 @@
     <include file="add-album-scalars-dates.xml" relativeToChangelogFile="true"/>
     <include file="add-album-multivalue.xml" relativeToChangelogFile="true"/>
     <include file="add-media-file-disc-subtitle.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-contributors.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/domain/ContributorsTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/domain/ContributorsTest.java
@@ -1,0 +1,161 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for {@link Contributors#pack(List)} and {@link Contributors#split(String)} —
+ * the encoding that backs the {@code media_file.contributors} column. Locks the
+ * collision-safety contract: the field separator ({@code U+001F}) and the record separator
+ * ({@code \n}) must never re-emerge from a packed value even when contributor names or
+ * roles contain those characters themselves.
+ */
+public class ContributorsTest {
+
+    private static final String FS = String.valueOf(Contributors.FIELD_SEPARATOR);
+    private static final String RS = String.valueOf(Contributors.RECORD_SEPARATOR);
+
+    @Test
+    public void testPackNullReturnsNull() {
+        assertNull(Contributors.pack(null));
+    }
+
+    @Test
+    public void testPackEmptyReturnsNull() {
+        assertNull(Contributors.pack(List.of()));
+    }
+
+    @Test
+    public void testSplitNullReturnsEmpty() {
+        assertTrue(Contributors.split(null).isEmpty());
+    }
+
+    @Test
+    public void testSplitBlankReturnsEmpty() {
+        assertTrue(Contributors.split("").isEmpty());
+        assertTrue(Contributors.split("   ").isEmpty());
+    }
+
+    @Test
+    public void testRoundTripSingleContributorWithoutSubRole() {
+        List<Contributor> source = List.of(new Contributor("composer", null, "John Williams"));
+        assertEquals(source, Contributors.split(Contributors.pack(source)));
+    }
+
+    @Test
+    public void testRoundTripMultipleContributors() {
+        List<Contributor> source = List.of(
+                new Contributor("composer", null, "John Williams"),
+                new Contributor("lyricist", null, "Bernie Taupin"),
+                new Contributor("performer", "guitar", "Jimi Hendrix"));
+        assertEquals(source, Contributors.split(Contributors.pack(source)));
+    }
+
+    @Test
+    public void testRoundTripWithSubRoleEmptyStringNormalizesToNull() {
+        // Pack writes empty subRole as empty field; split trims empty → null. The round-trip
+        // therefore canonicalizes "" → null, matching how callers should read subRole.
+        List<Contributor> source = List.of(new Contributor("composer", "", "John Williams"));
+        List<Contributor> expected = List.of(new Contributor("composer", null, "John Williams"));
+        assertEquals(expected, Contributors.split(Contributors.pack(source)));
+    }
+
+    @Test
+    public void testPackSkipsContributorWithNullRole() {
+        List<Contributor> source = List.of(
+                new Contributor(null, null, "John Williams"),
+                new Contributor("lyricist", null, "Bernie Taupin"));
+        assertEquals(List.of(new Contributor("lyricist", null, "Bernie Taupin")),
+                Contributors.split(Contributors.pack(source)));
+    }
+
+    @Test
+    public void testPackSkipsContributorWithNullName() {
+        List<Contributor> source = List.of(
+                new Contributor("composer", null, null),
+                new Contributor("lyricist", null, "Bernie Taupin"));
+        assertEquals(List.of(new Contributor("lyricist", null, "Bernie Taupin")),
+                Contributors.split(Contributors.pack(source)));
+    }
+
+    @Test
+    public void testPackSanitizesNameContainingRecordSeparator() {
+        // Pathological name with embedded newline must not corrupt the encoding.
+        String packed = Contributors.pack(List.of(
+                new Contributor("composer", null, "Foo" + RS + "Bar"),
+                new Contributor("lyricist", null, "Baz")));
+        List<Contributor> roundTripped = Contributors.split(packed);
+        assertEquals(List.of(
+                new Contributor("composer", null, "Foo Bar"),
+                new Contributor("lyricist", null, "Baz")), roundTripped);
+    }
+
+    @Test
+    public void testPackSanitizesNameContainingFieldSeparator() {
+        // Pathological name with embedded unit separator must not corrupt the encoding.
+        String packed = Contributors.pack(List.of(
+                new Contributor("performer", "guitar", "Foo" + FS + "Bar")));
+        List<Contributor> roundTripped = Contributors.split(packed);
+        assertEquals(List.of(new Contributor("performer", "guitar", "Foo Bar")), roundTripped);
+    }
+
+    @Test
+    public void testPackSanitizesRoleAndSubRoleContainingSeparators() {
+        // Roles and subRoles are also sanitized — defending all three field positions
+        // keeps the encoding self-delimiting against any input.
+        String packed = Contributors.pack(List.of(
+                new Contributor("comp" + FS + "oser", "lead" + RS + "guitar", "Hendrix")));
+        List<Contributor> roundTripped = Contributors.split(packed);
+        assertEquals(List.of(new Contributor("comp oser", "lead guitar", "Hendrix")), roundTripped);
+    }
+
+    @Test
+    public void testSplitSkipsMalformedRecordWithWrongFieldCount() {
+        String malformed = "composer" + FS + "John Williams";  // only 2 fields, not 3
+        String wellFormed = "lyricist" + FS + FS + "Bernie Taupin";
+        String packed = malformed + RS + wellFormed;
+        assertEquals(List.of(new Contributor("lyricist", null, "Bernie Taupin")),
+                Contributors.split(packed));
+    }
+
+    @Test
+    public void testSplitTrimsFields() {
+        String packed = "  composer  " + FS + "  " + FS + "  John Williams  ";
+        assertEquals(List.of(new Contributor("composer", null, "John Williams")),
+                Contributors.split(packed));
+    }
+
+    @Test
+    public void testPackPreservesContributorOrder() {
+        // Multiple contributors for the same role keep their declared order — important
+        // when the spec emits them as a list (e.g. two composers credited Foo, Bar).
+        List<Contributor> source = List.of(
+                new Contributor("composer", null, "Foo"),
+                new Contributor("composer", null, "Bar"),
+                new Contributor("lyricist", null, "Baz"));
+        assertEquals(source, Contributors.split(Contributors.pack(source)));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -22,6 +22,7 @@ import org.airsonic.player.controller.CoverArtController;
 import org.airsonic.player.controller.JAXBWriter;
 import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.Artist;
+import org.airsonic.player.domain.Contributors;
 import org.airsonic.player.domain.CoverArt;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.Player;
@@ -36,10 +37,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.subsonic.restapi.AlbumID3;
 import org.subsonic.restapi.ArtistID3;
 import org.subsonic.restapi.Child;
+import org.subsonic.restapi.Contributor;
 import org.subsonic.restapi.MediaType;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -623,6 +626,123 @@ class JaxbContentServiceTest {
 
             assertNull(child.getGenre());
             assertTrue(child.getGenres().isEmpty());
+        }
+    }
+
+    @Nested
+    class JaxbContributorsTest {
+
+        @Test
+        void buildContributors_nullColumnReturnsEmpty() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFile.getContributors()).thenReturn(null);
+            assertTrue(service.buildContributors(mediaFile).isEmpty());
+        }
+
+        @Test
+        void buildContributors_blankColumnReturnsEmpty() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFile.getContributors()).thenReturn("");
+            assertTrue(service.buildContributors(mediaFile).isEmpty());
+        }
+
+        @Test
+        void buildContributors_packedColumnReturnsMatchingJaxbContributors() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            String packed = Contributors.pack(List.of(
+                    new org.airsonic.player.domain.Contributor("composer", null, "John Williams"),
+                    new org.airsonic.player.domain.Contributor("lyricist", null, "Bernie Taupin")));
+            when(mediaFile.getContributors()).thenReturn(packed);
+            // Both contributors uncatalogued — fallback path produces empty-id artists.
+            when(artistService.getArtist("John Williams")).thenReturn(null);
+            when(artistService.getArtist("Bernie Taupin")).thenReturn(null);
+
+            List<Contributor> result = service.buildContributors(mediaFile);
+
+            assertEquals(2, result.size());
+            assertEquals("composer", result.get(0).getRole());
+            assertNull(result.get(0).getSubRole());
+            assertEquals("John Williams", result.get(0).getArtist().getName());
+            assertEquals("lyricist", result.get(1).getRole());
+            assertEquals("Bernie Taupin", result.get(1).getArtist().getName());
+        }
+
+        @Test
+        void createJaxbArtistByName_catalogedArtistEmitsRealId() {
+            Artist catalogued = mock(Artist.class);
+            when(catalogued.getId()).thenReturn(42);
+            when(catalogued.getName()).thenReturn("John Williams");
+            when(artistService.getArtist("John Williams")).thenReturn(catalogued);
+
+            ArtistID3 result = service.createJaxbArtistByName("John Williams");
+
+            assertEquals("42", result.getId());
+            assertEquals("John Williams", result.getName());
+        }
+
+        @Test
+        void createJaxbArtistByName_uncatalogedArtistEmitsEmptyIdSentinel() {
+            // No matching Airsonic Artist for this tag-derived name → empty-string id
+            // sentinel + raw tag name + albumCount=0 (the local XSD requires albumCount).
+            when(artistService.getArtist("Unknown Composer")).thenReturn(null);
+
+            ArtistID3 result = service.createJaxbArtistByName("Unknown Composer");
+
+            assertEquals("", result.getId());
+            assertEquals("Unknown Composer", result.getName());
+            assertEquals(0, result.getAlbumCount());
+        }
+
+        @Test
+        void createJaxbChild_populatesContributorsFromPackedColumn() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(700);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(700)).thenReturn(CoverArt.NULL_ART);
+            String packed = Contributors.pack(List.of(
+                    new org.airsonic.player.domain.Contributor("composer", null, "John Williams"),
+                    new org.airsonic.player.domain.Contributor("lyricist", null, "Bernie Taupin")));
+            when(mediaFile.getContributors()).thenReturn(packed);
+            Artist catalogued = mock(Artist.class);
+            when(catalogued.getId()).thenReturn(42);
+            when(catalogued.getName()).thenReturn("John Williams");
+            when(artistService.getArtist("John Williams")).thenReturn(catalogued);
+            when(artistService.getArtist("Bernie Taupin")).thenReturn(null);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertEquals(2, child.getContributors().size());
+            Contributor composer = child.getContributors().get(0);
+            assertEquals("composer", composer.getRole());
+            assertNull(composer.getSubRole());
+            assertEquals("42", composer.getArtist().getId());
+            assertEquals("John Williams", composer.getArtist().getName());
+            Contributor lyricist = child.getContributors().get(1);
+            assertEquals("lyricist", lyricist.getRole());
+            assertNull(lyricist.getSubRole());
+            assertEquals("", lyricist.getArtist().getId());
+            assertEquals("Bernie Taupin", lyricist.getArtist().getName());
+        }
+
+        @Test
+        void createJaxbChild_omitsContributorsWhenColumnNull() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(800);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(800)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getContributors()).thenReturn(null);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertTrue(child.getContributors().isEmpty());
+            // No DB artist lookup performed when the column is empty.
+            verify(artistService, never()).getArtist(anyString());
         }
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.airsonic.player.service.metadata;
 
+import org.airsonic.player.domain.Contributor;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.id3.ID3v24Frame;
 import org.jaudiotagger.tag.id3.ID3v24Tag;
@@ -79,5 +80,79 @@ public class JaudiotaggerParserTestCase {
     public void testGetAllTagFieldsAbsentReturnsEmpty() {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
         assertEquals(List.of(), JaudiotaggerParser.getAllTagFields(tag, FieldKey.GENRE));
+    }
+
+    @Test
+    public void testGetContributorsExtractsSingleRoleFromVorbis() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.COMPOSER, "John Williams");
+        assertEquals(List.of(new Contributor("composer", null, "John Williams")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsExtractsMultipleRolesFromVorbis() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.COMPOSER, "John Williams");
+        tag.addField(FieldKey.LYRICIST, "Bernie Taupin");
+        tag.addField(FieldKey.CONDUCTOR, "Leonard Bernstein");
+        tag.addField(FieldKey.PRODUCER, "Rick Rubin");
+        tag.addField(FieldKey.MIXER, "Andy Wallace");
+        // Asserts both presence and the table-declaration order: composer, lyricist,
+        // conductor are followed by producer, mixer because that's the order in
+        // JaudiotaggerParser.CONTRIBUTOR_ROLES.
+        assertEquals(List.of(
+                new Contributor("composer", null, "John Williams"),
+                new Contributor("lyricist", null, "Bernie Taupin"),
+                new Contributor("conductor", null, "Leonard Bernstein"),
+                new Contributor("producer", null, "Rick Rubin"),
+                new Contributor("mixer", null, "Andy Wallace")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsMultipleValuesForOneRole() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.COMPOSER, "John Williams");
+        tag.addField(FieldKey.COMPOSER, "Hans Zimmer");
+        assertEquals(List.of(
+                new Contributor("composer", null, "John Williams"),
+                new Contributor("composer", null, "Hans Zimmer")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsLeavesSubRoleNullForCleanFieldKeys() throws Exception {
+        // Batch 1 covers clean FieldKey roles only — no TMCL frame access — so subRole must
+        // be null for every contributor it produces. The TMCL/TIPL extraction that populates
+        // subRole is the planned Batch 2 follow-up.
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.COMPOSER, "John Williams");
+        tag.addField(FieldKey.LYRICIST, "Bernie Taupin");
+        List<Contributor> contributors = JaudiotaggerParser.getContributors(tag);
+        assertEquals(2, contributors.size());
+        assertNull(contributors.get(0).subRole());
+        assertNull(contributors.get(1).subRole());
+    }
+
+    @Test
+    public void testGetContributorsAbsentReturnsEmpty() {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        assertEquals(List.of(), JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsExtractsFromId3v24() {
+        ID3v24Tag tag = new ID3v24Tag();
+        try {
+            tag.setField(FieldKey.COMPOSER, "John Williams");
+            tag.setField(FieldKey.LYRICIST, "Bernie Taupin");
+        } catch (Exception x) {
+            throw new AssertionError(x);
+        }
+        assertEquals(List.of(
+                new Contributor("composer", null, "John Williams"),
+                new Contributor("lyricist", null, "Bernie Taupin")),
+                JaudiotaggerParser.getContributors(tag));
     }
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -36,6 +36,15 @@
   `FieldKey.DISC_SUBTITLE`. No album-side column — `AlbumID3.discTitles` is built at response
   time in `getAlbum` by grouping the album's already-loaded tracks. Filled by the same #135
   rescan — no separate rescan needed.
+* #144 (Batch 1) adds a packed `contributors` column on `media_file` populated from the clean-
+  FieldKey credit roles (`COMPOSER`, `LYRICIST`, `CONDUCTOR`, `ARRANGER`, `PRODUCER`, `ENGINEER`,
+  `MIXER`, `REMIXER`, `DJMIXER`, `ORCHESTRA`, `CHOIR`, `ENSEMBLE`). Each role accepts multiple
+  values via `tag.getAll(...)`. Encoded as records of `role + U+001F + subRole + U+001F + name`
+  joined by `\n`, with control-character occurrences inside any field replaced by a space at
+  pack time so the encoding stays self-delimiting against pathological inputs. `subRole` is
+  always empty in Batch 1; the performer-with-instrument credits from ID3 TMCL / TIPL paired
+  frames and Vorbis `Name (Instrument)` are scope for a planned Batch 2 follow-up on #144.
+  Filled by the same #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
 
@@ -51,3 +60,4 @@
 * #142 (Batch A) OpenSubsonic: AlbumID3.isCompilation (boolean), AlbumID3.originalReleaseDate and AlbumID3.releaseDate (ItemDate{year,month,day}, parsed from raw tag values). New ItemDate complexType. Other #142 fields (releaseTypes, recordLabels, discTitles) are deferred to follow-up batches.
 * #142 (Batch B) OpenSubsonic: AlbumID3.releaseTypes (repeated string) and AlbumID3.recordLabels (repeated RecordLabel{name}) populated from `tag.getAll(FieldKey.MUSICBRAINZ_RELEASE_TYPE)` and `tag.getAll(FieldKey.RECORD_LABEL)`. New RecordLabel complexType. discTitles is the remaining #142 follow-up batch.
 * #142 (Batch C, closes #142) OpenSubsonic: AlbumID3.discTitles (repeated DiscTitle{disc,title}) built at response time on `getAlbum` by grouping the album's tracks by disc number and taking the first non-blank `disc_subtitle` per disc. New DiscTitle complexType. The list endpoints (`getAlbumList2`, `getStarred2`, etc.) emit no discTitles and incur no per-album track fetch.
+* #144 (Batch 1, part of #144) OpenSubsonic: Child.contributors[] (repeated Contributor{role, optional subRole, ArtistID3 artist}) populated from the clean-FieldKey credit roles (composer, lyricist, conductor, arranger, producer, engineer, mixer, remixer, djmixer, orchestra, choir, ensemble). Each contributor's `artist` is resolved by name through `artistService.getArtist(name)` — when a matching Airsonic Artist exists the real id and name are emitted, otherwise an `id=""` sentinel with the raw tag name and `albumCount=0` keeps the response valid against the local XSD's required-id rule. New Contributor complexType. `subRole` is always absent in Batch 1; the performer-with-instrument credits from ID3 TMCL / TIPL frames and Vorbis `Name (Instrument)` strings are the planned Batch 2 follow-up that will close #144.

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -264,6 +264,7 @@
         <xs:sequence>
             <xs:element name="replayGain" type="sub:ReplayGain" minOccurs="0"/>  <!-- Added in OpenSubsonic -->
             <xs:element name="genres" type="sub:ItemGenre" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
+            <xs:element name="contributors" type="sub:Contributor" minOccurs="0" maxOccurs="unbounded"/>  <!-- Added in OpenSubsonic -->
         </xs:sequence>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="parent" type="xs:string" use="optional"/>
@@ -314,6 +315,14 @@
 
     <xs:complexType name="ItemGenre">  <!-- Added in OpenSubsonic -->
         <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="Contributor">  <!-- Added in OpenSubsonic -->
+        <xs:sequence>
+            <xs:element name="artist" type="sub:ArtistID3"/>
+        </xs:sequence>
+        <xs:attribute name="role" type="xs:string" use="required"/>
+        <xs:attribute name="subRole" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="MediaType">


### PR DESCRIPTION
Batch 1 of #144 contributor support (of two; batch 2 closes it). Adds Child.contributors[].

Reads the credit roles with clean jaudiotagger FieldKeys -- composer, lyricist, conductor, arranger, producer, engineer, mixer, remixer, djmixer, orchestra, choir, ensemble -- as one Contributor each (role + name, no subRole).

Storage: a packed media_file.contributors VARCHAR (track-level carrier, no aggregation), encoding role + U+001F + subRole + U+001F + name per record, records joined by newline; both separators are sanitized out of every field so free-text names can't corrupt the encoding. Chosen over a join table because createJaxbChild is a hot path (getStarred2 is effectively unbounded) and a OneToMany would be the first on MediaFile -- consistent with the 13.2.x genres/releaseTypes/recordLabels packed columns.

At response time createJaxbChild splits the column and builds each Contributor's artist via getArtist(name) -- a real ArtistID3 id when the name is a catalogued artist, otherwise a name-only sentinel. New Contributor XSD complexType on Child. No MediaFile.VERSION bump.

Remaining for batch 2 (closes #144): performer-with-instrument credits via TMCL/TIPL frame access and Vorbis "Name (Instrument)" parsing -> subRole. The encoding already carries subRole (empty here), so batch 2 adds no storage/wire change.

Known follow-up (filed separately): the per-contributor getArtist resolution is uncached on the hot path -- bounded by tag content for now, to be cached before batch 2 amplifies it with performers.

Part of #144.