### PR TITLE
OpenSubsonic: performer contributors with subRole (fixes #144)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -32,8 +32,10 @@ import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
 import org.jaudiotagger.tag.TagField;
+import org.jaudiotagger.tag.datatype.Pair;
 import org.jaudiotagger.tag.id3.AbstractID3v2Frame;
 import org.jaudiotagger.tag.id3.AbstractID3v2Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.PictureTypes;
@@ -51,6 +53,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.LogManager;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Parses meta data from audio files using the Jaudiotagger library
@@ -70,9 +74,8 @@ public class JaudiotaggerParser extends MetaDataParser {
     static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
 
     // Clean-FieldKey contributor roles — each FieldKey is read via tag.getAll(...) and every
-    // returned value becomes one Contributor with the given role label and no subRole. The
-    // performer-with-instrument credits in TMCL/TIPL frames (which carry the subRole) are not
-    // covered here; that frame-access work is the planned Batch 2 follow-up for #144.
+    // returned value becomes one Contributor with the given role label and no subRole. Performer
+    // credits with an instrument as subRole are handled separately by addPerformers() below.
     private static final List<Map.Entry<FieldKey, String>> CONTRIBUTOR_ROLES = List.of(
             Map.entry(FieldKey.COMPOSER, "composer"),
             Map.entry(FieldKey.LYRICIST, "lyricist"),
@@ -86,6 +89,10 @@ public class JaudiotaggerParser extends MetaDataParser {
             Map.entry(FieldKey.ORCHESTRA, "orchestra"),
             Map.entry(FieldKey.CHOIR, "choir"),
             Map.entry(FieldKey.ENSEMBLE, "ensemble"));
+
+    // Vorbis PERFORMER convention: "Name (Instrument)" — capture the bare name and a single
+    // trailing parenthetical as instrument. No parens → whole string is the name.
+    private static final Pattern VORBIS_PERFORMER_PATTERN = Pattern.compile("^(.*?)\\s*\\(([^()]+)\\)\\s*$");
 
     @Autowired
     private MediaFolderService mediaFolderService;
@@ -205,12 +212,14 @@ public class JaudiotaggerParser extends MetaDataParser {
     }
 
     /**
-     * Builds the per-track contributor list from clean-FieldKey roles only. Walks
-     * {@link #CONTRIBUTOR_ROLES} in declaration order and turns every non-blank tag value into
-     * a {@link Contributor} with the corresponding lowercase role label and no subRole.
-     * Performer-with-instrument credits (ID3 TMCL / TIPL paired frames, Vorbis
-     * {@code "Name (Instrument)"}) are out of scope here and will be added in a follow-up batch
-     * that mirrors {@link #getReplayGainField}'s frame-access pattern.
+     * Builds the per-track contributor list — clean-FieldKey credits (composer, lyricist, etc.)
+     * plus performer credits that carry an optional instrument as the subRole. Clean roles come
+     * from {@link #CONTRIBUTOR_ROLES} via {@link #getAllTagFields}. Performer extraction is
+     * format-dispatched: ID3v2 reads the dedicated TMCL musician-credits frame (v2.4) for
+     * (instrument, performer) pairs; everything else (Vorbis on FLAC/Ogg/Opus, MP4, etc.) reads
+     * {@code FieldKey.PERFORMER} and parses the common {@code "Name (Instrument)"} convention.
+     * ID3v2.3 IPLS (combined musicians+people in one frame, no spec-mandated key vocabulary)
+     * and MP4 freeform performer atoms are out of scope here.
      */
     static List<Contributor> getContributors(Tag tag) {
         List<Contributor> result = new ArrayList<>();
@@ -219,7 +228,62 @@ public class JaudiotaggerParser extends MetaDataParser {
                 result.add(new Contributor(entry.getValue(), null, name));
             }
         }
+        addPerformers(result, tag);
         return result;
+    }
+
+    /**
+     * Appends performer Contributors with the instrument carried as {@code subRole}. ID3v2.4 keeps
+     * (instrument, performer) pairs in the dedicated TMCL frame; reading them through the
+     * generic {@code FieldKey.PERFORMER} accessor flattens the pairs and loses the instrument,
+     * so frame-level access is required. Non-ID3 formats expose performer values directly under
+     * {@code FieldKey.PERFORMER}, with the {@code "Name (Instrument)"} convention parsed below.
+     * Wraps any jaudiotagger throwable so a malformed frame can't break the scan for one file.
+     */
+    private static void addPerformers(List<Contributor> sink, Tag tag) {
+        try {
+            if (tag instanceof AbstractID3v2Tag id3v2) {
+                List<TagField> frames = id3v2.getFrame("TMCL");
+                if (frames == null) {
+                    return;
+                }
+                for (TagField field : frames) {
+                    if (!(field instanceof AbstractID3v2Frame frame)
+                            || !(frame.getBody() instanceof FrameBodyTMCL tmcl)) {
+                        continue;
+                    }
+                    for (Pair pair : tmcl.getPairing().getMapping()) {
+                        String instrument = StringUtils.trimToNull(pair.getKey());
+                        String rawNames = pair.getValue();
+                        if (rawNames == null) {
+                            continue;
+                        }
+                        // ID3v2.4 spec allows a comma-delimited list of performers per instrument.
+                        for (String name : rawNames.split(",")) {
+                            String cleaned = StringUtils.trimToNull(name);
+                            if (cleaned != null) {
+                                sink.add(new Contributor("performer", instrument, cleaned));
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+            for (String raw : getAllTagFields(tag, FieldKey.PERFORMER)) {
+                Matcher m = VORBIS_PERFORMER_PATTERN.matcher(raw);
+                if (m.matches()) {
+                    String name = StringUtils.trimToNull(m.group(1));
+                    String instrument = StringUtils.trimToNull(m.group(2));
+                    if (name != null) {
+                        sink.add(new Contributor("performer", instrument, name));
+                    }
+                } else {
+                    sink.add(new Contributor("performer", null, raw));
+                }
+            }
+        } catch (Exception x) {
+            // Ignored.
+        }
     }
 
     /**

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -728,6 +728,33 @@ class JaxbContentServiceTest {
         }
 
         @Test
+        void createJaxbChild_emitsPerformerWithSubRole() {
+            // End-to-end: a performer Contributor packed into the media_file.contributors
+            // column round-trips through Contributors.split → buildContributors → JAXB with
+            // the instrument carried as subRole. Locks the Batch 2 promise that subRole
+            // populates on the wire.
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(900);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(900)).thenReturn(CoverArt.NULL_ART);
+            String packed = Contributors.pack(List.of(
+                    new org.airsonic.player.domain.Contributor("performer", "Guitar", "Eric Clapton")));
+            when(mediaFile.getContributors()).thenReturn(packed);
+            when(artistService.getArtist("Eric Clapton")).thenReturn(null);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertEquals(1, child.getContributors().size());
+            Contributor performer = child.getContributors().get(0);
+            assertEquals("performer", performer.getRole());
+            assertEquals("Guitar", performer.getSubRole());
+            assertEquals("Eric Clapton", performer.getArtist().getName());
+        }
+
+        @Test
         void createJaxbChild_omitsContributorsWhenColumnNull() {
             Player player = mock(Player.class);
             MediaFile mediaFile = mock(MediaFile.class);

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -20,6 +20,7 @@ import org.airsonic.player.domain.Contributor;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.id3.ID3v24Frame;
 import org.jaudiotagger.tag.id3.ID3v24Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.id3.valuepair.TextEncoding;
 import org.jaudiotagger.tag.vorbiscomment.VorbisCommentTag;
@@ -123,9 +124,8 @@ public class JaudiotaggerParserTestCase {
 
     @Test
     public void testGetContributorsLeavesSubRoleNullForCleanFieldKeys() throws Exception {
-        // Batch 1 covers clean FieldKey roles only — no TMCL frame access — so subRole must
-        // be null for every contributor it produces. The TMCL/TIPL extraction that populates
-        // subRole is the planned Batch 2 follow-up.
+        // Clean-FieldKey roles (composer, lyricist, conductor, …) never carry an instrument —
+        // subRole is exclusive to performer credits sourced from TMCL / Vorbis PERFORMER.
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
         tag.addField(FieldKey.COMPOSER, "John Williams");
         tag.addField(FieldKey.LYRICIST, "Bernie Taupin");
@@ -153,6 +153,98 @@ public class JaudiotaggerParserTestCase {
         assertEquals(List.of(
                 new Contributor("composer", null, "John Williams"),
                 new Contributor("lyricist", null, "Bernie Taupin")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    private static ID3v24Tag tagWithTmcl(String... pairs) {
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("pairs must be (instrument, name)+");
+        }
+        ID3v24Tag tag = new ID3v24Tag();
+        FrameBodyTMCL body = new FrameBodyTMCL();
+        for (int i = 0; i < pairs.length; i += 2) {
+            body.addPair(pairs[i], pairs[i + 1]);
+        }
+        ID3v24Frame frame = new ID3v24Frame("TMCL");
+        frame.setBody(body);
+        tag.addFrame(frame);
+        return tag;
+    }
+
+    @Test
+    public void testGetContributorsExtractsPerformersFromId3v2Tmcl() {
+        ID3v24Tag tag = tagWithTmcl("Guitar", "Jimi Hendrix", "Bass", "Noel Redding");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("performer", "Bass", "Noel Redding")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsSplitsCommaDelimitedPerformersForOneInstrument() {
+        // ID3v2.4 spec allows the value of a TMCL pair to be a comma-delimited list of
+        // performers all sharing the same instrument.
+        ID3v24Tag tag = tagWithTmcl("Vocals", "John Lennon, Paul McCartney");
+        assertEquals(List.of(
+                new Contributor("performer", "Vocals", "John Lennon"),
+                new Contributor("performer", "Vocals", "Paul McCartney")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsAlongsidePerformersOnId3v24() {
+        // Both clean-FieldKey roles AND TMCL performers populate on the same tag — clean
+        // roles emit first (in CONTRIBUTOR_ROLES order), performers appended after.
+        ID3v24Tag tag = tagWithTmcl("Guitar", "Eric Clapton");
+        try {
+            tag.setField(FieldKey.COMPOSER, "George Harrison");
+        } catch (Exception x) {
+            throw new AssertionError(x);
+        }
+        assertEquals(List.of(
+                new Contributor("composer", null, "George Harrison"),
+                new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsId3v24WithoutTmclEmitsNoPerformers() {
+        ID3v24Tag tag = new ID3v24Tag();
+        try {
+            tag.setField(FieldKey.COMPOSER, "George Harrison");
+        } catch (Exception x) {
+            throw new AssertionError(x);
+        }
+        assertEquals(List.of(new Contributor("composer", null, "George Harrison")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsParsesNameInstrumentFromVorbisPerformer() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.PERFORMER, "Eric Clapton (Guitar)");
+        assertEquals(List.of(new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsBareVorbisPerformerHasNullSubRole() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.PERFORMER, "Eric Clapton");
+        assertEquals(List.of(new Contributor("performer", null, "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsExtractsMultipleVorbisPerformers() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.addField(FieldKey.PERFORMER, "Eric Clapton (Guitar)");
+        tag.addField(FieldKey.PERFORMER, "Jack Bruce (Bass)");
+        tag.addField(FieldKey.PERFORMER, "Ginger Baker (Drums)");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Eric Clapton"),
+                new Contributor("performer", "Bass", "Jack Bruce"),
+                new Contributor("performer", "Drums", "Ginger Baker")),
                 JaudiotaggerParser.getContributors(tag));
     }
 }

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -41,9 +41,15 @@
   `MIXER`, `REMIXER`, `DJMIXER`, `ORCHESTRA`, `CHOIR`, `ENSEMBLE`). Each role accepts multiple
   values via `tag.getAll(...)`. Encoded as records of `role + U+001F + subRole + U+001F + name`
   joined by `\n`, with control-character occurrences inside any field replaced by a space at
-  pack time so the encoding stays self-delimiting against pathological inputs. `subRole` is
-  always empty in Batch 1; the performer-with-instrument credits from ID3 TMCL / TIPL paired
-  frames and Vorbis `Name (Instrument)` are scope for a planned Batch 2 follow-up on #144.
+  pack time so the encoding stays self-delimiting against pathological inputs.
+  Filled by the same #135 rescan — no separate rescan needed.
+* #144 (Batch 2) extends the parser to also emit performer credits with the instrument as
+  `subRole`. ID3v2.4 reads the dedicated TMCL musician-credits frame (instrument → performer,
+  comma-delimited performer lists per instrument split into individual entries); Vorbis on
+  FLAC/Ogg/Opus reads `FieldKey.PERFORMER` and parses the `Name (Instrument)` convention with
+  a single trailing parenthetical as the instrument. The packed `contributors` column from
+  Batch 1 carries `subRole` end-to-end without an encoding change. ID3v2.3 IPLS combined
+  musician+people credits and MP4 freeform performer atoms are not extracted in this batch.
   Filled by the same #135 rescan — no separate rescan needed.
 
 ## OpenSubsonic
@@ -60,7 +66,8 @@
 * #142 (Batch A) OpenSubsonic: AlbumID3.isCompilation (boolean), AlbumID3.originalReleaseDate and AlbumID3.releaseDate (ItemDate{year,month,day}, parsed from raw tag values). New ItemDate complexType. Other #142 fields (releaseTypes, recordLabels, discTitles) are deferred to follow-up batches.
 * #142 (Batch B) OpenSubsonic: AlbumID3.releaseTypes (repeated string) and AlbumID3.recordLabels (repeated RecordLabel{name}) populated from `tag.getAll(FieldKey.MUSICBRAINZ_RELEASE_TYPE)` and `tag.getAll(FieldKey.RECORD_LABEL)`. New RecordLabel complexType. discTitles is the remaining #142 follow-up batch.
 * #142 (Batch C, closes #142) OpenSubsonic: AlbumID3.discTitles (repeated DiscTitle{disc,title}) built at response time on `getAlbum` by grouping the album's tracks by disc number and taking the first non-blank `disc_subtitle` per disc. New DiscTitle complexType. The list endpoints (`getAlbumList2`, `getStarred2`, etc.) emit no discTitles and incur no per-album track fetch.
-* #144 (Batch 1, part of #144) OpenSubsonic: Child.contributors[] (repeated Contributor{role, optional subRole, ArtistID3 artist}) populated from the clean-FieldKey credit roles (composer, lyricist, conductor, arranger, producer, engineer, mixer, remixer, djmixer, orchestra, choir, ensemble). Each contributor's `artist` is resolved by name through `artistService.getArtist(name)` — when a matching Airsonic Artist exists the real id and name are emitted, otherwise an `id=""` sentinel with the raw tag name and `albumCount=0` keeps the response valid against the local XSD's required-id rule. New Contributor complexType. `subRole` is always absent in Batch 1; the performer-with-instrument credits from ID3 TMCL / TIPL frames and Vorbis `Name (Instrument)` strings are the planned Batch 2 follow-up that will close #144.
+* #144 (Batch 1, part of #144) OpenSubsonic: Child.contributors[] (repeated Contributor{role, optional subRole, ArtistID3 artist}) populated from the clean-FieldKey credit roles (composer, lyricist, conductor, arranger, producer, engineer, mixer, remixer, djmixer, orchestra, choir, ensemble). Each contributor's `artist` is resolved by name through `artistService.getArtist(name)` — when a matching Airsonic Artist exists the real id and name are emitted, otherwise an `id=""` sentinel with the raw tag name and `albumCount=0` keeps the response valid against the local XSD's required-id rule. New Contributor complexType. `subRole` is always absent in Batch 1; performer-with-instrument credits arrive in Batch 2.
+* #144 (Batch 2, closes #144) OpenSubsonic: Child.contributors[] now also emits `performer` entries with the instrument carried as `subRole`. ID3v2.4 reads the dedicated TMCL musician-credits frame (`AbstractID3v2Tag.getFrame("TMCL")` → `FrameBodyTMCL.getPairing().getMapping()`); comma-delimited performer lists per instrument are split into individual contributors per the spec. Vorbis (FLAC/Ogg/Opus) reads `FieldKey.PERFORMER` and parses a single trailing parenthetical as the instrument — `"Eric Clapton (Guitar)"` yields `{role: performer, subRole: Guitar, name: "Eric Clapton"}`; bare names without parens yield `subRole: null`. No encoding/XSD/wiring change — Batch 1's packed column and Contributor complexType already carry `subRole`. ID3v2.3 IPLS (combined musicians + people in one frame) and MP4 freeform performer atoms are noted follow-ups, not in this batch.
 
 ## Performance / internal
 


### PR DESCRIPTION
Batch 2 of #144, closing the contributors bundle. Batch 1 (#227) shipped the clean-FieldKey roles; this adds performer-with-instrument credits -- the frame-access piece and the source of subRole.

- ID3v2.4: reads TMCL (musician credits) instrument->performer pairs via FrameBodyTMCL.getPairing(), splitting comma-separated performers sharing one instrument.
- Vorbis/FLAC: parses PERFORMER "Name (Instrument)" -- the trailing parenthetical becomes subRole, the rest the name; a bare name has null subRole.

Each performer becomes a Contributor with role=performer and the instrument as subRole. Parser-only: the media_file.contributors column, the Contributor XSD type (subRole already present), Contributors.pack/split, and createJaxbChild's loop all shipped in batch 1, so subRole flows end-to-end unchanged. The per-contributor artist resolution is cached as of #228, so the added volume doesn't amplify the hot path.

Out of scope, noted as follow-ups: ID3v2.3 IPLS (combines musicians + involved people with no key vocabulary to separate them from batch 1's TIPL-backed roles, so iterating it would duplicate them) and MP4 freeform performer atoms. No MediaFile.VERSION bump.

fixes #144