### PR TITLE
fix: ApiKeyRepositoryTest Postgres portability + logback analyze-only (#145 follow-up)

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/repository/ApiKeyRepositoryTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/repository/ApiKeyRepositoryTest.java
@@ -22,7 +22,6 @@ import org.airsonic.player.config.AirsonicHomeConfig;
 import org.airsonic.player.domain.ApiKey;
 import org.airsonic.player.domain.User;
 import org.airsonic.player.domain.User.Role;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.Path;
@@ -61,9 +59,6 @@ public class ApiKeyRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
-
     @TempDir
     private static Path tempDir;
 
@@ -76,17 +71,14 @@ public class ApiKeyRepositoryTest {
 
     @BeforeEach
     public void setUp() {
-        jdbcTemplate.execute("delete from api_key where username = '" + TEST_USER + "'");
-        userRepository.findById(TEST_USER).ifPresent(u -> userRepository.delete(u));
+        // No manual cleanup — class-level @Transactional rolls back the test transaction at
+        // method end, including the user saved here and any api_key rows inserted by the test.
+        // Postgres would reject a manual cleanup DELETE that runs in a transaction already
+        // aborted by uniqueKeyHashIsEnforced's constraint violation (SQLSTATE 25P02); relying
+        // on framework rollback is portable across HSQLDB/Postgres/MariaDB.
         User user = new User(TEST_USER, "alice@example.com", false, 0L, 0L, 0L,
                 Set.of(Role.STREAM));
         userRepository.saveAndFlush(user);
-    }
-
-    @AfterEach
-    public void clean() {
-        jdbcTemplate.execute("delete from api_key where username = '" + TEST_USER + "'");
-        userRepository.findById(TEST_USER).ifPresent(u -> userRepository.delete(u));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,16 @@
                                 <ignoredUsedUndeclaredDependency>com.sun.mail:jakarta.mail*</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>com.jayway.jsonpath:json-path:</ignoredUsedUndeclaredDependency>
+                                <!--
+                                  Logback ListAppender is used by tests to capture log events
+                                  (e.g. asserting the show-once contract on apiKey raw keys).
+                                  Logback is the project's runtime logger via the transitive
+                                  spring-boot-starter-logging at compile scope, so a direct
+                                  test-scope declaration here would override that and strip
+                                  the JARs from the WAR. Whitelist on both axes instead.
+                                -->
+                                <ignoredUsedUndeclaredDependency>ch.qos.logback:logback-classic</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>ch.qos.logback:logback-core</ignoredUsedUndeclaredDependency>
                             </ignoredUsedUndeclaredDependencies>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>com.google.code.findbugs:jsr305:*</ignoredUnusedDeclaredDependency>
@@ -448,6 +458,11 @@
                                 <ignoredUnusedDeclaredDependency>com.twelvemonkeys.imageio:imageio-webp</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.httpcomponents.client5:httpclient5</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
+                            <ignoredNonTestScopedDependencies>
+                                <!-- See logback comment in ignoredUsedUndeclaredDependencies above. -->
+                                <ignoredNonTestScopedDependency>ch.qos.logback:logback-classic</ignoredNonTestScopedDependency>
+                                <ignoredNonTestScopedDependency>ch.qos.logback:logback-core</ignoredNonTestScopedDependency>
+                            </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
PR-A (#145) passed locally on HSQLDB but failed CI on the Postgres/MariaDB matrix and the dependency:analyze-only gate. Both are CI-only issues in test/build config -- no production-code, schema, or DDL change.

ApiKeyRepositoryTest: uniqueKeyHashIsEnforced inserts a duplicate key_hash, and Postgres aborts the transaction on the unique violation, then rejects the @AfterEach cleanup delete with SQL state 25P02 (HSQLDB tolerates statements after a constraint violation; Postgres does not). Dropped the manual jdbcTemplate cleanup and rely on the class-level @Transactional rollback, which works even on an aborted Postgres transaction -- matching the ArtistRepositoryTest pattern that already passes on the matrix.

logback analyze-only: the show-once logging test uses logback's ListAppender directly, so analyze-only flags logback-classic/core as used-undeclared and non-test-scoped-test-only. Declaring them at test scope clears the warning but strips the logback JARs from the WAR (the direct test-scope declaration demotes the transitive compile scope), breaking runtime logging -- so both artifacts are instead whitelisted on the used-undeclared and non-test-scoped analyze axes in the root pom, leaving the dependency graph and the WAR contents unchanged.

Verified three ways: ApiKeyRepositoryTest 4/4 against postgres:16-alpine, mvnd verify clean with the logback JARs still present in the WAR, and the full HSQLDB suite at 983/0. Test + pom only.