### PR TITLE
Add apiKey filter, provider, and extension advert (#145 PR-B)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -65,7 +65,8 @@ public class SubsonicRESTController extends AbstractSubsonicController {
             buildExtension("formPost", 1),
             buildExtension("transcodeOffset", 1),
             buildExtension("songLyrics", 1),
-            buildExtension("indexBasedQueue", 1)
+            buildExtension("indexBasedQueue", 1),
+            buildExtension("apiKeyAuthentication", 1)
         );
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationProvider.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationProvider.java
@@ -1,0 +1,93 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.service.ApiKeyService;
+import org.airsonic.player.service.SecurityService;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+/**
+ * Resolves an {@link APIKeyAuthenticationToken} against the apiKey storage layer. Returns a
+ * fully-authenticated token carrying the user's principal + authorities, or throws
+ * {@link BadCredentialsException} for any failure (unknown key, disabled key, expired key,
+ * unknown user). All failure paths collapse to the same generic exception — no enumeration
+ * oracle distinguishes "no such key" from "disabled key" from "expired key" from "user gone".
+ * The raw key is never logged or included in exception messages.
+ */
+public class APIKeyAuthenticationProvider implements AuthenticationProvider {
+
+    private final ApiKeyService apiKeyService;
+    private final SecurityService securityService;
+
+    public APIKeyAuthenticationProvider(ApiKeyService apiKeyService, SecurityService securityService) {
+        this.apiKeyService = apiKeyService;
+        this.securityService = securityService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        APIKeyAuthenticationToken token = (APIKeyAuthenticationToken) authentication;
+        Object credentials = token.getCredentials();
+        if (!(credentials instanceof String rawKey) || rawKey.isBlank()) {
+            throw new BadCredentialsException("Invalid API key");
+        }
+
+        Optional<ApiKey> resolved = apiKeyService.resolve(rawKey);
+        if (resolved.isEmpty()) {
+            throw new BadCredentialsException("Invalid API key");
+        }
+        ApiKey apiKey = resolved.get();
+
+        UserDetails user;
+        try {
+            user = securityService.loadUserByUsername(apiKey.getUsername());
+        } catch (UsernameNotFoundException x) {
+            // Key references a user that no longer exists. Collapse to the same generic error so
+            // an attacker cannot distinguish "user gone" from "no such key".
+            throw new BadCredentialsException("Invalid API key");
+        }
+        if (!user.isEnabled() || !user.isAccountNonLocked() || !user.isAccountNonExpired()
+                || !user.isCredentialsNonExpired()) {
+            throw new BadCredentialsException("Invalid API key");
+        }
+
+        // ApiKey goes on the dedicated field rather than credentials/details so it survives
+        // ProviderManager.eraseCredentialsAfterAuthentication (which clears credentials on
+        // success by default). The filter reads it for the throttled last_used update.
+        // Credentials passed as null — the raw key is not needed after authentication and
+        // shouldn't be retained on the authenticated token even briefly.
+        APIKeyAuthenticationToken authenticated =
+                new APIKeyAuthenticationToken(user, null, user.getAuthorities(), apiKey);
+        authenticated.setDetails(token.getDetails());
+        return authenticated;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return APIKeyAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationToken.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationToken.java
@@ -1,0 +1,95 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.domain.ApiKey;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * Authentication token for OpenSubsonic apiKey requests. Extends {@link AbstractAuthenticationToken}
+ * directly (not {@code UsernamePasswordAuthenticationToken}) so the inherited
+ * {@code supports()} of UPAT-matching providers ({@code DaoAuthenticationProvider},
+ * {@code AbstractLdapAuthenticationProvider}, etc.) does not match this token — apiKey requests
+ * route only to {@code APIKeyAuthenticationProvider} and don't incur a stray
+ * {@code loadUserByUsername("")} call on every other UPAT provider in the chain.
+ * <p>
+ * The resolved {@link ApiKey} is carried on a dedicated {@code final apiKey} field so it
+ * survives {@code ProviderManager.eraseCredentialsAfterAuthentication} — the filter needs it
+ * for the throttled {@code last_used} update without re-querying the DB. The raw key is never
+ * logged or echoed.
+ */
+public class APIKeyAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+    private Object credentials;
+    private final ApiKey apiKey;
+
+    /**
+     * Unauthenticated form — holds the raw key as credentials and a null principal; the
+     * authenticated form is produced by {@link APIKeyAuthenticationProvider#authenticate}.
+     */
+    public APIKeyAuthenticationToken(Object principal, Object credentials) {
+        super(null);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.apiKey = null;
+        setAuthenticated(false);
+    }
+
+    /**
+     * Authenticated form — built by the provider. Credentials are expected to be {@code null}
+     * (no need to retain the raw key after authentication); the {@link ApiKey} entity lives on
+     * its dedicated field.
+     */
+    public APIKeyAuthenticationToken(Object principal, Object credentials,
+            Collection<? extends GrantedAuthority> authorities, ApiKey apiKey) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.apiKey = apiKey;
+        super.setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    public ApiKey getApiKey() {
+        return apiKey;
+    }
+
+    /**
+     * Mirror {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken#eraseCredentials}:
+     * blanks the credentials reference so the raw key (if any is still held) is dropped.
+     */
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.credentials = null;
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyRequestParameterProcessingFilter.java
@@ -1,0 +1,166 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.controller.JAXBWriter;
+import org.airsonic.player.controller.SubsonicRESTController.ErrorCode;
+import org.airsonic.player.service.ApiKeyService;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * OpenSubsonic {@code apiKeyAuthentication} extension — extracts the apiKey from either the
+ * {@code Authorization: Bearer} header (preferred) or the {@code apiKey} query parameter,
+ * authenticates it via {@link APIKeyAuthenticationProvider}, and writes the result into the
+ * {@link SecurityContextHolder}. Composes ahead of the legacy
+ * {@code RESTRequestParameterProcessingFilter} via {@code addFilterBefore} in chain 2 —
+ * a successful apiKey context makes the legacy filter's already-authenticated short-circuit
+ * trigger so the legacy {@code u/p/t/s} reads are skipped untouched.
+ * <p>
+ * <b>Downgrade-attack prevention.</b> If an apiKey is presented alongside any legacy auth
+ * parameter ({@code u}/{@code p}/{@code t}/{@code s}), the filter responds with error
+ * {@link ErrorCode#CONFLICTING_AUTH_PARAMS} (43) and stops the chain. This prevents
+ * {@code apiKey=guess&u=victim&p=stolen} from falling through to legacy auth on an apiKey miss.
+ * Both transports of the apiKey (Bearer header AND query parameter) is NOT a conflict — they're
+ * the same auth method, header wins.
+ * <p>
+ * The filter only consumes {@code Authorization: Bearer}; the existing
+ * {@link org.springframework.security.web.authentication.www.BasicAuthenticationFilter} keeps
+ * handling {@code Authorization: Basic} untouched.
+ */
+public class APIKeyRequestParameterProcessingFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(APIKeyRequestParameterProcessingFilter.class);
+
+    public static final String API_KEY_PARAM = "apiKey";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    /** Throttle for the {@code last_used} write — bounded DB writes on the auth hot path. */
+    static final Duration LAST_USED_THROTTLE = Duration.ofMinutes(5);
+
+    private static final String[] LEGACY_AUTH_PARAMS = {"u", "p", "t", "s"};
+
+    private final AuthenticationManager authenticationManager;
+    private final ApiKeyService apiKeyService;
+    private final JAXBWriter jaxbWriter;
+
+    public APIKeyRequestParameterProcessingFilter(AuthenticationManager authenticationManager,
+            ApiKeyService apiKeyService, JAXBWriter jaxbWriter) {
+        this.authenticationManager = authenticationManager;
+        this.apiKeyService = apiKeyService;
+        this.jaxbWriter = jaxbWriter;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
+
+        String rawKey = extractApiKey(request);
+        if (rawKey == null) {
+            // No apiKey presented — defer to the legacy REST filter (u/p/t/s) and HTTP Basic
+            // exactly as before. Filter is purely additive.
+            chain.doFilter(req, resp);
+            return;
+        }
+
+        if (hasAnyLegacyAuthParam(request)) {
+            // Downgrade-attack prevention: any of u/p/t/s alongside apiKey → fail-fast.
+            // Without this, apiKey=guess&u=victim&p=stolen would resolve-miss on apiKey then
+            // fall through to legacy and authenticate via the stolen password.
+            jaxbWriter.writeErrorResponse(request, response,
+                    ErrorCode.CONFLICTING_AUTH_PARAMS, ErrorCode.CONFLICTING_AUTH_PARAMS.getMessage());
+            return;
+        }
+
+        Authentication authResult;
+        try {
+            authResult = authenticationManager.authenticate(new APIKeyAuthenticationToken(null, rawKey));
+        } catch (AuthenticationException failed) {
+            // No raw key, no key_hash, no internal state in the response. Same error code 40
+            // legacy auth produces so clients see a uniform "wrong credentials" outcome.
+            SecurityContextHolder.clearContext();
+            jaxbWriter.writeErrorResponse(request, response,
+                    ErrorCode.NOT_AUTHENTICATED, ErrorCode.NOT_AUTHENTICATED.getMessage());
+            return;
+        }
+
+        SecurityContextHolder.getContext().setAuthentication(authResult);
+        if (authResult instanceof APIKeyAuthenticationToken apiKeyAuth && apiKeyAuth.getApiKey() != null) {
+            try {
+                apiKeyService.markUsed(apiKeyAuth.getApiKey(), LAST_USED_THROTTLE);
+            } catch (Exception x) {
+                // last_used is a courtesy timestamp; a write failure must not break the request.
+                LOG.warn("Failed to update last_used for API key", x);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Bearer header wins; falls back to the {@code apiKey} query parameter. Both forms are the
+     * same auth method (apiKey), so presenting both is not a conflict — header simply takes
+     * precedence. Returns {@code null} when neither is present.
+     */
+    private static String extractApiKey(HttpServletRequest request) {
+        String auth = request.getHeader("Authorization");
+        if (auth != null && auth.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            String candidate = StringUtils.trimToNull(auth.substring(BEARER_PREFIX.length()));
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return StringUtils.trimToNull(request.getParameter(API_KEY_PARAM));
+    }
+
+    private static boolean hasAnyLegacyAuthParam(HttpServletRequest request) {
+        for (String param : LEGACY_AUTH_PARAMS) {
+            if (StringUtils.trimToNull(request.getParameter(param)) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -1,6 +1,7 @@
 package org.airsonic.player.security;
 
 import org.airsonic.player.controller.JAXBWriter;
+import org.airsonic.player.service.ApiKeyService;
 import org.airsonic.player.service.JWTSecurityService;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
@@ -59,6 +60,9 @@ public class GlobalSecurityConfig {
     @Autowired
     private JAXBWriter jaxbWriter;
 
+    @Autowired
+    private ApiKeyService apiKeyService;
+
     @EventListener
     public void loginFailureListener(AbstractAuthenticationFailureEvent event) {
         if (event.getSource() instanceof AbstractAuthenticationToken token) {
@@ -94,6 +98,7 @@ public class GlobalSecurityConfig {
         jwtAuth.addAdditionalCheck("/ws/Sonos", sonosJwtVerification);
         auth.authenticationProvider(jwtAuth);
         auth.authenticationProvider(multipleCredsProvider);
+        auth.authenticationProvider(new APIKeyAuthenticationProvider(apiKeyService, securityService));
     }
 
     @Bean
@@ -139,6 +144,14 @@ public class GlobalSecurityConfig {
         RESTRequestParameterProcessingFilter restAuthenticationFilter = new RESTRequestParameterProcessingFilter(jaxbWriter);
         restAuthenticationFilter.setAuthenticationManager(authenticationManager);
 
+        // The apiKey filter runs BEFORE the legacy REST filter so that:
+        //   1. An apiKey request short-circuits the legacy u/p/t/s reads (the legacy filter
+        //      sees an already-authenticated SecurityContext and returns it untouched).
+        //   2. The downgrade-attack guard fires before any legacy path is even considered —
+        //      apiKey + u/p/t/s → CONFLICTING_AUTH_PARAMS(43), never falls through.
+        APIKeyRequestParameterProcessingFilter apiKeyFilter =
+                new APIKeyRequestParameterProcessingFilter(authenticationManager, apiKeyService, jaxbWriter);
+
         // Try to load the 'remember me' key.
         //
         // Note that using a fixed key compromises security as perfect
@@ -159,6 +172,7 @@ public class GlobalSecurityConfig {
             //.addFilterBefore(restAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .httpBasic(Customizer.withDefaults())
             .addFilterAfter(restAuthenticationFilter, BasicAuthenticationFilter.class)
+            .addFilterBefore(apiKeyFilter, RESTRequestParameterProcessingFilter.class)
             .csrf(csrf -> csrf.ignoringRequestMatchers("/ws/Sonos/**").requireCsrfProtectionMatcher(csrfSecurityRequestMatcher))
             .headers(header -> header.frameOptions(fo -> fo.sameOrigin()))
             .authorizeHttpRequests((authorize) -> authorize.requestMatchers("/recover*", "/accessDenied*", "/style/**", "/icons/**", "/flash/**", "/script/**",

--- a/airsonic-main/src/main/java/org/airsonic/player/service/ApiKeyService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/ApiKeyService.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HexFormat;
@@ -170,6 +171,26 @@ public class ApiKeyService {
             k.setEnabled(enabled);
             return apiKeyRepository.save(k);
         });
+    }
+
+    /**
+     * Update {@code last_used} on the given key, but only when the stored value is null or
+     * older than {@code throttle}. Called from the auth hot path (per-request authentication)
+     * — the throttle keeps the DB write rare, since the entity is already in hand from a
+     * preceding {@link #resolve} the caller doesn't pay an extra read.
+     */
+    @Transactional
+    public void markUsed(ApiKey apiKey, Duration throttle) {
+        if (apiKey == null || apiKey.getId() == null || throttle == null) {
+            return;
+        }
+        Instant now = Instant.now();
+        Instant lastUsed = apiKey.getLastUsed();
+        if (lastUsed != null && lastUsed.isAfter(now.minus(throttle))) {
+            return;
+        }
+        apiKey.setLastUsed(now);
+        apiKeyRepository.save(apiKey);
     }
 
     String hash(String rawKey) {

--- a/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthTest.java
@@ -1,0 +1,393 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.config.AirsonicHomeConfig;
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.repository.ApiKeyRepository;
+import org.airsonic.player.service.ApiKeyService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for the apiKey auth wiring — covers the full request flow through the
+ * security chain (the apiKey filter + the legacy REST filter + HTTP Basic) against a real
+ * database, the downgrade-attack prevention, the Bearer-vs-query precedence, the byte-unchanged
+ * legacy paths, and the throttled {@code last_used} update.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest
+@EnableConfigurationProperties({AirsonicHomeConfig.class})
+public class APIKeyAuthTest {
+
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "admin";
+    private static final String API_VERSION = "1.16.1";
+
+    @TempDir
+    private static Path tempDir;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Autowired
+    private ApiKeyRepository apiKeyRepository;
+
+    private String aliveKey;
+    private Integer aliveKeyId;
+
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty("airsonic.home", tempDir.toString());
+    }
+
+    @BeforeEach
+    public void setUp() {
+        apiKeyRepository.deleteAll();
+        ApiKeyService.GeneratedApiKey g = apiKeyService.generate(USERNAME, "test-key", null);
+        this.aliveKey = g.rawKey();
+        this.aliveKeyId = g.persisted().getId();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // happy paths
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void apiKeyQueryParam_authenticates() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void apiKeyBearerHeader_authenticates() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .header("Authorization", "Bearer " + aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void bearerHeaderWins_overQueryParam() throws Exception {
+        // Header has the valid key; query has a bogus one — header wins, request succeeds.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", "ap_bogus_query")
+                .header("Authorization", "Bearer " + aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // downgrade-attack prevention (the security core)
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void apiKeyPlusU_returns43_neverFallsThroughToLegacy() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", "ap_anything")
+                .param("u", "victim")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(43));
+    }
+
+    @Test
+    public void apiKeyPlusP_returns43_neverFallsThroughToLegacy() throws Exception {
+        // The literal downgrade-attack shape: apiKey=guess + p=stolen.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", "ap_guess")
+                .param("p", "stolen_password")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(43));
+    }
+
+    @Test
+    public void apiKeyPlusTAndS_returns43_neverFallsThroughToLegacy() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", aliveKey)
+                .param("t", "ignored")
+                .param("s", "ignored")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(43));
+    }
+
+    @Test
+    public void bearerPlusLegacyParam_returns43() throws Exception {
+        // Conflict detection covers the Bearer transport too.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("u", "victim")
+                .header("Authorization", "Bearer " + aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(43));
+    }
+
+    @Test
+    public void apiKeyHeaderAndQueryTogether_isNotAConflict() throws Exception {
+        // Both transports of the SAME auth method (apiKey) — not a conflict, header wins.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", aliveKey)
+                .header("Authorization", "Bearer " + aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // invalid keys → 40 (same as legacy wrong-creds)
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void unknownApiKey_returns40() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", "ap_definitely_not_real")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    @Test
+    public void keyWithoutApPrefix_returns40() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", "wrong-prefix-key")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    @Test
+    public void disabledKey_returns40() throws Exception {
+        apiKeyService.setEnabled(aliveKeyId, false);
+
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    @Test
+    public void expiredKey_returns40() throws Exception {
+        // Issue a key already expired; resolve filters it out → BadCredentials → 40.
+        ApiKeyService.GeneratedApiKey expired = apiKeyService.generate(USERNAME, "expired",
+                Instant.now().minus(Duration.ofMinutes(1)));
+
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", expired.rawKey())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // legacy auth must remain byte-unchanged
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void legacyUsernamePassword_stillAuthenticates() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("u", USERNAME)
+                .param("p", PASSWORD)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void legacyUsernamePasswordWrongPassword_stillReturns40() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("u", USERNAME)
+                .param("p", "wrong"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    @Test
+    public void basicAuth_stillAuthenticates() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .with(httpBasic(USERNAME, PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void basicAuthFailure_stillReturns401() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .with(httpBasic(USERNAME, "wrong"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // last_used write — round-trips against the real DB, locks the throttle behavior
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void successfulAuth_updatesLastUsedInDb() throws Exception {
+        // First auth — no prior last_used, should write.
+        assertEquals(null, apiKeyRepository.findById(aliveKeyId).orElseThrow().getLastUsed());
+
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("apiKey", aliveKey)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ApiKey reloaded = apiKeyRepository.findById(aliveKeyId).orElseThrow();
+        assertNotNull(reloaded.getLastUsed(),
+                "first successful auth must persist last_used on a real DB round-trip");
+    }
+
+    @Test
+    public void repeatedAuthWithinThrottle_doesNotRewriteLastUsed() throws Exception {
+        // First auth populates last_used.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("apiKey", aliveKey))
+                .andExpect(status().isOk());
+        Instant firstWrite = apiKeyRepository.findById(aliveKeyId).orElseThrow().getLastUsed();
+        assertNotNull(firstWrite);
+
+        // Second auth within the 5-minute throttle window — last_used must NOT advance.
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("apiKey", aliveKey))
+                .andExpect(status().isOk());
+        Instant secondRead = apiKeyRepository.findById(aliveKeyId).orElseThrow().getLastUsed();
+
+        assertEquals(firstWrite, secondRead,
+                "throttle must prevent a DB write on every authenticated request");
+    }
+
+    @Test
+    public void staleLastUsed_updatesOnNextAuth() throws Exception {
+        // Force a stale lastUsed (older than the throttle); next auth should advance it.
+        ApiKey key = apiKeyRepository.findById(aliveKeyId).orElseThrow();
+        Instant stale = Instant.now().minus(Duration.ofMinutes(10));
+        key.setLastUsed(stale);
+        apiKeyRepository.saveAndFlush(key);
+
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("apiKey", aliveKey))
+                .andExpect(status().isOk());
+
+        Instant after = apiKeyRepository.findById(aliveKeyId).orElseThrow().getLastUsed();
+        assertTrue(after.isAfter(stale),
+                "stale last_used must be advanced on the next authenticated request");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // extension advert
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void extensionsListAdvertisesApiKeyAuthenticationV1() throws Exception {
+        mvc.perform(get("/rest/getOpenSubsonicExtensions")
+                .param("f", "json")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[*].name")
+                        .value(org.hamcrest.Matchers.hasItem("apiKeyAuthentication")))
+                .andExpect(jsonPath(
+                        "$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[?(@.name=='apiKeyAuthentication')].versions[0]")
+                        .value(org.hamcrest.Matchers.hasItem(1)));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthenticationProviderTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthenticationProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.service.ApiKeyService;
+import org.airsonic.player.service.SecurityService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class APIKeyAuthenticationProviderTest {
+
+    @Mock
+    private ApiKeyService apiKeyService;
+    @Mock
+    private SecurityService securityService;
+
+    @InjectMocks
+    private APIKeyAuthenticationProvider provider;
+
+    private UserDetails activeUser() {
+        return new User("alice", "n/a", true, true, true, true,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    private ApiKey aliceKey() {
+        ApiKey k = new ApiKey("alice", "h", "phone", Instant.now(), null);
+        k.setId(7);
+        return k;
+    }
+
+    @Test
+    void supports_onlyAPIKeyToken() {
+        assertTrue(provider.supports(APIKeyAuthenticationToken.class));
+        assertTrue(!provider.supports(UsernamePasswordAuthenticationToken.class));
+    }
+
+    @Test
+    void authenticate_validKey_returnsAuthenticatedTokenWithUserAuthorities() {
+        ApiKey apiKey = aliceKey();
+        when(apiKeyService.resolve("ap_alpha")).thenReturn(Optional.of(apiKey));
+        when(securityService.loadUserByUsername("alice")).thenReturn(activeUser());
+
+        Authentication result = provider.authenticate(new APIKeyAuthenticationToken(null, "ap_alpha"));
+
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(result).isInstanceOf(APIKeyAuthenticationToken.class);
+        assertSame(apiKey, ((APIKeyAuthenticationToken) result).getApiKey(),
+                "ApiKey must be carried on the dedicated field so it survives credential erasure");
+        assertThat(result.getAuthorities()).extracting(Object::toString).contains("ROLE_USER");
+        assertThat(((UserDetails) result.getPrincipal()).getUsername()).isEqualTo("alice");
+    }
+
+    @Test
+    void authenticate_unknownKey_collapsesToBadCredentials() {
+        when(apiKeyService.resolve("ap_unknown")).thenReturn(Optional.empty());
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_unknown")));
+    }
+
+    @Test
+    void authenticate_disabledOrExpiredKey_collapsesToBadCredentials() {
+        // ApiKeyService.resolve already filters disabled + expired — provider sees Optional.empty.
+        when(apiKeyService.resolve("ap_disabled")).thenReturn(Optional.empty());
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_disabled")));
+    }
+
+    @Test
+    void authenticate_userGone_collapsesToBadCredentials() {
+        // Enumeration-oracle defence: a key pointing at a deleted user must look identical
+        // to "no such key" from the outside.
+        when(apiKeyService.resolve("ap_orphaned")).thenReturn(Optional.of(aliceKey()));
+        when(securityService.loadUserByUsername("alice"))
+                .thenThrow(new UsernameNotFoundException("alice"));
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_orphaned")));
+    }
+
+    @Test
+    void authenticate_disabledUser_collapsesToBadCredentials() {
+        when(apiKeyService.resolve("ap_alpha")).thenReturn(Optional.of(aliceKey()));
+        UserDetails locked = new User("alice", "n/a", false, true, true, true,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        when(securityService.loadUserByUsername("alice")).thenReturn(locked);
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_alpha")));
+    }
+
+    @Test
+    void authenticate_blankOrNullCredentials_rejected() {
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, null)));
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "")));
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "   ")));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyRequestParameterProcessingFilterTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyRequestParameterProcessingFilterTest.java
@@ -1,0 +1,328 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.controller.JAXBWriter;
+import org.airsonic.player.controller.SubsonicRESTController.ErrorCode;
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.service.ApiKeyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the apiKey filter — fast, no Spring context. The downgrade-attack prevention
+ * (apiKey + any legacy param → 43) is the security core; the rest enforces transport precedence
+ * (Bearer wins), the absent-key pass-through (legacy stays untouched), and the failure mapping
+ * (invalid key → 40).
+ */
+@ExtendWith(MockitoExtension.class)
+class APIKeyRequestParameterProcessingFilterTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private ApiKeyService apiKeyService;
+    @Mock
+    private JAXBWriter jaxbWriter;
+
+    private APIKeyRequestParameterProcessingFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new APIKeyRequestParameterProcessingFilter(authenticationManager, apiKeyService, jaxbWriter);
+        SecurityContextHolder.clearContext();
+    }
+
+    private Authentication successfulAuth(ApiKey apiKey) {
+        // Mirror what APIKeyAuthenticationProvider returns: an APIKeyAuthenticationToken whose
+        // dedicated apiKey field carries the resolved entity (survives
+        // ProviderManager.eraseCredentialsAfterAuthentication).
+        return new APIKeyAuthenticationToken(
+                "alice", "ap_raw", List.of(new SimpleGrantedAuthority("ROLE_USER")), apiKey);
+    }
+
+    private static ApiKey newKey() {
+        ApiKey k = new ApiKey("alice", "deadbeef", "phone", Instant.now(), null);
+        k.setId(7);
+        return k;
+    }
+
+    @Test
+    void doFilter_noApiKey_passesThroughUntouched() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNotNull(chain.getRequest(), "chain.doFilter must be called when no apiKey is present");
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verifyNoInteractions(authenticationManager, apiKeyService, jaxbWriter);
+    }
+
+    @Test
+    void doFilter_apiKeyQueryParam_authenticatesAndChains() throws Exception {
+        ApiKey apiKey = newKey();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_alpha");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        when(authenticationManager.authenticate(any(APIKeyAuthenticationToken.class)))
+                .thenReturn(successfulAuth(apiKey));
+
+        filter.doFilter(req, res, chain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertNotNull(chain.getRequest());
+        verify(apiKeyService).markUsed(eq(apiKey), eq(APIKeyRequestParameterProcessingFilter.LAST_USED_THROTTLE));
+    }
+
+    @Test
+    void doFilter_authorizationBearer_isPreferredOverQueryParam() throws Exception {
+        ApiKey apiKey = newKey();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.addHeader("Authorization", "Bearer ap_header_wins");
+        req.setParameter("apiKey", "ap_query_loses");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        ArgumentCaptor<APIKeyAuthenticationToken> captor = ArgumentCaptor.forClass(APIKeyAuthenticationToken.class);
+        when(authenticationManager.authenticate(captor.capture())).thenReturn(successfulAuth(apiKey));
+
+        filter.doFilter(req, res, chain);
+
+        assertEquals("ap_header_wins", captor.getValue().getCredentials(),
+                "header value must win over the query parameter");
+    }
+
+    @Test
+    void doFilter_bearerSchemeIsCaseInsensitive() throws Exception {
+        ApiKey apiKey = newKey();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        // RFC 7235: auth scheme is case-insensitive.
+        req.addHeader("Authorization", "bearer ap_lowercase");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        ArgumentCaptor<APIKeyAuthenticationToken> captor = ArgumentCaptor.forClass(APIKeyAuthenticationToken.class);
+        when(authenticationManager.authenticate(captor.capture())).thenReturn(successfulAuth(apiKey));
+
+        filter.doFilter(req, res, chain);
+
+        assertEquals("ap_lowercase", captor.getValue().getCredentials());
+    }
+
+    @Test
+    void doFilter_basicSchemeIsIgnoredByApiKeyFilter() throws Exception {
+        // HTTP Basic must keep flowing to the existing BasicAuthenticationFilter — the apiKey
+        // filter consumes only Bearer.
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNotNull(chain.getRequest());
+        verifyNoInteractions(authenticationManager, apiKeyService, jaxbWriter);
+    }
+
+    @Test
+    void doFilter_conflictWithUsernameParam_returns43AndDoesNotAuthenticate() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_alpha");
+        req.setParameter("u", "victim");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        verify(jaxbWriter).writeErrorResponse(any(), any(),
+                eq(ErrorCode.CONFLICTING_AUTH_PARAMS),
+                eq(ErrorCode.CONFLICTING_AUTH_PARAMS.getMessage()));
+        assertNull(chain.getRequest(), "the chain must be stopped on conflict");
+        verifyNoInteractions(authenticationManager);
+    }
+
+    @Test
+    void doFilter_conflictWithPasswordParam_returns43() throws Exception {
+        // The actual downgrade-attack shape — apiKey=guess + p=stolen would historically have
+        // fallen through to legacy on an apiKey miss. This test locks the fail-fast.
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.addHeader("Authorization", "Bearer ap_guess");
+        req.setParameter("p", "stolen_password");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        verify(jaxbWriter).writeErrorResponse(any(), any(),
+                eq(ErrorCode.CONFLICTING_AUTH_PARAMS), any());
+        verifyNoInteractions(authenticationManager);
+    }
+
+    @Test
+    void doFilter_conflictWithSaltAndToken_returns43() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_alpha");
+        req.setParameter("s", "salt");
+        req.setParameter("t", "token");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        verify(jaxbWriter).writeErrorResponse(any(), any(),
+                eq(ErrorCode.CONFLICTING_AUTH_PARAMS), any());
+        verifyNoInteractions(authenticationManager);
+    }
+
+    @Test
+    void doFilter_apiKeyInBothHeaderAndQuery_isNotAConflict() throws Exception {
+        // Same auth method (apiKey), two transports — header wins, no 43.
+        ApiKey apiKey = newKey();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.addHeader("Authorization", "Bearer ap_header");
+        req.setParameter("apiKey", "ap_query");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        when(authenticationManager.authenticate(any(APIKeyAuthenticationToken.class)))
+                .thenReturn(successfulAuth(apiKey));
+
+        filter.doFilter(req, res, chain);
+
+        verify(jaxbWriter, never()).writeErrorResponse(any(), any(), any(), any());
+        verify(authenticationManager, times(1)).authenticate(any());
+    }
+
+    @Test
+    void doFilter_invalidKey_returns40() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_invalid");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        when(authenticationManager.authenticate(any(APIKeyAuthenticationToken.class)))
+                .thenThrow(new BadCredentialsException("Invalid API key"));
+
+        filter.doFilter(req, res, chain);
+
+        verify(jaxbWriter).writeErrorResponse(any(), any(),
+                eq(ErrorCode.NOT_AUTHENTICATED),
+                eq(ErrorCode.NOT_AUTHENTICATED.getMessage()));
+        assertNull(chain.getRequest(), "the chain must be stopped on failure so legacy doesn't run");
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void doFilter_blankBearerToken_isTreatedAsNoApiKey() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.addHeader("Authorization", "Bearer    ");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNotNull(chain.getRequest());
+        verifyNoInteractions(authenticationManager, apiKeyService, jaxbWriter);
+    }
+
+    @Test
+    void doFilter_markUsedFailureDoesNotBreakRequest() throws Exception {
+        ApiKey apiKey = newKey();
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_alpha");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        when(authenticationManager.authenticate(any(APIKeyAuthenticationToken.class)))
+                .thenReturn(successfulAuth(apiKey));
+        org.mockito.Mockito.doThrow(new RuntimeException("DB write failed"))
+                .when(apiKeyService).markUsed(any(), any());
+
+        filter.doFilter(req, res, chain);
+
+        // Request still completes — last_used is a courtesy timestamp, not a gate.
+        assertNotNull(chain.getRequest());
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void doFilter_emptyApiKeyQueryParam_passesThroughToLegacy() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNotNull(chain.getRequest());
+        verifyNoInteractions(authenticationManager);
+    }
+
+    @Test
+    void doFilter_validKeyTriggersLastUsedUpdate_thresholdRespected() throws Exception {
+        // Stale entity: lastUsed older than the throttle → markUsed should perform the write.
+        ApiKey apiKey = new ApiKey("alice", "h", "k", Instant.now(), null);
+        apiKey.setId(7);
+        apiKey.setLastUsed(Instant.now().minus(10, ChronoUnit.MINUTES));
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/ping");
+        req.setParameter("apiKey", "ap_x");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        when(authenticationManager.authenticate(any(APIKeyAuthenticationToken.class)))
+                .thenReturn(successfulAuth(apiKey));
+
+        filter.doFilter(req, res, chain);
+
+        // The decision (write vs throttle) lives inside ApiKeyService.markUsed; from the filter's
+        // perspective we just verify markUsed was invoked with the same entity + throttle.
+        verify(apiKeyService).markUsed(eq(apiKey), eq(APIKeyRequestParameterProcessingFilter.LAST_USED_THROTTLE));
+    }
+
+    @Test
+    void lastUsedThrottle_isFiveMinutes() {
+        // Lock the documented threshold so the constant can't quietly drift.
+        assertTrue(APIKeyRequestParameterProcessingFilter.LAST_USED_THROTTLE.toMinutes() == 5);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/ApiKeyServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/ApiKeyServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -399,5 +401,59 @@ class ApiKeyServiceTest {
         }
         // Sanity: at least we tested some generation path
         verify(apiKeyRepository, times(1)).save(any(ApiKey.class));
+    }
+
+    @Test
+    void markUsed_nullLastUsed_writes() {
+        ApiKey k = new ApiKey("alice", "h", "k", Instant.now(), null);
+        k.setId(7);
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.markUsed(k, Duration.ofMinutes(5));
+
+        verify(apiKeyRepository).save(k);
+        assertNotNull(k.getLastUsed());
+    }
+
+    @Test
+    void markUsed_lastUsedOlderThanThreshold_writes() {
+        ApiKey k = new ApiKey("alice", "h", "k", Instant.now(), null);
+        k.setId(7);
+        k.setLastUsed(Instant.now().minus(10, ChronoUnit.MINUTES));
+        Instant before = k.getLastUsed();
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.markUsed(k, Duration.ofMinutes(5));
+
+        verify(apiKeyRepository).save(k);
+        assertTrue(k.getLastUsed().isAfter(before));
+    }
+
+    @Test
+    void markUsed_lastUsedWithinThreshold_doesNotWrite() {
+        // The load-bearing throttle assertion — repeated auth hits within the throttle window
+        // must NOT incur a DB write per request.
+        ApiKey k = new ApiKey("alice", "h", "k", Instant.now(), null);
+        k.setId(7);
+        k.setLastUsed(Instant.now().minus(30, ChronoUnit.SECONDS));
+
+        service.markUsed(k, Duration.ofMinutes(5));
+
+        verify(apiKeyRepository, never()).save(any());
+    }
+
+    @Test
+    void markUsed_nullEntityOrThrottle_isNoOp() {
+        service.markUsed(null, Duration.ofMinutes(5));
+        service.markUsed(new ApiKey(), null);
+        verifyNoInteractions(apiKeyRepository);
+    }
+
+    @Test
+    void markUsed_entityWithoutId_isNoOp() {
+        // Defensive — should never happen via the filter path, but guard anyway.
+        ApiKey unsaved = new ApiKey("alice", "h", "k", Instant.now(), null);
+        service.markUsed(unsaved, Duration.ofMinutes(5));
+        verifyNoInteractions(apiKeyRepository);
     }
 }


### PR DESCRIPTION
Second of the apiKeyAuthentication PRs (#145): wires apiKey into the REST filter chain so /rest/ requests can authenticate with it, and advertises apiKeyAuthentication v1 in the OpenSubsonic extensions list. PR-C adds the key-management UI; PR-D adds the legacy-auth deprecation warning.

APIKeyRequestParameterProcessingFilter slots in via addFilterBefore(..., RESTRequestParameterProcessingFilter.class) in the main REST chain. Bearer header wins precedence over the apiKey query parameter; HTTP Basic is untouched. If apiKey coexists with any legacy param (u/p/t/s) the filter fails fast with CONFLICTING_AUTH_PARAMS(43) before authenticate() runs -- the downgrade-attack prevention, locked by the literal attack-shape test apiKey=guess + p=stolen. Invalid, disabled, or expired keys collapse to NOT_AUTHENTICATED(40) with a single error message so the provider gives no enumeration oracle.

APIKeyAuthenticationProvider resolves via ApiKeyService.resolve() and throttles the last_used write via a new ApiKeyService.markUsed (5-minute staleness threshold; the entity is already loaded by resolve(), so it's a free read plus an occasional write). APIKeyAuthenticationToken extends AbstractAuthenticationToken directly rather than UsernamePasswordAuthenticationToken -- the UPAT inheritance match would have routed apiKey tokens through every UPAT-handling provider in the chain (multiCreds, LdapAuthenticationProvider) before reaching the apiKey provider, hitting empty-username DB and LDAP lookups per request. The direct extension fixes routing for every UPAT-matching provider, present and future, with zero per-provider patches; the legacy auth files are byte-unchanged in the diff.

PASSWORD_AUTH_NOT_SUPPORTED(42) stays reserved -- its emission needs a password-auth-disabled state, which is the future per-user toggle / #56.

Verified four ways: HSQLDB full suite at 1030/0 (983 floor + 47 new), Postgres against postgres:16-alpine exercising the new last_used UPDATE end-to-end, mvnd verify clean with the logback JARs still present in the WAR, and a unit assertion on buildExtensionList for the v1 advert. Does not close #145.

Part of #145.