### PR TITLE
Add apiKey self-service settings page (#145 PR-C)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ApiKeySettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ApiKeySettingsController.java
@@ -1,0 +1,202 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.service.ApiKeyService;
+import org.airsonic.player.service.ApiKeyService.GeneratedApiKey;
+import org.airsonic.player.service.SecurityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.security.Principal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Per-user management of OpenSubsonic API keys (issue #145).
+ *
+ * Each authenticated user manages ONLY their own keys: list/generate/disable/revoke.
+ * The generate flow uses the post-redirect-get pattern with a flash attribute so the
+ * raw key is shown exactly once and never persisted on the entity, in the response
+ * after the show-once render, or in any log line.
+ *
+ * The {@link ApiKeyService#revoke(Integer)} and {@link ApiKeyService#setEnabled(Integer, boolean)}
+ * methods are intentionally ownership-blind. This controller enforces ownership via
+ * a {@link ApiKeyService#list(String)} membership check before either call, so a user
+ * forging another user's key id cannot affect that key.
+ */
+@Controller
+@RequestMapping({"/apikeySettings", "/apikeySettings.view"})
+public class ApiKeySettingsController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApiKeySettingsController.class);
+
+    static final int MAX_NAME_LENGTH = 120;
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Autowired
+    private SecurityService securityService;
+
+    @GetMapping
+    protected String displayForm() {
+        return "apiKeySettings";
+    }
+
+    @ModelAttribute
+    protected void populateModel(Authentication user, ModelMap map) {
+        String username = user.getName();
+        List<ApiKeyView> keys = apiKeyService.list(username).stream()
+                .map(ApiKeyView::from)
+                .toList();
+
+        User userInDb = securityService.getUserByName(username);
+
+        map.addAttribute("username", username);
+        map.addAttribute("keys", keys);
+        map.addAttribute("adminRole", userInDb != null && userInDb.isAdminRole());
+    }
+
+    @PostMapping("/generate")
+    protected String generate(Principal user,
+            @RequestParam("name") String name,
+            @RequestParam(name = "expiresAt", required = false) String expiresAt,
+            RedirectAttributes redirectAttributes) {
+        if (user == null) {
+            return "redirect:/login";
+        }
+        String trimmedName = name == null ? "" : name.trim();
+        if (trimmedName.isEmpty()) {
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            redirectAttributes.addFlashAttribute("apikey_error", "apikeysettings.error.nameRequired");
+            return "redirect:/apikeySettings.view";
+        }
+        if (trimmedName.length() > MAX_NAME_LENGTH) {
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            redirectAttributes.addFlashAttribute("apikey_error", "apikeysettings.error.nameTooLong");
+            return "redirect:/apikeySettings.view";
+        }
+
+        Instant expiresAtInstant;
+        try {
+            expiresAtInstant = parseExpiresAt(expiresAt);
+        } catch (DateTimeParseException x) {
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            redirectAttributes.addFlashAttribute("apikey_error", "apikeysettings.error.expiresInvalid");
+            return "redirect:/apikeySettings.view";
+        }
+        if (expiresAtInstant != null && expiresAtInstant.isBefore(Instant.now())) {
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            redirectAttributes.addFlashAttribute("apikey_error", "apikeysettings.error.expiresInPast");
+            return "redirect:/apikeySettings.view";
+        }
+
+        GeneratedApiKey generated = apiKeyService.generate(user.getName(), trimmedName, expiresAtInstant);
+
+        // Raw key flows back to the view via flash attributes ONLY. Spring's FlashMap
+        // removes them from the session after the next request retrieves them, so the
+        // key lives in the user's own session for a single HTTP roundtrip and is gone
+        // after the show-once render. Never logged.
+        redirectAttributes.addFlashAttribute("freshlyGeneratedKey", generated.rawKey());
+        redirectAttributes.addFlashAttribute("freshlyGeneratedName", generated.persisted().getName());
+        redirectAttributes.addFlashAttribute("settings_toast", true);
+        return "redirect:/apikeySettings.view";
+    }
+
+    @PostMapping("/revoke")
+    protected String revoke(Principal user,
+            @RequestParam("id") Integer id,
+            RedirectAttributes redirectAttributes) {
+        if (user == null) {
+            return "redirect:/login";
+        }
+        if (!isOwnedBy(id, user.getName())) {
+            // IDOR guard: silently no-op on a not-owned id rather than echo back any
+            // information that distinguishes "not yours" from "no such key".
+            LOG.debug("Rejected API-key revoke: id does not belong to authenticated user");
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            return "redirect:/apikeySettings.view";
+        }
+        apiKeyService.revoke(id);
+        redirectAttributes.addFlashAttribute("settings_toast", true);
+        return "redirect:/apikeySettings.view";
+    }
+
+    @PostMapping("/setEnabled")
+    protected String setEnabled(Principal user,
+            @RequestParam("id") Integer id,
+            @RequestParam("enabled") boolean enabled,
+            RedirectAttributes redirectAttributes) {
+        if (user == null) {
+            return "redirect:/login";
+        }
+        if (!isOwnedBy(id, user.getName())) {
+            LOG.debug("Rejected API-key setEnabled: id does not belong to authenticated user");
+            redirectAttributes.addFlashAttribute("settings_toast", false);
+            return "redirect:/apikeySettings.view";
+        }
+        apiKeyService.setEnabled(id, enabled);
+        redirectAttributes.addFlashAttribute("settings_toast", true);
+        return "redirect:/apikeySettings.view";
+    }
+
+    private boolean isOwnedBy(Integer id, String username) {
+        if (id == null || username == null) {
+            return false;
+        }
+        return apiKeyService.list(username).stream()
+                .map(ApiKey::getId)
+                .anyMatch(id::equals);
+    }
+
+    private static Instant parseExpiresAt(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        return LocalDateTime.parse(raw).atZone(ZoneId.systemDefault()).toInstant();
+    }
+
+    /**
+     * View-layer projection of {@link ApiKey} that intentionally omits {@code username}
+     * and {@code keyHash}, so the template cannot accidentally render either.
+     */
+    public record ApiKeyView(Integer id, String name, Instant created, Instant lastUsed,
+            boolean enabled, Instant expiresAt) {
+        static ApiKeyView from(ApiKey k) {
+            return new ApiKeyView(k.getId(), k.getName(), k.getCreated(), k.getLastUsed(),
+                    k.isEnabled(), k.getExpiresAt());
+        }
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -178,7 +178,8 @@ public class GlobalSecurityConfig {
             .authorizeHttpRequests((authorize) -> authorize.requestMatchers("/recover*", "/accessDenied*", "/style/**", "/icons/**", "/flash/**", "/script/**",
                     "/login", "/error", "/sonos/**", "/sonoslink/**", "/ws/Sonos/**",
                     "/rest/getOpenSubsonicExtensions*").permitAll().requestMatchers("/personalSettings*",
-                    "/playerSettings*", "/shareSettings*", "/credentialsSettings*").hasRole("SETTINGS")
+                    "/playerSettings*", "/shareSettings*", "/credentialsSettings*", "/apikeySettings*",
+                    "/apikeySettings/**").hasRole("SETTINGS")
                     .requestMatchers("/generalSettings*", "/advancedSettings*", "/userSettings*", "/musicFolderSettings*",
                             "/databaseSettings*", "/transcodeSettings*", "/rest/startScan*").hasRole("ADMIN")
                     .requestMatchers("/deletePlaylist*", "/savePlaylist*").hasRole("PLAYLIST").requestMatchers("/download*").hasRole("DOWNLOAD")

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -356,6 +356,7 @@ settingsheader.coverArt=Cover art
 settingsheader.password=Password
 settingsheader.database=Database
 settingsheader.credentials=Credentials
+settingsheader.apikey=API Keys
 
 generalsettings.playlistfolder=Import playlists from
 generalsettings.musicmask=Music files
@@ -687,6 +688,37 @@ credentialsettings.decodableencoder=Preferred decodable encoder
 credentialsettings.prefernondecodablepasswords=Use non-decodable passwords wherever possible
 credentialsettings.keepkeyssafe=These are your encryption keys. KEEP THEM SAFE! (Hover to see them)
 credentialsettings.immutable=Note: Credentials are immutable. They can only be added or removed, but cannot be changed (except how they are stored). If you want to change passwords, ADD new credentials and DELETE old ones.
+
+apikeysettings.title=API Keys for {0}
+apikeysettings.intro=API keys let third-party clients authenticate via the OpenSubsonic apiKey extension without sharing your password. Each key belongs only to your account. Generated keys are shown exactly once at creation - copy the key before leaving the page.
+apikeysettings.existingkeys=Your API keys
+apikeysettings.nokeys=You have no API keys yet.
+apikeysettings.name=Name
+apikeysettings.created=Created
+apikeysettings.lastused=Last used
+apikeysettings.expires=Expires
+apikeysettings.expires.hint=Leave blank for a key with no expiry.
+apikeysettings.enabled=Enabled
+apikeysettings.actions=Actions
+apikeysettings.never=Never
+apikeysettings.noexpiry=Never
+apikeysettings.enable=Enable
+apikeysettings.disable=Disable
+apikeysettings.revoke=Revoke
+apikeysettings.confirmrevoke=Revoke this API key? Clients using it will stop working immediately. This cannot be undone.
+apikeysettings.generate=Generate a new API key
+apikeysettings.generate.submit=Generate
+apikeysettings.newkey.title=New API key generated
+apikeysettings.newkey.warning=Copy this key now - it will not be shown again. If you lose it, revoke the key and generate a new one.
+apikeysettings.copy=Copy
+apikeysettings.copied=API key copied to clipboard.
+apikeysettings.copyfailed=Could not copy automatically. Select the key text and copy it manually.
+apikeysettings.error.nameRequired=A name is required.
+apikeysettings.error.nameTooLong=The name is too long (max 120 characters).
+apikeysettings.error.expiresInvalid=The expiry date could not be parsed.
+apikeysettings.error.expiresInPast=The expiry date must be in the future.
+apikeysettings.yes=Yes
+apikeysettings.no=No
 
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source

--- a/airsonic-main/src/main/resources/templates/apiKeySettings.html
+++ b/airsonic-main/src/main/resources/templates/apiKeySettings.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+
+<html><head>
+
+  <th:block th:replace="~{head :: common_head}" />
+  <th:block th:replace="~{jquery}" />
+  <script type="text/javascript" th:src="@{/script/utils.js}"></script>
+
+  <script type="text/javascript" th:inline="javascript">
+    // JS-escaped i18n strings (Thymeleaf [[...]] produces a JSON-safe literal).
+    // Using the [(...)] unescaped form would break the moment a translation
+    // contained an apostrophe or quote, with both a UX (broken JS) and an
+    // injection (translator-controlled string in JS context) consequence.
+    var msgConfirmRevoke = /*[[#{apikeysettings.confirmrevoke}]]*/ "";
+    var msgCopied = /*[[#{apikeysettings.copied}]]*/ "";
+    var msgCopyFailed = /*[[#{apikeysettings.copyfailed}]]*/ "";
+
+    function copyGeneratedKey() {
+      var input = document.getElementById("freshlyGeneratedKey");
+      if (!input) return;
+      input.removeAttribute("disabled");
+      input.select();
+      input.setSelectionRange(0, 99999);
+      var ok = false;
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(input.value);
+          ok = true;
+        } else {
+          ok = document.execCommand("copy");
+        }
+      } catch (e) {
+        ok = false;
+      }
+      input.setAttribute("disabled", "disabled");
+      input.blur();
+      $().toastmessage(ok ? "showSuccessToast" : "showWarningToast", ok ? msgCopied : msgCopyFailed);
+    }
+
+    function confirmRevoke() {
+      return confirm(msgConfirmRevoke);
+    }
+  </script>
+</head>
+
+<body class="mainframe bgcolor1">
+<script type="text/javascript" th:src="@{/script/wz_tooltip.js}"></script>
+<script type="text/javascript" th:src="@{/script/tip_balloon.js}"></script>
+
+<th:block th:replace="~{settingsHeader::header(cat='apikey',toast=${settings_toast},restricted=${!adminRole})}" />
+
+<h2 th:text="#{apikeysettings.title(${username})}"></h2>
+
+<p th:text="#{apikeysettings.intro}"></p>
+
+<th:block th:if="${apikey_error}">
+  <p class="warning" th:text="#{__${apikey_error}__}"></p>
+</th:block>
+
+<th:block th:if="${freshlyGeneratedKey}">
+  <div class="warning"
+       style="border:2px solid #c00;padding:0.8em;margin-bottom:1em;background-color:#fee">
+    <h3 th:text="#{apikeysettings.newkey.title}"></h3>
+    <p th:text="#{apikeysettings.newkey.warning}"></p>
+    <p>
+      <strong th:text="#{apikeysettings.name}"></strong>:
+      <span th:text="${freshlyGeneratedName}"></span>
+    </p>
+    <p>
+      <input type="text" id="freshlyGeneratedKey" th:value="${freshlyGeneratedKey}"
+             readonly="readonly" disabled="disabled"
+             style="width:34em;font-family:monospace" />
+      <input type="button" th:value="#{apikeysettings.copy}" onclick="copyGeneratedKey()" />
+    </p>
+  </div>
+</th:block>
+
+<div>
+  <h3 th:text="#{apikeysettings.existingkeys}"></h3>
+  <th:block th:if="${#lists.isEmpty(keys)}">
+    <p th:text="#{apikeysettings.nokeys}"></p>
+  </th:block>
+  <table th:unless="${#lists.isEmpty(keys)}" id="apiKeysTable">
+    <tr>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.name}"></th>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.created}"></th>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.lastused}"></th>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.expires}"></th>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.enabled}"></th>
+      <th style="padding:0 0.5em 0 0.5em;border-style:double" th:text="#{apikeysettings.actions}"></th>
+    </tr>
+    <tr th:each="key:${keys}">
+      <td style="padding:0 0.5em 0 0.5em" th:text="${key.name}"></td>
+      <td style="padding:0 0.5em 0 0.5em" th:text="${#temporals.format(key.created,'SHORT')}"></td>
+      <td style="padding:0 0.5em 0 0.5em">
+        <span th:if="${key.lastUsed != null}" th:text="${#temporals.format(key.lastUsed,'SHORT')}"></span>
+        <span th:if="${key.lastUsed == null}" th:text="#{apikeysettings.never}"></span>
+      </td>
+      <td style="padding:0 0.5em 0 0.5em">
+        <span th:if="${key.expiresAt != null}" th:text="${#temporals.format(key.expiresAt,'SHORT')}"></span>
+        <span th:if="${key.expiresAt == null}" th:text="#{apikeysettings.noexpiry}"></span>
+      </td>
+      <td style="padding:0 0.5em 0 0.5em;text-align:center">
+        <span th:if="${key.enabled}" th:text="#{apikeysettings.yes}"></span>
+        <span th:unless="${key.enabled}" th:text="#{apikeysettings.no}"></span>
+      </td>
+      <td style="padding:0 0.5em 0 0.5em">
+        <form method="post" th:action="@{/apikeySettings/setEnabled}" style="display:inline">
+          <input type="hidden" name="id" th:value="${key.id}" />
+          <input type="hidden" name="enabled" th:value="${!key.enabled}" />
+          <input type="submit"
+                 th:value="${key.enabled} ? #{apikeysettings.disable} : #{apikeysettings.enable}" />
+        </form>
+        <form method="post" th:action="@{/apikeySettings/revoke}" style="display:inline"
+              onsubmit="return confirmRevoke()">
+          <input type="hidden" name="id" th:value="${key.id}" />
+          <input type="submit" th:value="#{apikeysettings.revoke}" />
+        </form>
+      </td>
+    </tr>
+  </table>
+</div>
+
+<div style="margin-top:2em">
+  <h3 th:text="#{apikeysettings.generate}"></h3>
+  <form method="post" th:action="@{/apikeySettings/generate}">
+    <table class="indent">
+      <tr>
+        <td th:text="#{apikeysettings.name}"></td>
+        <td><input type="text" name="name" size="30" maxlength="120" required="required" /></td>
+      </tr>
+      <tr>
+        <td th:text="#{apikeysettings.expires}"></td>
+        <td>
+          <input type="datetime-local" name="expiresAt" />
+          <span style="font-size:90%;color:#666" th:text="#{apikeysettings.expires.hint}"></span>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>
+          <input type="submit" th:value="#{apikeysettings.generate.submit}" />
+        </td>
+      </tr>
+    </table>
+  </form>
+</div>
+
+</body></html>

--- a/airsonic-main/src/main/resources/templates/settingsHeader.html
+++ b/airsonic-main/src/main/resources/templates/settingsHeader.html
@@ -29,10 +29,10 @@
 
     <h2 style="white-space: normal">
     <th:block th:if="${restricted}" >
-        <th:block th:replace="~{::links(${ {'personal', 'credentials', 'player', 'share'} })}" />
+        <th:block th:replace="~{::links(${ {'personal', 'credentials', 'apikey', 'player', 'share'} })}" />
     </th:block>
     <th:block th:unless="${restricted}" >
-        <th:block th:replace="~{::links(${ {'musicFolder', 'general', 'advanced', 'personal', 'credentials', 'user', 'player', 'share', 'dlna', 'sonos', 'transcoding', 'internetRadio', 'podcast', 'database'} })}" />
+        <th:block th:replace="~{::links(${ {'musicFolder', 'general', 'advanced', 'personal', 'credentials', 'apikey', 'user', 'player', 'share', 'dlna', 'sonos', 'transcoding', 'internetRadio', 'podcast', 'database'} })}" />
     </th:block>
     </h2>
 

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/ApiKeySettingsControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/ApiKeySettingsControllerTest.java
@@ -1,0 +1,395 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.config.AirsonicHomeConfig;
+import org.airsonic.player.domain.ApiKey;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.service.ApiKeyService;
+import org.airsonic.player.service.ApiKeyService.GeneratedApiKey;
+import org.airsonic.player.service.SecurityService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest
+@ContextConfiguration(classes = {ApiKeySettingsController.class}, initializers = ConfigDataApplicationContextInitializer.class)
+@EnableConfigurationProperties(AirsonicHomeConfig.class)
+class ApiKeySettingsControllerTest {
+
+    private static final String ALICE = "alice";
+    private static final String BOB = "bob";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApiKeyService apiKeyService;
+
+    @MockitoBean
+    private SecurityService securityService;
+
+    @TempDir
+    private static Path tempDir;
+
+    @BeforeAll
+    static void setUpHome() {
+        System.setProperty("airsonic.home", tempDir.toString());
+    }
+
+    @AfterAll
+    static void tearDownHome() {
+        System.clearProperty("airsonic.home");
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Default (empty) role set → isAdminRole() = false, which exercises the
+        // restricted nav path in the template.
+        User alice = new User(ALICE, "alice@example.com");
+        when(securityService.getUserByName(ALICE)).thenReturn(alice);
+    }
+
+    private static ApiKey key(Integer id, String username, String name) {
+        ApiKey k = new ApiKey(username, "hash-" + id, name, Instant.now(), null);
+        k.setId(id);
+        return k;
+    }
+
+    // ---------- GET / list scoping ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void displayForm_authenticated_returnsView() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+
+        mockMvc.perform(get("/apikeySettings"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("apiKeySettings"))
+                .andExpect(model().attribute("username", ALICE))
+                .andExpect(model().attribute("keys", List.of()));
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void displayForm_listsOnlyOwnKeys() throws Exception {
+        ApiKey aliceKey = key(1, ALICE, "phone");
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(aliceKey));
+
+        MvcResult result = mockMvc.perform(get("/apikeySettings"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<ApiKeySettingsController.ApiKeyView> keys =
+                (List<ApiKeySettingsController.ApiKeyView>) result.getModelAndView().getModel().get("keys");
+        assertThat(keys).hasSize(1);
+        assertThat(keys.get(0).id()).isEqualTo(1);
+        assertThat(keys.get(0).name()).isEqualTo("phone");
+        // Verify the controller asked the service for THIS user's keys only.
+        verify(apiKeyService).list(ALICE);
+        verify(apiKeyService, never()).list(BOB);
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void apiKeyView_doesNotExposeUsernameOrHash() {
+        ApiKey raw = key(7, ALICE, "phone");
+        ApiKeySettingsController.ApiKeyView view = ApiKeySettingsController.ApiKeyView.from(raw);
+        // The DTO is the only thing reaching the template. Verify by record components that
+        // username and keyHash are not present.
+        assertThat(view.getClass().getRecordComponents())
+                .extracting(java.lang.reflect.RecordComponent::getName)
+                .containsExactlyInAnyOrder("id", "name", "created", "lastUsed", "enabled", "expiresAt");
+    }
+
+    // ---------- generate ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_validName_callsServiceAndFlashesShowOnceKey() throws Exception {
+        ApiKey persisted = key(42, ALICE, "phone");
+        GeneratedApiKey generated = new GeneratedApiKey("ap_RAW_KEY_XYZ", persisted);
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+        when(apiKeyService.generate(eq(ALICE), eq("phone"), eq(null))).thenReturn(generated);
+
+        mockMvc.perform(post("/apikeySettings/generate").param("name", "phone").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/apikeySettings.view"))
+                .andExpect(flash().attribute("freshlyGeneratedKey", "ap_RAW_KEY_XYZ"))
+                .andExpect(flash().attribute("freshlyGeneratedName", "phone"))
+                .andExpect(flash().attribute("settings_toast", true));
+
+        verify(apiKeyService).generate(ALICE, "phone", null);
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_trimsNameWhitespace() throws Exception {
+        ApiKey persisted = key(43, ALICE, "phone");
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+        when(apiKeyService.generate(eq(ALICE), eq("phone"), eq(null)))
+                .thenReturn(new GeneratedApiKey("ap_X", persisted));
+
+        mockMvc.perform(post("/apikeySettings/generate").param("name", "  phone  ").with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        verify(apiKeyService).generate(ALICE, "phone", null);
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_blankName_doesNotCallServiceAndFlashesError() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+
+        mockMvc.perform(post("/apikeySettings/generate").param("name", "   ").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/apikeySettings.view"))
+                .andExpect(flash().attribute("settings_toast", false))
+                .andExpect(flash().attribute("apikey_error", "apikeysettings.error.nameRequired"));
+
+        verify(apiKeyService, never()).generate(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_overlongName_doesNotCallServiceAndFlashesError() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+        String tooLong = "x".repeat(ApiKeySettingsController.MAX_NAME_LENGTH + 1);
+
+        mockMvc.perform(post("/apikeySettings/generate").param("name", tooLong).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/apikeySettings.view"))
+                .andExpect(flash().attribute("settings_toast", false))
+                .andExpect(flash().attribute("apikey_error", "apikeysettings.error.nameTooLong"));
+
+        verify(apiKeyService, never()).generate(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_pastExpiresAt_doesNotCallServiceAndFlashesError() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+
+        mockMvc.perform(post("/apikeySettings/generate")
+                        .param("name", "phone")
+                        .param("expiresAt", "1970-01-01T00:00")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(flash().attribute("settings_toast", false))
+                .andExpect(flash().attribute("apikey_error", "apikeysettings.error.expiresInPast"));
+
+        verify(apiKeyService, never()).generate(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_invalidExpiresAt_doesNotCallServiceAndFlashesError() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+
+        mockMvc.perform(post("/apikeySettings/generate")
+                        .param("name", "phone")
+                        .param("expiresAt", "not-a-date")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(flash().attribute("settings_toast", false))
+                .andExpect(flash().attribute("apikey_error", "apikeysettings.error.expiresInvalid"));
+
+        verify(apiKeyService, never()).generate(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_withValidExpiresAt_passesInstantToService() throws Exception {
+        ApiKey persisted = key(44, ALICE, "phone");
+        when(apiKeyService.list(ALICE)).thenReturn(List.of());
+        when(apiKeyService.generate(eq(ALICE), eq("phone"), any(Instant.class)))
+                .thenReturn(new GeneratedApiKey("ap_X", persisted));
+
+        mockMvc.perform(post("/apikeySettings/generate")
+                        .param("name", "phone")
+                        .param("expiresAt", "2099-01-01T00:00")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<Instant> instantCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(apiKeyService).generate(eq(ALICE), eq("phone"), instantCaptor.capture());
+        assertThat(instantCaptor.getValue()).isNotNull();
+    }
+
+    // ---------- revoke / IDOR ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void revoke_ownedId_callsService() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(key(5, ALICE, "phone")));
+
+        mockMvc.perform(post("/apikeySettings/revoke").param("id", "5").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/apikeySettings.view"))
+                .andExpect(flash().attribute("settings_toast", true));
+
+        verify(apiKeyService).revoke(5);
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void revoke_notOwnedId_doesNotCallService_idorBlocked() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(key(5, ALICE, "phone")));
+
+        mockMvc.perform(post("/apikeySettings/revoke").param("id", "99").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/apikeySettings.view"))
+                .andExpect(flash().attribute("settings_toast", false));
+
+        verify(apiKeyService, never()).revoke(any());
+    }
+
+    // ---------- setEnabled / IDOR ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void setEnabled_ownedId_callsService() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(key(5, ALICE, "phone")));
+
+        mockMvc.perform(post("/apikeySettings/setEnabled")
+                        .param("id", "5")
+                        .param("enabled", "false")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(flash().attribute("settings_toast", true));
+
+        verify(apiKeyService).setEnabled(5, false);
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void setEnabled_notOwnedId_doesNotCallService_idorBlocked() throws Exception {
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(key(5, ALICE, "phone")));
+
+        mockMvc.perform(post("/apikeySettings/setEnabled")
+                        .param("id", "99")
+                        .param("enabled", "false")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(flash().attribute("settings_toast", false));
+
+        verify(apiKeyService, never()).setEnabled(any(), eq(false));
+        verify(apiKeyService, never()).setEnabled(any(), eq(true));
+    }
+
+    // ---------- CSRF ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void generate_withoutCsrfToken_isForbidden() throws Exception {
+        mockMvc.perform(post("/apikeySettings/generate").param("name", "phone"))
+                .andExpect(status().isForbidden());
+
+        verify(apiKeyService, never()).generate(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void revoke_withoutCsrfToken_isForbidden() throws Exception {
+        mockMvc.perform(post("/apikeySettings/revoke").param("id", "5"))
+                .andExpect(status().isForbidden());
+
+        verify(apiKeyService, never()).revoke(any());
+    }
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void setEnabled_withoutCsrfToken_isForbidden() throws Exception {
+        mockMvc.perform(post("/apikeySettings/setEnabled")
+                        .param("id", "5")
+                        .param("enabled", "false"))
+                .andExpect(status().isForbidden());
+
+        verify(apiKeyService, never()).setEnabled(any(), eq(false));
+        verify(apiKeyService, never()).setEnabled(any(), eq(true));
+    }
+
+    // ---------- Show-once flash semantics ----------
+
+    @Test
+    @WithMockUser(username = ALICE)
+    void freshlyGeneratedKey_reachesNextGetThenIsGone() throws Exception {
+        ApiKey persisted = key(50, ALICE, "phone");
+        when(apiKeyService.list(ALICE)).thenReturn(List.of(persisted));
+        when(apiKeyService.generate(eq(ALICE), eq("phone"), eq(null)))
+                .thenReturn(new GeneratedApiKey("ap_SECRET", persisted));
+
+        // POST seeds the flash...
+        MvcResult post = mockMvc.perform(post("/apikeySettings/generate")
+                        .param("name", "phone").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+        // ...next GET sees it as a model attribute (auto-pulled from FlashMap)...
+        MvcResult firstGet = mockMvc.perform(get("/apikeySettings.view")
+                        .session((org.springframework.mock.web.MockHttpSession) post.getRequest().getSession()))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("freshlyGeneratedKey", "ap_SECRET"))
+                .andReturn();
+
+        // ...and the GET after that does NOT (Spring removes the flash after consumption).
+        Map<String, Object> secondGetModel = mockMvc.perform(get("/apikeySettings.view")
+                        .session((org.springframework.mock.web.MockHttpSession) firstGet.getRequest().getSession()))
+                .andExpect(status().isOk())
+                .andReturn().getModelAndView().getModel();
+        assertThat(secondGetModel).doesNotContainKey("freshlyGeneratedKey");
+        assertThat(secondGetModel).doesNotContainKey("freshlyGeneratedName");
+    }
+}


### PR DESCRIPTION
Third of the apiKeyAuthentication PRs (#145): a Thymeleaf settings page where the logged-in user generates, lists, and revokes their own apiKeys, with the raw key shown exactly once at generation. PR-D adds the legacy-auth deprecation warning and closes the bundle.

ApiKeySettingsController mirrors the existing settings-page idiom -- GET lists the authenticated user's keys (metadata only); POST /generate creates a key and passes the raw key once via RedirectAttributes flash so it survives the redirect, renders Thymeleaf-escaped, then Spring clears the flash entry; POST /revoke and /setEnabled load the key and verify it belongs to the authenticated user before any state change. The ownership check uses apiKeyService.list(username).anyMatch on the id; a non-owned id is a silent no-op, not a 403 -- no enumeration oracle on the auto-increment id space. All three state-changing POSTs are CSRF-protected and gated by hasRole(SETTINGS) on both /apikeySettings* and /apikeySettings/** -- the sub-path matcher was the auditor's only Important finding; without it the POSTs would have fallen through to the broader USER role.

Server-side guards: name length capped (the client maxlength is bypassable, so the cap is enforced server-side too), expiresAt in the past rejected, all errors returned via i18n keys. JS-context i18n strings use Thymeleaf's [[...]] JS-escaped inlining rather than the unescaped [(...)] form, so a translator introducing an apostrophe can't break the page.

Show-once is the only path the raw key takes -- never persisted beyond the flash render, never logged (only static Rejected API-key log lines, no interpolation). The IDOR test asserts apiKeyService.revoke / setEnabled is never() called when the id isn't owned by the authenticated user.

English message-bundle entries only; other locales fall back. A per-user key cap and generate rate-limit are filed as a follow-up.

Verified four ways: HSQLDB full suite green (1030 floor + 18 new controller tests), ApiKeySettingsControllerTest 18/18 on postgres:16-alpine including the IDOR and CSRF assertions, mvnd verify analyze-only clean with the logback JARs still present in the WAR, and WAR packaging confirmed. Does not close #145.

Part of #145.