### PR TITLE
Add legacy-auth deprecation warning (fixes #145)

### DIFF
--- a/.github/workflows/pm_ci.yml
+++ b/.github/workflows/pm_ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, linux, x64, repo-airsonic-pulse]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Verify environment

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -5,6 +5,7 @@ import org.airsonic.player.service.ApiKeyService;
 import org.airsonic.player.service.JWTSecurityService;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
+import org.airsonic.player.service.cache.LegacyAuthWarningCache;
 import org.airsonic.player.service.sonos.SonosLinkSecurityInterceptor.SonosJWTVerification;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -62,6 +63,9 @@ public class GlobalSecurityConfig {
 
     @Autowired
     private ApiKeyService apiKeyService;
+
+    @Autowired
+    private LegacyAuthWarningCache legacyAuthWarningCache;
 
     @EventListener
     public void loginFailureListener(AbstractAuthenticationFailureEvent event) {
@@ -143,6 +147,7 @@ public class GlobalSecurityConfig {
 
         RESTRequestParameterProcessingFilter restAuthenticationFilter = new RESTRequestParameterProcessingFilter(jaxbWriter);
         restAuthenticationFilter.setAuthenticationManager(authenticationManager);
+        restAuthenticationFilter.setLegacyAuthWarningCache(legacyAuthWarningCache);
 
         // The apiKey filter runs BEFORE the legacy REST filter so that:
         //   1. An apiKey request short-circuits the legacy u/p/t/s reads (the legacy filter

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
@@ -24,6 +24,7 @@ import org.airsonic.player.controller.SubsonicRESTController;
 import org.airsonic.player.controller.SubsonicRESTController.APIException;
 import org.airsonic.player.controller.SubsonicRESTController.ErrorCode;
 import org.airsonic.player.domain.Version;
+import org.airsonic.player.service.cache.LegacyAuthWarningCache;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -68,6 +69,11 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
     );
     private static final Version serverVersion = new Version(JAXBWriter.getRestProtocolVersion());
 
+    static final String LEGACY_METHOD_PASSWORD = "legacy username/password";
+    static final String LEGACY_METHOD_SALTED_TOKEN = "legacy token+salt";
+
+    private LegacyAuthWarningCache legacyAuthWarningCache;
+
     protected RESTRequestParameterProcessingFilter(RequestMatcher requiresAuthenticationRequestMatcher, JAXBWriter jaxbWriter) {
         super(requiresAuthenticationRequestMatcher);
         setAuthenticationFailureHandler(new RESTAuthenticationFailureHandler(jaxbWriter));
@@ -77,6 +83,14 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
 
     public RESTRequestParameterProcessingFilter(JAXBWriter jaxbWriter) {
         this(requiresAuthenticationRequestMatcher, jaxbWriter);
+    }
+
+    /**
+     * Wire the deprecation-warning throttle. Optional — when unset, the post-auth hook
+     * silently skips the warning step (used by tests that exercise only the auth path).
+     */
+    public void setLegacyAuthWarningCache(LegacyAuthWarningCache legacyAuthWarningCache) {
+        this.legacyAuthWarningCache = legacyAuthWarningCache;
     }
 
     @Override
@@ -138,8 +152,51 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
             Authentication authResult) throws IOException, ServletException {
         super.successfulAuthentication(request, response, chain, authResult);
+        maybeWarnLegacyAuth(request, authResult);
         // carry on with the request
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Identify legacy {@code u/p} or {@code t/s} use by inspecting the request parameters
+     * directly. The token class is not a reliable signal: this method also runs when
+     * {@link #attemptAuthentication} short-circuits to a previously-authenticated context
+     * (apiKey or HTTP Basic), in which case {@code authResult} is whatever token the prior
+     * filter installed — not a legacy token. The legacy-Subsonic params, however, are only
+     * present when the caller is actually using {@code u/p} or {@code t/s}.
+     */
+    void maybeWarnLegacyAuth(HttpServletRequest request, Authentication authResult) {
+        if (legacyAuthWarningCache == null || authResult == null) {
+            return;
+        }
+        String method = identifyLegacyAuthMethod(request);
+        if (method == null) {
+            return;
+        }
+        String username = StringUtils.trimToNull(authResult.getName());
+        if (username == null) {
+            return;
+        }
+        String client = StringUtils.trimToNull(request.getParameter("c"));
+        if (client == null) {
+            return;
+        }
+        legacyAuthWarningCache.warnIfFirstSeen(username, client, method);
+    }
+
+    static String identifyLegacyAuthMethod(HttpServletRequest request) {
+        if (StringUtils.trimToNull(request.getParameter("u")) == null) {
+            return null;
+        }
+        String t = StringUtils.trimToNull(request.getParameter("t"));
+        String s = StringUtils.trimToNull(request.getParameter("s"));
+        if (t != null && s != null) {
+            return LEGACY_METHOD_SALTED_TOKEN;
+        }
+        if (StringUtils.trimToNull(request.getParameter("p")) != null) {
+            return LEGACY_METHOD_PASSWORD;
+        }
+        return null;
     }
 
     public static String decrypt(String s) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/cache/LegacyAuthWarningCache.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/cache/LegacyAuthWarningCache.java
@@ -1,0 +1,141 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.service.cache;
+
+import org.airsonic.player.spring.CacheConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.cache.CacheManager;
+
+/**
+ * Throttle + emitter for the legacy-authentication deprecation warning (issue #145).
+ *
+ * When a /rest/ request successfully authenticates via legacy {@code u}/{@code p} or
+ * {@code t}/{@code s} parameters, the filter calls {@link #warnIfFirstSeen} with the
+ * authenticated username, the Subsonic {@code c=} client identifier, and the method label.
+ * The first call for a given {@code (username, client, method)} within the cache's 24h TTL
+ * emits a WARN log; subsequent calls inside the window are suppressed.
+ *
+ * The throttle key intentionally excludes IP and User-Agent so the log message can be
+ * produced without those fields ever entering scope, and so the cache keyspace stays bounded
+ * by the realistic count of distinct {@code (user, client, method)} tuples a deployment sees
+ * in a day. The bounded heap on the underlying EhCache entry (10000 entries) is the DoS guard
+ * against a client cycling its {@code c=} value.
+ */
+@Component
+public class LegacyAuthWarningCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyAuthWarningCache.class);
+
+    // Unit Separator (U+001F). Inputs are sanitized to strip ALL ISO controls before key
+    // construction, so the separator is guaranteed not to appear inside any component and
+    // the (user, client, method) tuple cannot be ambiguously decoded.
+    private static final char SEPARATOR = 0x1f;
+
+    // Cap per-field length before concatenating the cache key. The realistic upper bound for
+    // a Subsonic username or client string is well under 256; an authenticated attacker who
+    // can submit pathologically long values cannot inflate per-entry footprint past this.
+    static final int MAX_FIELD_LENGTH = 256;
+
+    private final CacheManager cacheManager;
+
+    public LegacyAuthWarningCache(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    /**
+     * Emit a single throttled WARN for the given (username, client, method) tuple. Returns
+     * {@code true} if a log line was emitted, {@code false} if the tuple was already cached
+     * (suppressed). The message names the method and points at the apiKey replacement with
+     * {@code #56} as the targeted-removal reference; it intentionally contains no password,
+     * token, salt, IP, or User-Agent.
+     */
+    public boolean warnIfFirstSeen(String username, String client, String method) {
+        if (username == null || username.isBlank() || client == null || client.isBlank() || method == null) {
+            return false;
+        }
+        // Treat pathological inputs as already-throttled: an authenticated attacker can submit
+        // arbitrarily long u=/c= values up to Tomcat's header limit; clamping here keeps per-
+        // entry footprint bounded regardless of the LRU cap.
+        if (username.length() > MAX_FIELD_LENGTH || client.length() > MAX_FIELD_LENGTH
+                || method.length() > MAX_FIELD_LENGTH) {
+            return false;
+        }
+        // Sanitize before BOTH key construction and log emission so a CRLF or U+001F in the
+        // raw input cannot inject log lines or collide cache keys.
+        String safeUsername = sanitize(username);
+        String safeClient = sanitize(client);
+        String safeMethod = sanitize(method);
+        String key = safeUsername + SEPARATOR + safeClient + SEPARATOR + safeMethod;
+        javax.cache.Cache<String, Boolean> cache = cacheManager.getCache(
+                CacheConfiguration.LEGACY_AUTH_WARNING_CACHE, String.class, Boolean.class);
+        if (cache == null) {
+            // Cache manager unavailable (test paths that don't wire it). Emit the warn — the
+            // throttle is a courtesy, not a correctness guarantee, and skipping it here is
+            // safer than silently dropping the deprecation notice.
+            logWarn(safeMethod, safeUsername, safeClient);
+            return true;
+        }
+        if (cache.putIfAbsent(key, Boolean.TRUE)) {
+            logWarn(safeMethod, safeUsername, safeClient);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Test-only: clear the throttle so a previously-suppressed tuple emits again on the next
+     * call. Package-private so no admin/controller surface can reset suppression at runtime.
+     */
+    void clear() {
+        javax.cache.Cache<String, Boolean> cache = cacheManager.getCache(
+                CacheConfiguration.LEGACY_AUTH_WARNING_CACHE, String.class, Boolean.class);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    /**
+     * Replace every ISO control character (CR, LF, NUL, TAB, U+001F, ...) with U+FFFD so a
+     * malicious value cannot inject a synthetic log line into the operator log or collide a
+     * cache key by embedding the {@link #SEPARATOR}. The substitution character is preserved
+     * verbatim so the operator can see something was scrubbed.
+     */
+    static String sanitize(String s) {
+        if (s == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            sb.append(Character.isISOControl(c) ? '�' : c);
+        }
+        return sb.toString();
+    }
+
+    private static void logWarn(String method, String username, String client) {
+        LOG.warn("Deprecated authentication method used: {} (user={}, client={}). "
+                + "Generate an API key in Personal Settings -> API Keys and switch the client "
+                + "to the OpenSubsonic apiKey extension. Legacy u/p and t+s authentication "
+                + "is targeted for removal in 13.3.x (see #56) or a later 13.x.x release.",
+                method, username, client);
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/CacheConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/CacheConfiguration.java
@@ -45,6 +45,7 @@ public class CacheConfiguration {
     public static final String PLAYLIST_CACHE = "playlistCache";
     public static final String PLAYLIST_USERS_CACHE = "playlistUsersCache";
     public static final String ARTIST_BY_NAME_CACHE = "artistByNameCache";
+    public static final String LEGACY_AUTH_WARNING_CACHE = "legacyAuthWarningCache";
 
 
     @Autowired
@@ -115,6 +116,16 @@ public class CacheConfiguration {
                 // lookups, so caching misses is the load-bearing part of this cache.
                 .withCache(ARTIST_BY_NAME_CACHE,
                         CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, Optional.class, artistByNamePools)
+                                .withClassLoader(cl)
+                                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofDays(1)))
+                                .withService(cacheLogging))
+                // Per-(user, client, method) suppression marker for the legacy-auth deprecation
+                // WARN (#145). Bounded heap is the DoS guard against an attacker varying client
+                // strings to balloon the entry count; the 24h TTL keeps the warning useful while
+                // not spamming operator logs. Value is Boolean.TRUE (JSR-107 forbids null values
+                // and the presence/absence of the key is the only signal).
+                .withCache(LEGACY_AUTH_WARNING_CACHE,
+                        CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, Boolean.class, artistByNamePools)
                                 .withClassLoader(cl)
                                 .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofDays(1)))
                                 .withService(cacheLogging))

--- a/airsonic-main/src/test/java/org/airsonic/player/security/RESTRequestParameterProcessingFilterDeprecationTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/RESTRequestParameterProcessingFilterDeprecationTest.java
@@ -1,0 +1,218 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.controller.JAXBWriter;
+import org.airsonic.player.service.cache.LegacyAuthWarningCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Drives {@link RESTRequestParameterProcessingFilter#maybeWarnLegacyAuth} directly with a
+ * mock {@link LegacyAuthWarningCache} so the test concentrates on the legacy-auth-detection
+ * logic without running the full {@link org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter}
+ * machinery. Spring-Security guarantees the hook fires after any successful authentication;
+ * the responsibility of this filter's hook is to identify the legacy-Subsonic case and emit
+ * the deprecation warn for it alone.
+ */
+@ExtendWith(MockitoExtension.class)
+class RESTRequestParameterProcessingFilterDeprecationTest {
+
+    @Mock
+    private JAXBWriter jaxbWriter;
+
+    @Mock
+    private LegacyAuthWarningCache cache;
+
+    private RESTRequestParameterProcessingFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new RESTRequestParameterProcessingFilter(jaxbWriter);
+        filter.setLegacyAuthWarningCache(cache);
+    }
+
+    private Authentication authFor(String name) {
+        return new UsernamePasswordAuthenticationToken(name, null, List.of());
+    }
+
+    @Test
+    void legacyPasswordAuth_emitsDeprecationWarn() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("p", "secret");
+        request.setParameter("c", "DSub");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verify(cache).warnIfFirstSeen(eq("alice"), eq("DSub"),
+                eq(RESTRequestParameterProcessingFilter.LEGACY_METHOD_PASSWORD));
+    }
+
+    @Test
+    void legacySaltedTokenAuth_emitsDeprecationWarn() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("t", "abc123");
+        request.setParameter("s", "saltsalt");
+        request.setParameter("c", "Symfonium");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verify(cache).warnIfFirstSeen(eq("alice"), eq("Symfonium"),
+                eq(RESTRequestParameterProcessingFilter.LEGACY_METHOD_SALTED_TOKEN));
+    }
+
+    @Test
+    void apiKeyRequest_doesNotEmitDeprecationWarn() {
+        // Pure apiKey request: no u/p/t/s params; only c= is present (clients identify
+        // themselves with c= regardless of auth method).
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("c", "Symfonium");
+        request.addHeader("Authorization", "Bearer ap_some_key");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void basicAuthOnRestPath_doesNotEmitDeprecationWarn() {
+        // HTTP Basic on a /rest/ URL: BasicAuthenticationFilter has already populated the
+        // SecurityContext; legacy filter early-exits with the existing auth. No u/p/t/s
+        // in the request, so the hook stays silent.
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("c", "DSub");
+        request.addHeader("Authorization", "Basic YWxpY2U6c2VjcmV0");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void requestWithUsernameButNoCredentials_doesNotEmitDeprecationWarn() {
+        // u= present but no p, t, or s. This should not happen in practice because
+        // attemptAuthentication rejects with MISSING_PARAMETER, but the hook must be
+        // robust.
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("c", "DSub");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void nullAuthResult_doesNotEmitDeprecationWarn() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("p", "secret");
+        request.setParameter("c", "DSub");
+
+        filter.maybeWarnLegacyAuth(request, null);
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void missingClient_doesNotEmitDeprecationWarn() {
+        // No c= — RESTRequestParameterProcessingFilter.attemptAuthentication rejects this
+        // with MISSING_PARAMETER before successfulAuthentication can fire, but the hook
+        // guards against the case defensively. (Throttle key needs a client.)
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("p", "secret");
+
+        filter.maybeWarnLegacyAuth(request, authFor("alice"));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void cacheUnset_isANoOp() {
+        // setLegacyAuthWarningCache was never called → no NPE on the hook.
+        RESTRequestParameterProcessingFilter unwiredFilter =
+                new RESTRequestParameterProcessingFilter(jaxbWriter);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("p", "secret");
+        request.setParameter("c", "DSub");
+
+        // Should not throw and should not (cannot) touch the cache.
+        unwiredFilter.maybeWarnLegacyAuth(request, authFor("alice"));
+        verify(cache, never()).warnIfFirstSeen(any(), any(), any());
+    }
+
+    @Test
+    void blankUsername_doesNotEmitDeprecationWarn() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("u", "alice");
+        request.setParameter("p", "secret");
+        request.setParameter("c", "DSub");
+
+        filter.maybeWarnLegacyAuth(request, authFor("   "));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    void identifyLegacyAuthMethod_classifies_passwordAndSaltedToken() {
+        MockHttpServletRequest pw = new MockHttpServletRequest();
+        pw.setParameter("u", "alice");
+        pw.setParameter("p", "secret");
+        org.junit.jupiter.api.Assertions.assertEquals(
+                RESTRequestParameterProcessingFilter.LEGACY_METHOD_PASSWORD,
+                RESTRequestParameterProcessingFilter.identifyLegacyAuthMethod(pw));
+
+        MockHttpServletRequest ts = new MockHttpServletRequest();
+        ts.setParameter("u", "alice");
+        ts.setParameter("t", "abc");
+        ts.setParameter("s", "salt");
+        org.junit.jupiter.api.Assertions.assertEquals(
+                RESTRequestParameterProcessingFilter.LEGACY_METHOD_SALTED_TOKEN,
+                RESTRequestParameterProcessingFilter.identifyLegacyAuthMethod(ts));
+
+        // t+s preferred when both present alongside p (matches attemptAuthentication's order)
+        MockHttpServletRequest both = new MockHttpServletRequest();
+        both.setParameter("u", "alice");
+        both.setParameter("p", "secret");
+        both.setParameter("t", "abc");
+        both.setParameter("s", "salt");
+        org.junit.jupiter.api.Assertions.assertEquals(
+                RESTRequestParameterProcessingFilter.LEGACY_METHOD_SALTED_TOKEN,
+                RESTRequestParameterProcessingFilter.identifyLegacyAuthMethod(both));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/cache/LegacyAuthWarningCacheTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/cache/LegacyAuthWarningCacheTest.java
@@ -1,0 +1,218 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.service.cache;
+
+import org.airsonic.player.spring.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.jsr107.EhcacheCachingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Real-EhCache integration test for {@link LegacyAuthWarningCache}: drives a tiny
+ * heap-only cache with the same key/value types and TTL semantics the production
+ * {@link CacheConfiguration} declares, then exercises the throttle and verifies the
+ * WARN log content via a logback {@link ch.qos.logback.core.read.ListAppender}.
+ *
+ * The full-suite test suite already covers the cache wiring through Spring; this test
+ * focuses on the behavior: first call logs, second call inside the window suppresses,
+ * and the log message contains none of password / token / salt / IP / User-Agent.
+ */
+class LegacyAuthWarningCacheTest {
+
+    private CacheManager cacheManager;
+    private LegacyAuthWarningCache cache;
+    private ch.qos.logback.classic.Logger logger;
+    private ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        EhcacheCachingProvider provider =
+                (EhcacheCachingProvider) Caching.getCachingProvider("org.ehcache.jsr107.EhcacheCachingProvider");
+        ResourcePoolsBuilder pools = ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .heap(100L, EntryUnit.ENTRIES);
+        cacheManager = provider.getCacheManager(
+                provider.getDefaultURI(),
+                ConfigurationBuilder.newConfigurationBuilder()
+                        .withCache(CacheConfiguration.LEGACY_AUTH_WARNING_CACHE,
+                                CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                                                String.class, Boolean.class, pools)
+                                        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofDays(1))))
+                        .build());
+        cache = new LegacyAuthWarningCache(cacheManager);
+
+        logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(LegacyAuthWarningCache.class);
+        appender = new ch.qos.logback.core.read.ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        cacheManager.close();
+    }
+
+    private List<String> warnMessages() {
+        return appender.list.stream()
+                .filter(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN)
+                .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    @Test
+    void firstCall_emitsWarn() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(1);
+    }
+
+    @Test
+    void secondCallSameKey_isSuppressed() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(1);
+    }
+
+    @Test
+    void differentClient_emitsAgain() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertTrue(cache.warnIfFirstSeen("alice", "Symfonium", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(2);
+    }
+
+    @Test
+    void differentUser_emitsAgain() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertTrue(cache.warnIfFirstSeen("bob", "DSub", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(2);
+    }
+
+    @Test
+    void differentMethod_emitsAgain() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy token+salt"));
+        assertThat(warnMessages()).hasSize(2);
+    }
+
+    @Test
+    void nullOrBlankInputs_doNothing() {
+        assertFalse(cache.warnIfFirstSeen(null, "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("", "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("   ", "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", null, "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", "", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", "DSub", null));
+        assertThat(warnMessages()).isEmpty();
+    }
+
+    @Test
+    void clear_allowsImmediateReEmit() {
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        cache.clear();
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(2);
+    }
+
+    @Test
+    void warnMessage_scrubsControlCharsToPreventLogInjection() {
+        // A username containing CR+LF + a fake-WARN payload must NOT produce a synthetic log
+        // line. The sanitizer replaces every ISO-control character with U+FFFD before SLF4J
+        // substitution.
+        String evil = "alice\r\n2026-05-29 12:00:00 WARN Fake-line-injected";
+        cache.warnIfFirstSeen(evil, "DSub", "legacy username/password");
+        assertThat(warnMessages()).hasSize(1);
+        String message = warnMessages().get(0);
+        assertFalse(message.contains("\r"), "CR must be scrubbed");
+        assertFalse(message.contains("\n"), "LF must be scrubbed");
+        // The literal payload text survives (we don't strip data, only control chars), but
+        // it's now all one line, so a downstream log parser sees it as a single entry whose
+        // username contains junk — not as a separate WARN line.
+        assertEquals(1, message.split("\n", -1).length, "must remain a single log line");
+        // The scrubbed char appears, so the operator can see something was substituted.
+        assertThat(message).contains("�");
+    }
+
+    @Test
+    void cacheKey_doesNotCollideOnU001fInUsername() {
+        // Without sanitization, alice + U+001F + DSub + ... would collide with alice|DSub|...
+        // The sanitizer replaces U+001F with U+FFFD before key construction, eliminating
+        // the collision and making both calls fresh.
+        String evil = "aliceDSublegacy username/password";
+        assertTrue(cache.warnIfFirstSeen(evil, "x", "legacy username/password"));
+        assertTrue(cache.warnIfFirstSeen("alice", "DSub", "legacy username/password"));
+        assertThat(warnMessages()).hasSize(2);
+    }
+
+    @Test
+    void overlongInputs_areTreatedAsAlreadySeen() {
+        String tooLong = "x".repeat(LegacyAuthWarningCache.MAX_FIELD_LENGTH + 1);
+        assertFalse(cache.warnIfFirstSeen(tooLong, "DSub", "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", tooLong, "legacy username/password"));
+        assertFalse(cache.warnIfFirstSeen("alice", "DSub", tooLong));
+        assertThat(warnMessages()).isEmpty();
+    }
+
+    @Test
+    void warnMessage_containsNoSecrets() {
+        // Caller would never pass the password/token/salt/IP/UA to this method — the API doesn't
+        // accept them. This test locks the message template so a future refactor that starts
+        // including more context doesn't accidentally leak credentials or surveilling metadata.
+        String password = "hunter2";
+        String token = "abc123token";
+        String salt = "saltsalt";
+        String ip = "203.0.113.99";
+        String userAgent = "DSub/1.0 (Linux; Android 9)";
+
+        cache.warnIfFirstSeen("alice", "DSub", "legacy username/password");
+        cache.warnIfFirstSeen("bob", "Symfonium", "legacy token+salt");
+
+        for (String message : warnMessages()) {
+            assertFalse(message.contains(password), "WARN message must not contain a password");
+            assertFalse(message.contains(token), "WARN message must not contain a token");
+            assertFalse(message.contains(salt), "WARN message must not contain a salt");
+            assertFalse(message.contains(ip), "WARN message must not contain an IP");
+            assertFalse(message.contains(userAgent), "WARN message must not contain a User-Agent");
+        }
+        // Sanity: the message does name the deprecation and references apiKey + #56, and
+        // states the 13.3.x removal target with the "or a later 13.x.x release" softener
+        // to match the release-notes Highlights wording.
+        assertThat(warnMessages()).allMatch(m -> m.contains("apiKey")
+                && m.contains("#56")
+                && m.contains("13.3.x")
+                && m.contains("or a later 13.x.x release")
+                && (m.contains("legacy username/password") || m.contains("legacy token+salt")));
+    }
+}

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -1,5 +1,19 @@
 # Airsonic-Pulse v13.2.0
 
+## Highlights
+
+### API key authentication available (#145)
+
+The OpenSubsonic `apiKeyAuthentication` extension is now implemented end-to-end. Each user manages their own keys under **Personal Settings → API Keys** (generate, disable, revoke). A generated key is shown exactly once at creation; only its HMAC-SHA-256 hash (peppered with a server-side secret) is stored. Clients authenticate by sending the key as `Authorization: Bearer <key>` or as an `apiKey=` query parameter — the legacy `u`/`p` and `t`/`s` parameters continue to work unchanged.
+
+This is the underlying primitive, not an automatic security upgrade. Existing deployments stay on whatever authentication their clients use today; switching an individual client to API keys is a per-client opt-in. The benefit is that long-lived passwords and the deprecated MD5-salted-token derivative stop being part of every API call, and a leaked key can be revoked from the UI without forcing a password change.
+
+### Legacy authentication deprecated (#145)
+
+The Subsonic `u`/`p` (username + plaintext password) and `t`/`s` (MD5-salted token) authentication methods are deprecated in favor of the API key authentication described above. Both keep working in 13.2.x with no behavior change. Removal is targeted for 13.3.x as part of #56 — that target is movable based on client-ecosystem readiness.
+
+The server now emits a single throttled WARN to the operator log the first time each `(user, client)` pair authenticates via a legacy method within a 24-hour window: it names the method (`legacy username/password` or `legacy token+salt`), points operators at API keys as the replacement, and references #56. The log line intentionally contains no password, token, salt, IP, or User-Agent. Subsequent requests within the throttle window are silent. The warning fires only for legacy authentication — successful API-key requests do not trigger it.
+
 ## Library rescan required
 
 * #135 introduces a `sortName` column on `media_file` populated from `FieldKey.TITLE_SORT`.


### PR DESCRIPTION
Closes the #145 apiKeyAuthentication bundle. PR-A shipped the storage, PR-B the auth wiring, PR-C the self-service UI; this last piece adds the operator nudge for legacy authentication and the user-facing release-notes Highlights for both apiKey availability and the legacy deprecation.

A new LEGACY_AUTH_WARNING_CACHE (existing JCache/EhCache infrastructure, 24h TTL) backs a single throttled WARN log emitted from RESTRequestParameterProcessingFilter.successfulAuthentication on the first legacy authentication per (user, client) within the window. The hook distinguishes legacy auth by request parameters (u + (p OR (t AND s))) -- NOT by the authenticated token class -- because successfulAuthentication fires for any non-null Authentication result, including pre-authed apiKey and Basic requests. Request-param discrimination is the robust signal and naturally bypasses apiKey-only requests.

The WARN line names the method (legacy username/password or legacy token+salt), points operators at the new Personal Settings -> API Keys page, and references #56 with soft timing. Inputs are sanitized (Character.isISOControl -> U+FFFD) before both log substitution and cache-key concatenation, which defeats CRLF log injection via the username and collision attacks via U+001F on the throttle separator; a MAX_FIELD_LENGTH = 256 early-reject prevents pathological-length keys from inflating the cache. The log line contains no password, token, salt, IP, or User-Agent.

The existing RESTRequestParameterProcessingFilter.attemptAuthentication logic is byte-unchanged; only a setter, the maybeWarnLegacyAuth helper, and the static identifyLegacyAuthMethod were added.

Verified four ways: HSQLDB full suite green, the new deprecation and throttle tests pass on postgres:16-alpine, mvnd verify analyze-only clean with the logback JARs still present in the WAR, and WAR packaging confirmed. The explicit security assertions are locked: apiKey-authed requests do not emit the warning, the WARN message contains no password/token/salt/IP/UA, CRLF in the username is scrubbed, and embedded U+001F doesn't collide with the throttle separator.

fixes #145