### PR TITLE
fix: bound playlist watcher fan-out and debounce events (fixes #215)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistFileService.java
@@ -38,6 +38,7 @@ public class PlaylistFileService {
     private final SettingsService settingsService;
     private final UserRepository userRepository;
     private final PathWatcherService pathWatcherService;
+    private final PlaylistImportThrottle importThrottle;
     private final List<PlaylistExportHandler> exportHandlers;
     private final List<PlaylistImportHandler> importHandlers;
 
@@ -45,12 +46,14 @@ public class PlaylistFileService {
                                SettingsService settingsService,
                                UserRepository userRepository,
                                PathWatcherService pathWatcherService,
+                               PlaylistImportThrottle importThrottle,
                                List<PlaylistExportHandler> exportHandlers,
                                List<PlaylistImportHandler> importHandlers) {
         this.playlistService = playlistService;
         this.settingsService = settingsService;
         this.userRepository = userRepository;
         this.pathWatcherService = pathWatcherService;
+        this.importThrottle = importThrottle;
         this.exportHandlers = exportHandlers;
         this.importHandlers = importHandlers;
     }
@@ -75,7 +78,13 @@ public class PlaylistFileService {
 
     private void handleModifiedPlaylist(Path path, WatchEvent<Path> event) {
         Path fullPath = path.resolve(event.context());
-        importPlaylist(fullPath, playlistService.getAllPlaylists());
+        // Coalesce filesystem-event bursts for the same path and bound concurrent imports
+        // against the HikariCP pool (issue #215). The Runnable evaluates
+        // getAllPlaylists() only when the debounce window elapses and a permit is
+        // acquired, so a 35,000-event rsync becomes at most one DB-fetch + one import
+        // per distinct file.
+        importThrottle.submit(fullPath,
+                () -> importPlaylist(fullPath, playlistService.getAllPlaylists()));
     }
 
     public void importPlaylists() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistImportThrottle.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistImportThrottle.java
@@ -1,0 +1,175 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.service;
+
+import org.airsonic.player.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PreDestroy;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-path debounce and bounded fan-out around the playlist folder watcher (issue #215).
+ *
+ * <p>Filesystem events for the same path within {@link #DEFAULT_DEBOUNCE_WINDOW_MS} are
+ * coalesced into a single import task; at most {@link #DEFAULT_MAX_IN_FLIGHT} import tasks
+ * run concurrently and the rest queue at the {@link Semaphore} (no carrier-thread cost).
+ * Import tasks run on virtual threads so they remain consistent with the project-wide
+ * virtual-thread commitment; the bound comes from the semaphore, not the executor.
+ *
+ * <p>Bounds were chosen against {@code spring.datasource.hikari.maximum-pool-size=20}: a
+ * cap of 8 (= {@code min(20/2, 8)}) lets a watcher-triggered storm use at most 40% of the
+ * pool, leaving the scanner, REST handlers, and scrobblers room to make progress. The 1s
+ * debounce matches the SMB-rsync burst characteristics reported in #215 (NIO's
+ * {@code WatchService} does not surface inotify {@code CLOSE_WRITE}, so a time-based
+ * quiet-period is the practical signal that a file write has settled).
+ */
+@Component
+class PlaylistImportThrottle {
+    private static final Logger LOG = LoggerFactory.getLogger(PlaylistImportThrottle.class);
+
+    static final long DEFAULT_DEBOUNCE_WINDOW_MS = 1000L;
+    static final int DEFAULT_MAX_IN_FLIGHT = 8;
+    private static final long SHUTDOWN_TIMEOUT_MS = 5000L;
+
+    private final ConcurrentMap<Path, ScheduledFuture<?>> pending = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduler;
+    private final Semaphore semaphore;
+    private final long debounceWindowMs;
+    private final int maxInFlight;
+    private volatile boolean shuttingDown = false;
+
+    @Autowired
+    PlaylistImportThrottle() {
+        this(DEFAULT_DEBOUNCE_WINDOW_MS, DEFAULT_MAX_IN_FLIGHT,
+                Executors.newSingleThreadScheduledExecutor(
+                        Util.getDaemonThreadfactory("playlist-watcher-debounce-")));
+    }
+
+    // Package-private for tests: lets a fixture inject a controllable scheduler and tweak
+    // the debounce window / bound without going through Spring or system properties.
+    PlaylistImportThrottle(long debounceWindowMs, int maxInFlight, ScheduledExecutorService scheduler) {
+        this.debounceWindowMs = debounceWindowMs;
+        this.maxInFlight = maxInFlight;
+        this.semaphore = new Semaphore(maxInFlight);
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Coalesce filesystem events for {@code path}: any pending scheduled task for the same
+     * path is cancelled and replaced. When the debounce window elapses without another
+     * event for that path, {@code task} runs on a virtual thread under the bounded
+     * semaphore.
+     */
+    void submit(Path path, Runnable task) {
+        if (this.shuttingDown) {
+            return;
+        }
+        try {
+            // compute() makes the cancel-prior + schedule-new + put-tracking sequence
+            // atomic per key, so concurrent submits for the same path cannot leave a
+            // stranded future scheduled-but-untracked. The selfRef holder gives fire()
+            // an identity it can use to do a conditional remove from the map.
+            this.pending.compute(path, (k, prior) -> {
+                if (prior != null) {
+                    prior.cancel(false);
+                }
+                ScheduledFuture<?>[] selfRef = new ScheduledFuture<?>[1];
+                selfRef[0] = this.scheduler.schedule(
+                        () -> this.fire(path, selfRef[0], task),
+                        this.debounceWindowMs, TimeUnit.MILLISECONDS);
+                return selfRef[0];
+            });
+        } catch (RejectedExecutionException rejected) {
+            // shutdown() raced ahead of us and closed the scheduler — drop this submit
+            // silently. The NIO watcher thread must not propagate exceptions back into
+            // the WatchService loop.
+        }
+    }
+
+    private void fire(Path path, ScheduledFuture<?> self, Runnable task) {
+        // Remove our entry only if it still points at us — a concurrent submit() may
+        // have replaced it with a fresh future before this method ran, and that one
+        // must stay.
+        this.pending.remove(path, self);
+        Thread.startVirtualThread(() -> runBounded(task));
+    }
+
+    private void runBounded(Runnable task) {
+        try {
+            this.semaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        try {
+            task.run();
+        } catch (Throwable t) {
+            LOG.warn("Playlist import task failed", t);
+        } finally {
+            this.semaphore.release();
+        }
+    }
+
+    int currentInFlight() {
+        return this.maxInFlight - this.semaphore.availablePermits();
+    }
+
+    int pendingScheduled() {
+        return this.pending.size();
+    }
+
+    int maxInFlight() {
+        return this.maxInFlight;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        // Stop admitting new debounce timers, cancel everything pending, drain the
+        // scheduler. In-flight virtual threads (past the semaphore acquire) are not
+        // joined: when Spring closes the DataSource, HikariCP closes the underlying
+        // JDBC connection and the in-flight statement throws SQLException, which the
+        // AspectJ-woven @Transactional advice catches and rolls back. No half-committed
+        // playlist state. Virtual threads do not hold JVM shutdown open.
+        this.shuttingDown = true;
+        this.pending.values().forEach(f -> f.cancel(false));
+        this.pending.clear();
+        this.scheduler.shutdownNow();
+        try {
+            if (!this.scheduler.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                LOG.warn("Playlist import throttle scheduler did not terminate within {}ms",
+                        SHUTDOWN_TIMEOUT_MS);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistFileServiceTestExport.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistFileServiceTestExport.java
@@ -63,6 +63,9 @@ public class PlaylistFileServiceTestExport {
     private PathWatcherService pathWatcherService;
 
     @Mock
+    private PlaylistImportThrottle importThrottle;
+
+    @Mock
     MusicFolder mockedFolder;
 
     @TempDir
@@ -81,6 +84,7 @@ public class PlaylistFileServiceTestExport {
                 settingsService,
                 userRepository,
                 pathWatcherService,
+                importThrottle,
                 new ArrayList<>(List.of(defaultPlaylistExportHandler)),
                 new ArrayList<>());
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistFileServiceTestImport.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistFileServiceTestImport.java
@@ -62,6 +62,9 @@ public class PlaylistFileServiceTestImport {
     private PathWatcherService pathWatcherService;
 
     @Mock
+    private PlaylistImportThrottle importThrottle;
+
+    @Mock
     private PlaylistService playlistService;
 
     @TempDir
@@ -82,6 +85,7 @@ public class PlaylistFileServiceTestImport {
                 settingsService,
                 userRepository,
                 pathWatcherService,
+                importThrottle,
                 Collections.emptyList(),
                 Lists.newArrayList(defaultPlaylistImportHandler));
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistImportThrottleTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistImportThrottleTest.java
@@ -1,0 +1,233 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavior test for {@link PlaylistImportThrottle} (issue #215). Drives the throttle
+ * with a small debounce window and a tight bound so the asserts run in real time but
+ * stay well under any CI timeout. Uses real virtual threads and a real
+ * {@link ScheduledExecutorService} so what gets tested matches what runs in production.
+ */
+class PlaylistImportThrottleTest {
+
+    private static final long DEBOUNCE_MS = 100L;
+    private static final int MAX_IN_FLIGHT = 3;
+    // Headroom for the scheduler thread + virtual-thread start + semaphore acquire under
+    // a loaded CI runner. The debounce itself is DEBOUNCE_MS; the wall-clock budget for
+    // a single submit to complete is DEBOUNCE_MS + this constant.
+    private static final long DELIVERY_HEADROOM_MS = 1500L;
+
+    private ScheduledExecutorService scheduler;
+    private PlaylistImportThrottle throttle;
+
+    @BeforeEach
+    void setUp() {
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "throttle-test-debounce");
+            t.setDaemon(true);
+            return t;
+        });
+        this.throttle = new PlaylistImportThrottle(DEBOUNCE_MS, MAX_IN_FLIGHT, this.scheduler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.throttle.shutdown();
+    }
+
+    @Test
+    void multipleEventsForSamePath_coalesceIntoOneTask() throws Exception {
+        Path path = Paths.get("/tmp/playlist-1.m3u");
+        AtomicInteger runs = new AtomicInteger();
+        CountDownLatch done = new CountDownLatch(1);
+
+        // Fire 20 events for the same path inside the debounce window. Each subsequent
+        // submit must cancel the prior scheduled future and replace it; only the last
+        // one survives to fire.
+        for (int i = 0; i < 20; i++) {
+            this.throttle.submit(path, () -> {
+                runs.incrementAndGet();
+                done.countDown();
+            });
+        }
+
+        assertTrue(done.await(DEBOUNCE_MS + DELIVERY_HEADROOM_MS, TimeUnit.MILLISECONDS),
+                "Coalesced task should have run within the debounce window + headroom");
+        // Give any rogue extra firings a fair chance to land before asserting the count.
+        Thread.sleep(DEBOUNCE_MS);
+        assertEquals(1, runs.get(), "20 events for the same path must coalesce into a single delivery");
+    }
+
+    @Test
+    void eventsForDifferentPaths_eachFireOnce() throws Exception {
+        Path pathA = Paths.get("/tmp/playlist-a.m3u");
+        Path pathB = Paths.get("/tmp/playlist-b.m3u");
+        CountDownLatch latch = new CountDownLatch(2);
+
+        this.throttle.submit(pathA, latch::countDown);
+        this.throttle.submit(pathB, latch::countDown);
+
+        assertTrue(latch.await(DEBOUNCE_MS + DELIVERY_HEADROOM_MS, TimeUnit.MILLISECONDS),
+                "Both paths should deliver; debounce is per-path, not global");
+    }
+
+    @Test
+    void inFlightCount_neverExceedsBound() throws Exception {
+        int submitted = MAX_IN_FLIGHT * 3; // 9 tasks for a bound of 3
+        AtomicInteger observedMax = new AtomicInteger();
+        CountDownLatch allEntered = new CountDownLatch(submitted);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(submitted);
+
+        for (int i = 0; i < submitted; i++) {
+            Path path = Paths.get("/tmp/playlist-" + i + ".m3u");
+            this.throttle.submit(path, () -> {
+                observedMax.accumulateAndGet(this.throttle.currentInFlight(), Math::max);
+                allEntered.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                finished.countDown();
+            });
+        }
+
+        // Wait for the first MAX_IN_FLIGHT tasks to actually be running (i.e. holding
+        // permits and parked on `release`). The rest must be parked on semaphore.acquire().
+        Thread.sleep(DEBOUNCE_MS + DELIVERY_HEADROOM_MS);
+        assertEquals(MAX_IN_FLIGHT, this.throttle.currentInFlight(),
+                "in-flight count should equal the bound while tasks are held");
+
+        // Release the held tasks; everything must eventually finish.
+        release.countDown();
+        assertTrue(allEntered.await(5, TimeUnit.SECONDS),
+                "All submitted tasks should eventually enter the critical section");
+        assertTrue(finished.await(5, TimeUnit.SECONDS),
+                "All submitted tasks should eventually finish");
+        assertTrue(observedMax.get() <= MAX_IN_FLIGHT,
+                "in-flight tasks never exceeded the bound (saw " + observedMax.get() + ")");
+        assertEquals(0, this.throttle.currentInFlight(),
+                "all permits returned after tasks finish");
+    }
+
+    @Test
+    void lateEvent_triggersSecondDelivery() throws Exception {
+        Path path = Paths.get("/tmp/playlist-late.m3u");
+        AtomicInteger runs = new AtomicInteger();
+        CountDownLatch first = new CountDownLatch(1);
+        CountDownLatch second = new CountDownLatch(1);
+
+        this.throttle.submit(path, () -> {
+            runs.incrementAndGet();
+            first.countDown();
+        });
+        assertTrue(first.await(DEBOUNCE_MS + DELIVERY_HEADROOM_MS, TimeUnit.MILLISECONDS),
+                "First delivery should fire within the window");
+
+        // After the first task fires, the pending entry must have been cleared; a fresh
+        // submit for the same path then deserves its own delivery.
+        this.throttle.submit(path, () -> {
+            runs.incrementAndGet();
+            second.countDown();
+        });
+        assertTrue(second.await(DEBOUNCE_MS + DELIVERY_HEADROOM_MS, TimeUnit.MILLISECONDS),
+                "Second delivery after the window should fire as its own task");
+        assertEquals(2, runs.get());
+    }
+
+    @Test
+    void shutdown_cancelsPendingAndDoesNotBlockOrThrow() throws Exception {
+        Path path = Paths.get("/tmp/playlist-pending.m3u");
+        AtomicInteger runs = new AtomicInteger();
+        // Kill the @BeforeEach fixture throttle so this test owns lifecycle entirely;
+        // build a fresh one with a 10s debounce so the timer is guaranteed pending when
+        // we shut it down a few lines later. tearDown() runs shutdown() on the field
+        // again — harmless, ScheduledExecutorService.shutdownNow on a terminated pool
+        // is a no-op.
+        this.throttle.shutdown();
+        ScheduledExecutorService longScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "throttle-shutdown-test");
+            t.setDaemon(true);
+            return t;
+        });
+        PlaylistImportThrottle longThrottle = new PlaylistImportThrottle(
+                10_000L, MAX_IN_FLIGHT, longScheduler);
+        try {
+            for (int i = 0; i < 5; i++) {
+                longThrottle.submit(path, runs::incrementAndGet);
+            }
+            assertEquals(1, longThrottle.pendingScheduled(),
+                    "5 same-path submits should leave exactly one pending future");
+
+            long start = System.nanoTime();
+            longThrottle.shutdown();
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+            assertTrue(elapsedMs < 5_000L,
+                    "shutdown should not block (took " + elapsedMs + "ms)");
+            assertEquals(0, longThrottle.pendingScheduled(),
+                    "all pending futures cleared on shutdown");
+
+            // After shutdown, no late firings should run the task.
+            Thread.sleep(200L);
+            assertEquals(0, runs.get(),
+                    "no late deliveries should run after shutdown");
+        } finally {
+            longThrottle.shutdown();
+        }
+    }
+
+    @Test
+    void submitAfterShutdown_isNoOp() {
+        Path path = Paths.get("/tmp/playlist-post-shutdown.m3u");
+        AtomicInteger runs = new AtomicInteger();
+        this.throttle.shutdown();
+        this.throttle.submit(path, runs::incrementAndGet);
+        assertEquals(0, this.throttle.pendingScheduled(),
+                "submit() after shutdown should not schedule new work");
+        assertEquals(0, runs.get());
+    }
+
+    @Test
+    void bound_isExposedForOperability() {
+        assertEquals(MAX_IN_FLIGHT, this.throttle.maxInFlight());
+        assertEquals(0, this.throttle.currentInFlight(),
+                "fresh throttle reports zero in-flight");
+        assertFalse(this.throttle.pendingScheduled() > 0,
+                "fresh throttle reports nothing pending");
+    }
+
+}


### PR DESCRIPTION
The playlist folder watcher fired DB-touching tasks per filesystem event with two compounding problems: each event spawned an unbounded virtual thread, and there was no debounce of OS event bursts. A large initial scan or a watcher-triggered re-sync of a large library could drain the HikariCP pool and block other requests until the work cleared. Named in the v13.2.0-alpha Known Issues.

## What changed

`PlaylistImportThrottle` wraps each watcher-triggered import in two composing mechanisms:

- **Per-path debounce, 1000ms quiet period.** A `ConcurrentMap<Path, ScheduledFuture<?>>` tracks pending tasks; each new event for path P cancels any pending future for P and schedules a fresh one. A burst of OS events for the same file becomes one logical task.
- **Bounded fan-out, 8 permits.** A `Semaphore` caps concurrent in-flight imports. Sized `min(pool/2, 8)` against the configured HikariCP pool of 20, leaving 11+ connections idle for REST, scrobbler, websocket, and the naturally-serial scanner.

The handler logic in `PlaylistFileService.handleModifiedPlaylist` is unchanged — only the dispatch is throttled. The virtual-thread submission model is preserved throughout. `@PreDestroy` cancels pending scheduled tasks and shuts down the dedicated debounce scheduler cleanly.

## Justifications

- **1000ms debounce floor.** NIO WatchService on Linux accumulates events in the kernel ring buffer and delivers them in batches; 500ms produces second-burst events for the tail of a large rsync. 1000ms is the empirical floor for SMB rsync described in the issue.
- **8-permit bound.** Pool 20 minus headroom for the serial scanner, REST traffic, scrobbler, and websocket. Performance-engineer signed off: watcher burst worst case 8, leaves 11+ idle. Dropping to 4 would halve legitimate-import throughput without safety gain — the harm condition was exhaustion of all 20.
- **Bypass analysis clean.** `MediaScannerService.importPlaylists()` and `GeneralSettingsController` admin-save are the other call sites; both are naturally serial (one connection from the scanner thread or HTTP thread). Watcher is the only flooding path, and it now goes through the gate.

## Tests

`PlaylistImportThrottleTest` — 7 behavior tests covering coalescing, per-path independence, bound enforcement under burst, late-arriving events, shutdown-cancels-pending, post-shutdown rejection, and bound exposure. Floor 1069 → 1076 (HSQLDB). New tests also green against postgres:16-alpine. Analyze-only clean. WAR carries the new class.

## Follow-ups (separate issues)

- `PathWatcherService` still uses an unbounded virtual-thread executor at the generic layer; harmless today because its only consumer is now throttled, but a footgun for any future watcher added to the codebase.
- The bound is currently a compile-time constant; operators with non-default Hikari pool sizes can't tune the watcher.
- Pre-existing: `PlaylistFileService` binds its logger to `PlaylistService.class` rather than itself.