### PR TITLE
OpenSubsonic: ArtistID3 userRating/averageRating (fixes #203)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -55,6 +55,7 @@ public class JaxbContentService {
     private final PlaylistService playlistService;
     private final AlbumService albumService;
     private final MediaFileService mediaFileService;
+    private final MediaFolderService mediaFolderService;
     private final TranscodingService transcodingService;
     private final RatingService ratingService;
     private final SettingsService settingsService;
@@ -66,6 +67,7 @@ public class JaxbContentService {
             PlaylistService playlistService,
             AlbumService albumService,
             MediaFileService mediaFileService,
+            MediaFolderService mediaFolderService,
             TranscodingService transcodingService,
             RatingService ratingService,
             SettingsService settingsService) {
@@ -75,6 +77,7 @@ public class JaxbContentService {
         this.playlistService = playlistService;
         this.albumService = albumService;
         this.mediaFileService = mediaFileService;
+        this.mediaFolderService = mediaFolderService;
         this.transcodingService = transcodingService;
         this.ratingService = ratingService;
         this.settingsService = settingsService;
@@ -91,6 +94,16 @@ public class JaxbContentService {
         jaxbArtist.setMediaType("artist");
         jaxbArtist.setSortName(artist.getSortName());
         jaxbArtist.setMusicBrainzId(artist.getMusicBrainzArtistId());
+        // Ratings key on MediaFile id, so resolve the artist's directory MediaFile (the
+        // physical row that carries rating-eligible ids). Virtual artists derived from
+        // albumArtist tags have no directory and resolve to null; RatingService treats a
+        // null MediaFile as "no rating", so userRating and averageRating come back null
+        // and JAXB omits the attributes — matching the #201 (#179) convention on the
+        // MediaFile-keyed overload.
+        MediaFile artistMediaFile = mediaFileService.getArtistByName(artist.getName(),
+                mediaFolderService.getMusicFoldersForUser(username));
+        jaxbArtist.setUserRating(ratingService.getRatingForUser(username, artistMediaFile));
+        jaxbArtist.setAverageRating(ratingService.getAverageRating(artistMediaFile));
         return jaxbArtist;
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -25,6 +25,7 @@ import org.airsonic.player.domain.Artist;
 import org.airsonic.player.domain.Contributors;
 import org.airsonic.player.domain.CoverArt;
 import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.Player;
 import org.airsonic.player.domain.Playlist;
 import org.junit.jupiter.api.Nested;
@@ -66,6 +67,8 @@ class JaxbContentServiceTest {
     private AlbumService albumService;
     @Mock
     private MediaFileService mediaFileService;
+    @Mock
+    private MediaFolderService mediaFolderService;
     @Mock
     private TranscodingService transcodingService;
     @Mock
@@ -118,6 +121,73 @@ class JaxbContentServiceTest {
             assertEquals("1", result.getId());
             assertEquals("NoArt", result.getName());
             assertEquals(0, result.getAlbumCount());
+        }
+
+        @Test
+        void createJaxbArtist_setsRatings_whenArtistDirectoryResolvable() {
+            ArtistID3 jaxbArtist = new ArtistID3();
+            Artist artist = mock(Artist.class);
+            MediaFile artistDir = mock(MediaFile.class);
+            List<MusicFolder> folders = List.of(mock(MusicFolder.class));
+            when(artist.getId()).thenReturn(7);
+            when(artist.getName()).thenReturn("Rated Artist");
+            when(artist.getAlbumCount()).thenReturn(2);
+            when(coverArtService.getArtistArt(7)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFolderService.getMusicFoldersForUser("user")).thenReturn(folders);
+            when(mediaFileService.getArtistByName("Rated Artist", folders)).thenReturn(artistDir);
+            when(ratingService.getRatingForUser("user", artistDir)).thenReturn(4);
+            when(ratingService.getAverageRating(artistDir)).thenReturn(3.7);
+
+            ArtistID3 result = service.createJaxbArtist(jaxbArtist, artist, "user");
+
+            assertEquals(4, result.getUserRating());
+            assertEquals(3.7, result.getAverageRating());
+        }
+
+        @Test
+        void createJaxbArtist_omitsUserRating_whenUserHasNoRatingButAverageExists() {
+            ArtistID3 jaxbArtist = new ArtistID3();
+            Artist artist = mock(Artist.class);
+            MediaFile artistDir = mock(MediaFile.class);
+            List<MusicFolder> folders = List.of(mock(MusicFolder.class));
+            when(artist.getId()).thenReturn(8);
+            when(artist.getName()).thenReturn("Average Only");
+            when(artist.getAlbumCount()).thenReturn(1);
+            when(coverArtService.getArtistArt(8)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFolderService.getMusicFoldersForUser("user")).thenReturn(folders);
+            when(mediaFileService.getArtistByName("Average Only", folders)).thenReturn(artistDir);
+            when(ratingService.getRatingForUser("user", artistDir)).thenReturn(null);
+            when(ratingService.getAverageRating(artistDir)).thenReturn(2.5);
+
+            ArtistID3 result = service.createJaxbArtist(jaxbArtist, artist, "user");
+
+            assertNull(result.getUserRating());
+            assertEquals(2.5, result.getAverageRating());
+        }
+
+        @Test
+        void createJaxbArtist_omitsBothRatings_whenArtistIsVirtual() {
+            // Virtual artist: derived from albumArtist tag with no physical directory. The
+            // resolver returns null; rating lookups against a null MediaFile return null;
+            // JAXB omits both attributes — no exception, no implicit MediaFile creation.
+            ArtistID3 jaxbArtist = new ArtistID3();
+            Artist artist = mock(Artist.class);
+            List<MusicFolder> folders = List.of(mock(MusicFolder.class));
+            when(artist.getId()).thenReturn(9);
+            when(artist.getName()).thenReturn("Virtual Artist");
+            when(artist.getAlbumCount()).thenReturn(0);
+            when(coverArtService.getArtistArt(9)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFolderService.getMusicFoldersForUser("user")).thenReturn(folders);
+            when(mediaFileService.getArtistByName("Virtual Artist", folders)).thenReturn(null);
+            when(ratingService.getRatingForUser("user", null)).thenReturn(null);
+            when(ratingService.getAverageRating(null)).thenReturn(null);
+
+            ArtistID3 result = service.createJaxbArtist(jaxbArtist, artist, "user");
+
+            assertNull(result.getUserRating());
+            assertNull(result.getAverageRating());
+            assertEquals("9", result.getId());
+            assertEquals("Virtual Artist", result.getName());
         }
     }
 

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -151,6 +151,8 @@
         <xs:attribute name="mediaType" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="musicBrainzId" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
         <xs:attribute name="sortName" type="xs:string" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="userRating" type="sub:UserRating" use="optional"/>  <!-- Added in OpenSubsonic -->
+        <xs:attribute name="averageRating" type="sub:AverageRating" use="optional"/>  <!-- Added in OpenSubsonic -->
     </xs:complexType>
 
     <xs:complexType name="ArtistWithAlbumsID3">


### PR DESCRIPTION
PR #201 added `userRating` and `averageRating` to the `MediaFile`-keyed `createJaxbArtist` overload, but the `Artist`-keyed overload — used in the album-list and artist-index hot paths — did not yet emit those fields. This PR closes the gap, completing OpenSubsonic ArtistID3 rating coverage.

## What changed

- **XSD:** added `userRating` and `averageRating` optional attributes on the ArtistID3 complexType, reusing the existing `sub:UserRating` (xs:int 1..5) and `sub:AverageRating` (xs:double 1.0..5.0) simpleTypes already defined for the legacy Artist, Directory, and Child types.
- **JaxbContentService:** injected `MediaFolderService`; in `createJaxbArtist(T, Artist, String username)` added a two-step resolution — `mediaFileService.getArtistByName(name, mediaFolderService.getMusicFoldersForUser(username))` → existing `RatingService.getRatingForUser` / `getAverageRating` — and set the two fields.

The signature didn't change; the `Artist`-keyed overload already took `username`, matching the #136 (sortName) and #137 (musicBrainzId) precedents. All 5 call sites are untouched.

## Resolver behavior

`MediaFileService.getArtistByName(name, folders)` performs a single indexed SELECT (`findByFolderInAndMediaTypeAndArtistAndPresentTrue`) — no `@Transactional`, no save/persist/merge, no implicit MediaFile creation. For virtual artists (album-artist names with no physical directory) it returns null, `RatingService` null-returns for both methods, JAXB omits the unset attributes. No exception path.

## Tests

Three new tests inside `JaxbContentServiceTest.JaxbArtistTest`:
- Rating present — both setters land on the result.
- No user rating, global average present — `userRating` omitted, `averageRating` set.
- Virtual artist (resolver returns null) — both attributes omitted, no exception.

1076 → 1082 (HSQLDB suite). New tests also green against postgres:16-alpine. Analyze-only clean. WAR carries the regenerated ArtistID3 class with both setters.

## Follow-up

Code-reviewer flagged the per-call resolver cost on large artist responses (~500 SELECTs + up to ~1000 rating queries for a 500-artist response). Acceptable for the #203 scope — separate enhancement to follow.