### PR TITLE
OpenSubsonic: ReplayGain coverage — MP4 atoms, Opus R128, fallbackGain (#205 PR-A)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -419,7 +419,12 @@ public class JaxbContentService {
         Double albumGain = mediaFile.getReplayGainAlbumGain();
         Double trackPeak = mediaFile.getReplayGainTrackPeak();
         Double albumPeak = mediaFile.getReplayGainAlbumPeak();
-        if (trackGain == null && albumGain == null && trackPeak == null && albumPeak == null) {
+        // Operator-supplied fallback emitted on every replayGain element when configured —
+        // clients are expected to apply it only when the per-track values are absent. When
+        // unset (the default), the attribute is omitted and there is no behavior change.
+        Double fallbackGain = settingsService.getReplayGainFallback();
+        if (trackGain == null && albumGain == null && trackPeak == null && albumPeak == null
+                && fallbackGain == null) {
             return null;
         }
         ReplayGain replayGain = new ReplayGain();
@@ -427,6 +432,7 @@ public class JaxbContentService {
         replayGain.setAlbumGain(albumGain);
         replayGain.setTrackPeak(trackPeak);
         replayGain.setAlbumPeak(albumPeak);
+        replayGain.setFallbackGain(fallbackGain);
         return replayGain;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -73,6 +73,7 @@ public class SettingsService {
     private static final String KEY_COVER_ART_SOURCE = "CoverArtSource";
     private static final String KEY_COVER_ART_CONCURRENCY = "CoverArtConcurrency";
     private static final String KEY_COVER_ART_QUALITY = "CoverArtQuality";
+    private static final String KEY_REPLAY_GAIN_FALLBACK = "ReplayGainFallback";
     private static final String KEY_WELCOME_TITLE = "WelcomeTitle";
     private static final String KEY_WELCOME_SUBTITLE = "WelcomeSubtitle";
     private static final String KEY_WELCOME_MESSAGE = "WelcomeMessage2";
@@ -749,6 +750,36 @@ public class SettingsService {
 
     public void setCoverArtQuality(Integer quality) {
         setInt(KEY_COVER_ART_QUALITY, quality);
+    }
+
+    /**
+     * Returns the operator-supplied ReplayGain fallback (in dB) emitted on every
+     * {@code replayGain} response element. {@code null} when unset (the default), in which
+     * case the {@code fallbackGain} attribute is omitted. Stored as a string so the null /
+     * not-set state round-trips through the underlying configuration without aliasing the
+     * numeric zero.
+     */
+    public Double getReplayGainFallback() {
+        String raw = getString(KEY_REPLAY_GAIN_FALLBACK, null);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public void setReplayGainFallback(Double dB) {
+        // Guard against NaN / +Infinity / -Infinity — these survive Double.toString /
+        // parseDouble round-trip, would later serialize as xs:double "NaN" / "Infinity",
+        // and are rejected by many Subsonic clients. Treat them as "clear the setting".
+        if (dB != null && !Double.isFinite(dB)) {
+            setString(KEY_REPLAY_GAIN_FALLBACK, null);
+            return;
+        }
+        setString(KEY_REPLAY_GAIN_FALLBACK, dB == null ? null : dB.toString());
     }
 
     public String getWelcomeTitle() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -38,6 +38,8 @@ import org.jaudiotagger.tag.id3.AbstractID3v2Tag;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.images.Artwork;
+import org.jaudiotagger.tag.mp4.Mp4Tag;
+import org.jaudiotagger.tag.mp4.field.Mp4TagReverseDnsField;
 import org.jaudiotagger.tag.reference.PictureTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +74,19 @@ public class JaudiotaggerParser extends MetaDataParser {
     static final String RG_ALBUM_GAIN = "REPLAYGAIN_ALBUM_GAIN";
     static final String RG_TRACK_PEAK = "REPLAYGAIN_TRACK_PEAK";
     static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
+
+    // Opus carries EBU R128 gain (an integer Q7.8 fixed-point value referenced to -23 LUFS)
+    // rather than ReplayGain dB referenced to -18 dBFS. Both can co-exist on the same file;
+    // RG is preferred when present and R128 is converted to RG-equivalent dB otherwise. See
+    // {@link #parseR128GainQ78} for the conversion.
+    static final String R128_TRACK_GAIN = "R128_TRACK_GAIN";
+    static final String R128_ALBUM_GAIN = "R128_ALBUM_GAIN";
+
+    // MP4 stores ReplayGain in iTunes-style reverse-DNS freeform atoms keyed by lowercase
+    // descriptor (replaygain_track_gain, replaygain_album_gain, replaygain_track_peak,
+    // replaygain_album_peak). jaudiotagger 3.0.1 exposes them through Mp4Tag.getFields()
+    // with the prefix below; no Mp4FieldKey enum value covers them.
+    static final String MP4_ITUNES_FREEFORM_PREFIX = "----:com.apple.iTunes:";
 
     // Clean-FieldKey contributor roles — each FieldKey is read via tag.getAll(...) and every
     // returned value becomes one Contributor with the given role label and no subRole. Performer
@@ -154,8 +169,8 @@ public class JaudiotaggerParser extends MetaDataParser {
                 // from the release-artist tags rather than the per-track artist tags.
                 metaData.setMusicBrainzArtistId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEARTISTID));
                 metaData.setArtistSortName(getTagField(tag, FieldKey.ALBUM_ARTIST_SORT));
-                metaData.setReplayGainTrackGain(parseReplayGain(getReplayGainField(tag, RG_TRACK_GAIN)));
-                metaData.setReplayGainAlbumGain(parseReplayGain(getReplayGainField(tag, RG_ALBUM_GAIN)));
+                metaData.setReplayGainTrackGain(parseTrackGain(tag));
+                metaData.setReplayGainAlbumGain(parseAlbumGain(tag));
                 metaData.setReplayGainTrackPeak(parseReplayGain(getReplayGainField(tag, RG_TRACK_PEAK)));
                 metaData.setReplayGainAlbumPeak(parseReplayGain(getReplayGainField(tag, RG_ALBUM_PEAK)));
 
@@ -287,9 +302,11 @@ public class JaudiotaggerParser extends MetaDataParser {
     }
 
     /**
-     * Reads a ReplayGain value by name. ReplayGain has no jaudiotagger {@link FieldKey}, so it is
-     * read directly: from ID3v2 it lives in a TXXX frame keyed by a (case-insensitive) description,
-     * while Vorbis comments (FLAC/Ogg/Opus) expose it as a plain keyed field.
+     * Reads a ReplayGain or R128 value by name. ReplayGain has no jaudiotagger
+     * {@link FieldKey}, so it is read directly: from ID3v2 it lives in a TXXX frame keyed by a
+     * (case-insensitive) description; Vorbis comments (FLAC/Ogg/Opus) expose it as a plain
+     * keyed field; MP4 stores it as an iTunes-style reverse-DNS freeform atom keyed by the
+     * lowercase descriptor under {@link #MP4_ITUNES_FREEFORM_PREFIX}.
      */
     static String getReplayGainField(Tag tag, String name) {
         try {
@@ -306,9 +323,69 @@ public class JaudiotaggerParser extends MetaDataParser {
                 }
                 return null;
             }
+            if (tag instanceof Mp4Tag mp4) {
+                List<TagField> fields = mp4.getFields(MP4_ITUNES_FREEFORM_PREFIX + name.toLowerCase());
+                if (fields != null) {
+                    for (TagField field : fields) {
+                        if (field instanceof Mp4TagReverseDnsField rdns) {
+                            return StringUtils.trimToNull(rdns.getContent());
+                        }
+                    }
+                }
+                return null;
+            }
             return StringUtils.trimToNull(tag.getFirst(name));
         } catch (Exception x) {
             // Ignored.
+            return null;
+        }
+    }
+
+    /**
+     * Returns the track gain in ReplayGain-equivalent dB, preferring the ReplayGain tag when
+     * present and falling back to the Opus R128 tag otherwise. A present-but-unparseable RG
+     * tag returns {@code null} and does NOT fall through to R128 — the operator's authored
+     * tag takes precedence over any inferred R128 value. See {@link #parseR128GainQ78} for
+     * the R128↔RG conversion.
+     */
+    Double parseTrackGain(Tag tag) {
+        String rg = getReplayGainField(tag, RG_TRACK_GAIN);
+        if (rg != null) {
+            return parseReplayGain(rg);
+        }
+        return parseR128GainQ78(getReplayGainField(tag, R128_TRACK_GAIN));
+    }
+
+    /**
+     * Returns the album gain in ReplayGain-equivalent dB, preferring the ReplayGain tag when
+     * present and falling back to the Opus R128 tag otherwise. Same precedence rule as
+     * {@link #parseTrackGain}.
+     */
+    Double parseAlbumGain(Tag tag) {
+        String rg = getReplayGainField(tag, RG_ALBUM_GAIN);
+        if (rg != null) {
+            return parseReplayGain(rg);
+        }
+        return parseR128GainQ78(getReplayGainField(tag, R128_ALBUM_GAIN));
+    }
+
+    /**
+     * Converts an Opus R128 integer gain (Q7.8 fixed-point, referenced to -23 LUFS) to a
+     * ReplayGain-equivalent dB value (ReplayGain 2 is anchored at -18 LUFS):
+     * {@code dB = q78 / 256 + 5}. The +5 dB shift accounts for the difference between EBU
+     * R128's -23 LUFS reference and the ReplayGain 2 -18 LUFS reference; the same mapping is
+     * used by <a href="https://github.com/Moonbase59/loudgain">loudgain</a>,
+     * <a href="https://github.com/complexlogic/rsgain">rsgain</a>, mutagen, and kid3.
+     * Returns {@code null} on blank, non-integer, or out-of-int-range input.
+     */
+    static Double parseR128GainQ78(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            int q78 = Integer.parseInt(raw.trim());
+            return q78 / 256.0 + 5.0;
+        } catch (NumberFormatException e) {
             return null;
         }
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -635,6 +635,81 @@ class JaxbContentServiceTest {
             assertNull(child.getCoverArt());
         }
 
+        // Mockito 5's RETURNS_DEFAULTS returns boxed-zero (0.0) for Double-returning mocked
+        // methods rather than null, so unstubbed mediaFile.getReplayGain*() reads as 0.0 — a
+        // valid gain value as far as buildReplayGain is concerned. These tests stub all four
+        // explicitly to null so the omission and emission logic is the only thing under test.
+        @Test
+        void createJaxbChild_replayGain_omitsElement_whenAllSourcesNull() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(310);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(310)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getReplayGainTrackGain()).thenReturn(null);
+            when(mediaFile.getReplayGainAlbumGain()).thenReturn(null);
+            when(mediaFile.getReplayGainTrackPeak()).thenReturn(null);
+            when(mediaFile.getReplayGainAlbumPeak()).thenReturn(null);
+            when(settingsService.getReplayGainFallback()).thenReturn(null);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertNull(child.getReplayGain(),
+                    "replayGain element must be omitted when no source produces any value");
+        }
+
+        @Test
+        void createJaxbChild_replayGain_emitsFallbackOnly_whenTagsAbsentButFallbackSet() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(320);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(320)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getReplayGainTrackGain()).thenReturn(null);
+            when(mediaFile.getReplayGainAlbumGain()).thenReturn(null);
+            when(mediaFile.getReplayGainTrackPeak()).thenReturn(null);
+            when(mediaFile.getReplayGainAlbumPeak()).thenReturn(null);
+            when(settingsService.getReplayGainFallback()).thenReturn(-10.0);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertNotNull(child.getReplayGain(),
+                    "replayGain element must be emitted whenever fallbackGain is configured");
+            assertEquals(-10.0, child.getReplayGain().getFallbackGain());
+            assertNull(child.getReplayGain().getTrackGain());
+            assertNull(child.getReplayGain().getAlbumGain());
+            assertNull(child.getReplayGain().getTrackPeak());
+            assertNull(child.getReplayGain().getAlbumPeak());
+        }
+
+        @Test
+        void createJaxbChild_replayGain_emitsFallbackAlongsideTagValues() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(330);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(330)).thenReturn(CoverArt.NULL_ART);
+            when(mediaFile.getReplayGainTrackGain()).thenReturn(-6.5);
+            when(mediaFile.getReplayGainAlbumGain()).thenReturn(null);
+            when(mediaFile.getReplayGainTrackPeak()).thenReturn(0.988);
+            when(mediaFile.getReplayGainAlbumPeak()).thenReturn(null);
+            when(settingsService.getReplayGainFallback()).thenReturn(-8.0);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertNotNull(child.getReplayGain());
+            assertEquals(-6.5, child.getReplayGain().getTrackGain());
+            assertEquals(0.988, child.getReplayGain().getTrackPeak());
+            assertEquals(-8.0, child.getReplayGain().getFallbackGain());
+            assertNull(child.getReplayGain().getAlbumGain());
+        }
+
         @Test
         void createJaxbChild_populatesGenresArrayAndKeepsSingleGenre() {
             Player player = mock(Player.class);

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -23,6 +23,8 @@ import org.jaudiotagger.tag.id3.ID3v24Tag;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.id3.valuepair.TextEncoding;
+import org.jaudiotagger.tag.mp4.Mp4Tag;
+import org.jaudiotagger.tag.mp4.field.Mp4TagReverseDnsField;
 import org.jaudiotagger.tag.vorbiscomment.VorbisCommentTag;
 import org.junit.jupiter.api.Test;
 
@@ -67,6 +69,105 @@ public class JaudiotaggerParserTestCase {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
         tag.setField("REPLAYGAIN_TRACK_GAIN", "-7.50 dB");
         assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+
+    private static Mp4Tag mp4TagWithItunesFreeform(String descriptorLower, String value) {
+        Mp4Tag tag = new Mp4Tag();
+        // jaudiotagger's 4-string Mp4TagReverseDnsField(id, issuer, descriptor, content) sets
+        // the field's id directly to the first argument (the iTunes reverse-DNS atom name);
+        // that's what Mp4Tag.getFields(String) matches against and what
+        // JaudiotaggerParser.getReplayGainField composes its lookup key for.
+        String id = JaudiotaggerParser.MP4_ITUNES_FREEFORM_PREFIX + descriptorLower;
+        Mp4TagReverseDnsField field = new Mp4TagReverseDnsField(id, "com.apple.iTunes",
+                descriptorLower, value);
+        tag.addField(field);
+        return tag;
+    }
+
+    @Test
+    public void testGetReplayGainFieldFromMp4FreeformAtom() {
+        Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain", "-7.50 dB");
+        assertEquals("-7.50 dB",
+                JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+    }
+
+    @Test
+    public void testGetReplayGainFieldMp4MissingAtomReturnsNull() {
+        Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain", "-7.50 dB");
+        assertNull(JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_ALBUM_PEAK));
+    }
+
+    @Test
+    public void testParseR128GainQ78ReferenceShiftAt0() {
+        // Q7.8 of 0 → 0/256 + 5 = 5.0 dB (a track already at -23 LUFS reads as +5 dB in RG terms)
+        assertEquals(Double.valueOf(5.0), JaudiotaggerParser.parseR128GainQ78("0"));
+    }
+
+    @Test
+    public void testParseR128GainQ78PositiveValues() {
+        // Q7.8 of 256 = 1 dB raw → 1 + 5 = 6 dB; -512 = -2 raw → -2 + 5 = 3 dB
+        assertEquals(Double.valueOf(6.0), JaudiotaggerParser.parseR128GainQ78("256"));
+        assertEquals(Double.valueOf(3.0), JaudiotaggerParser.parseR128GainQ78("-512"));
+        // Trimming
+        assertEquals(Double.valueOf(6.0), JaudiotaggerParser.parseR128GainQ78("  256  "));
+    }
+
+    @Test
+    public void testParseR128GainQ78MalformedReturnsNull() {
+        assertNull(JaudiotaggerParser.parseR128GainQ78(null));
+        assertNull(JaudiotaggerParser.parseR128GainQ78(""));
+        assertNull(JaudiotaggerParser.parseR128GainQ78("not-an-int"));
+        assertNull(JaudiotaggerParser.parseR128GainQ78("-7.50 dB"));
+    }
+
+    @Test
+    public void testParseR128GainQ78OutOfIntRangeReturnsNull() {
+        // Integer.parseInt rejects values outside [Integer.MIN_VALUE, Integer.MAX_VALUE] with
+        // NumberFormatException — the catch in parseR128GainQ78 normalizes that to null.
+        assertNull(JaudiotaggerParser.parseR128GainQ78("999999999999"));
+        assertNull(JaudiotaggerParser.parseR128GainQ78("-999999999999"));
+    }
+
+    @Test
+    public void testParseTrackGainPrefersRgWhenBothPresent() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.setField(JaudiotaggerParser.RG_TRACK_GAIN, "-6.50 dB");
+        tag.setField(JaudiotaggerParser.R128_TRACK_GAIN, "256"); // would be 6.0 dB after shift
+        JaudiotaggerParser parser = new JaudiotaggerParser(null);
+        assertEquals(Double.valueOf(-6.5), parser.parseTrackGain(tag));
+    }
+
+    @Test
+    public void testParseTrackGainFallsBackToR128WhenOnlyR128() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.setField(JaudiotaggerParser.R128_TRACK_GAIN, "0"); // 5.0 dB after shift
+        JaudiotaggerParser parser = new JaudiotaggerParser(null);
+        assertEquals(Double.valueOf(5.0), parser.parseTrackGain(tag));
+    }
+
+    @Test
+    public void testParseAlbumGainPrefersRgWhenBothPresent() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.setField(JaudiotaggerParser.RG_ALBUM_GAIN, "-4.25 dB");
+        tag.setField(JaudiotaggerParser.R128_ALBUM_GAIN, "256");
+        JaudiotaggerParser parser = new JaudiotaggerParser(null);
+        assertEquals(Double.valueOf(-4.25), parser.parseAlbumGain(tag));
+    }
+
+    @Test
+    public void testParseAlbumGainFallsBackToR128WhenOnlyR128() throws Exception {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        tag.setField(JaudiotaggerParser.R128_ALBUM_GAIN, "-512"); // 3.0 dB after shift
+        JaudiotaggerParser parser = new JaudiotaggerParser(null);
+        assertEquals(Double.valueOf(3.0), parser.parseAlbumGain(tag));
+    }
+
+    @Test
+    public void testParseTrackGainNeitherTagPresentReturnsNull() {
+        VorbisCommentTag tag = VorbisCommentTag.createNewTag();
+        JaudiotaggerParser parser = new JaudiotaggerParser(null);
+        assertNull(parser.parseTrackGain(tag));
+        assertNull(parser.parseAlbumGain(tag));
     }
 
     @Test

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -313,6 +313,7 @@
         <xs:attribute name="albumGain" type="xs:double" use="optional"/>
         <xs:attribute name="trackPeak" type="xs:double" use="optional"/>
         <xs:attribute name="albumPeak" type="xs:double" use="optional"/>
+        <xs:attribute name="fallbackGain" type="xs:double" use="optional"/>  <!-- Added in OpenSubsonic -->
     </xs:complexType>
 
     <xs:complexType name="ItemGenre">  <!-- Added in OpenSubsonic -->


### PR DESCRIPTION
PR #204 (#143) shipped `Child.replayGain` extraction from ID3v2 TXXX and Vorbis comments, covering MP3 and FLAC/OGG. This PR (PR-A of #205) fills in two further sources and adds the server-supplied fallback field. Opus `baseGain` is deferred to PR-B — see follow-up.

## What changed

- **XSD:** added `fallbackGain` (xs:double, optional) to the ReplayGain complexType.
- **MP4 / M4A atoms:** new `Mp4Tag` branch in `JaudiotaggerParser.getReplayGainField` resolves `----:com.apple.iTunes:replaygain_*_gain` freeform atoms via `Mp4Tag.getFields(...)` and reads the first match's `Mp4TagReverseDnsField` content. Format-dispatch order: ID3v2 TXXX → MP4 freeform → Vorbis-comment fallthrough.
- **Opus R128:** new `parseTrackGain(Tag)` / `parseAlbumGain(Tag)` instance helpers prefer `REPLAYGAIN_TRACK_GAIN` when present (no conversion needed) and fall back to `R128_TRACK_GAIN` with conversion via `parseR128GainQ78`. A present-but-unparseable RG tag returns null without falling through to R128 — operator's authored tag wins.
- **R128 → RG conversion:** `q78 / 256.0 + 5.0` in `parseR128GainQ78`. The +5 dB shift is the canonical R128 (-23 LUFS reference) → ReplayGain 2 (-18 LUFS reference) mapping, documented across loudgain, rsgain, mutagen, and kid3.
- **fallbackGain:** `SettingsService.KEY_REPLAY_GAIN_FALLBACK` ("ReplayGainFallback"), default null, NaN/Infinity guarded. `JaxbContentService.buildReplayGain` emits the field on every `replayGain` element when configured; participates in the omit-when-all-null check so unset deployments see no behavior change. No UI wiring in this PR.

## Deferred to PR-B

Opus `baseGain` (the OpusHead `output_gain` field). jaudiotagger 3.0.1 has no API to access it (no `OpusHeader` / `OpusVorbisAudioHeader` class; `OggInfoReader` doesn't extract it). PR-B requires either a small in-codebase Opus binary header parser or a tooling upgrade decision — see follow-up.

## Tests

11 new in `JaudiotaggerParserTestCase` (MP4 atom extraction, R128 conversion math across 0 / + / - / malformed / overflow / whitespace, RG-then-R128 preference both directions for track and album). 3 new in `JaxbContentServiceTest` (omit-when-all-null, fallback-only emission, fallback alongside tag values). All in-memory tag fixtures, no new binary files. 1082 → 1099 (HSQLDB). Postgres run of the new tests green. Analyze-only clean. WAR carries the regenerated `ReplayGain` class with `setFallbackGain` and the new parser constants.

## Reviewer fixes applied pre-merge

- Javadoc precision: "-18 dBFS" → "-18 LUFS" in `parseR128GainQ78`.
- `Double.isFinite(dB)` guard in `setReplayGainFallback` rejecting NaN / ±Infinity (would round-trip but emit invalid xs:double "NaN"/"Infinity" that many clients reject).
- New `testParseR128GainQ78OutOfIntRangeReturnsNull` covering `Integer.parseInt` overflow.
- Javadoc on `parseTrackGain` / `parseAlbumGain` documenting the "malformed RG → null, no R128 fallthrough" precedence.

## Follow-ups (separate issues)

- PR-B: Opus `baseGain` from OpusHead — tooling fork between in-codebase parser and jaudiotagger upgrade.
- MP4 atom case-sensitivity asymmetry: TXXX branch uses `equalsIgnoreCase`, MP4 branch uses lowercase exact. Real-world MP4 RG atoms are lowercase per iTunes spec, but a non-conformant writer could miss.
- `fallbackGain` admin UI surface in General Settings.