### PR TITLE
OpenSubsonic: feed genre count table from media_file.genres (fixes #213)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
@@ -37,32 +37,28 @@ public class Genres {
 
     private final Map<String, Genre> genres = new ConcurrentHashMap<>();
 
-    // genre names can be ([genre] --> [split to])
-    // - abc --> ['abc']
-    // - abc; --> ['abc', '']
-    // - abc;xyz --> ['abc', 'xyz']
-    // - abc; xyz --> ['abc', ' xyz']
-
-    public void incrementAlbumCount(String genreName, String separators) {
-        String[] splitGenres = StringUtils.split(genreName, separators);
-        if (splitGenres.length > 1) { // otherwise it's the same genre as the original
-            Stream.of(splitGenres)
-                    .map(StringUtils::trim)
-                    .filter(StringUtils::isNotBlank)
-                    .forEach(s -> genres.computeIfAbsent(s, k -> new Genre(k)).incrementAlbumCount());
+    /**
+     * Increments the album count for a single, already-split genre token. Callers are expected
+     * to feed pre-resolved tokens (typically via {@link #split(String, String)} on a packed
+     * multi-value column); blank tokens are ignored so callers do not have to filter.
+     */
+    public void incrementAlbumCount(String genreName) {
+        if (StringUtils.isBlank(genreName)) {
+            return;
         }
-        genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementAlbumCount();
+        genres.computeIfAbsent(genreName, Genre::new).incrementAlbumCount();
     }
 
-    public void incrementSongCount(String genreName, String separators) {
-        String[] splitGenres = StringUtils.split(genreName, separators);
-        if (splitGenres.length > 1) { // otherwise it's the same genre as the original
-            Stream.of(splitGenres)
-                    .map(StringUtils::trim)
-                    .filter(StringUtils::isNotBlank)
-                    .forEach(s -> genres.computeIfAbsent(s, k -> new Genre(k)).incrementSongCount());
+    /**
+     * Increments the song count for a single, already-split genre token. Callers are expected
+     * to feed pre-resolved tokens (typically via {@link #split(String, String)} on a packed
+     * multi-value column); blank tokens are ignored so callers do not have to filter.
+     */
+    public void incrementSongCount(String genreName) {
+        if (StringUtils.isBlank(genreName)) {
+            return;
         }
-        genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementSongCount();
+        genres.computeIfAbsent(genreName, Genre::new).incrementSongCount();
     }
 
     public List<Genre> getGenres() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -406,14 +406,23 @@ public class MediaScannerService {
     }
 
     private void updateGenres(MediaFile file, Genres genres) {
-        String genre = file.getGenre();
-        if (genre == null) {
+        // Prefer the packed multi-value media_file.genres column (PR #134) so multi-frame tags
+        // contribute to the count of every genre they carry, not just the primary scalar.
+        // Album-folder rows do not get a packed column populated during scan, so fall back to
+        // splitting the scalar genre on the same separators for parity. Both sources are already
+        // canonicalized by JaudiotaggerParser.mapGenre (e.g. ID3v1 "(17)" -> "Rock").
+        String separators = settingsService.getGenreSeparators();
+        String packed = file.getGenres();
+        List<String> resolved = packed != null
+                ? Genres.split(packed, separators)
+                : Genres.split(file.getGenre(), separators);
+        if (resolved.isEmpty()) {
             return;
         }
         if (file.isAlbum()) {
-            genres.incrementAlbumCount(genre, settingsService.getGenreSeparators());
+            resolved.forEach(genres::incrementAlbumCount);
         } else if (file.isAudio()) {
-            genres.incrementSongCount(genre, settingsService.getGenreSeparators());
+            resolved.forEach(genres::incrementSongCount);
         }
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
@@ -68,4 +68,55 @@ public class GenresTest {
         String packed = String.join(";", source);
         assertEquals(source, Genres.split(packed, ";"));
     }
+
+    @Test
+    public void testIncrementSongCountAccumulatesPerToken() {
+        Genres g = new Genres();
+        g.incrementSongCount("Rock");
+        g.incrementSongCount("Rock");
+        g.incrementSongCount("Metal");
+
+        Genre rock = findGenre(g, "Rock");
+        Genre metal = findGenre(g, "Metal");
+        assertEquals(2, rock.getSongCount());
+        assertEquals(0, rock.getAlbumCount());
+        assertEquals(1, metal.getSongCount());
+        assertEquals(0, metal.getAlbumCount());
+    }
+
+    @Test
+    public void testIncrementAlbumCountAccumulatesPerToken() {
+        Genres g = new Genres();
+        g.incrementAlbumCount("Rock");
+        g.incrementAlbumCount("Rock");
+        g.incrementAlbumCount("Metal");
+
+        Genre rock = findGenre(g, "Rock");
+        Genre metal = findGenre(g, "Metal");
+        assertEquals(2, rock.getAlbumCount());
+        assertEquals(0, rock.getSongCount());
+        assertEquals(1, metal.getAlbumCount());
+        assertEquals(0, metal.getSongCount());
+    }
+
+    @Test
+    public void testIncrementIgnoresBlankAndNullTokens() {
+        Genres g = new Genres();
+        g.incrementSongCount(null);
+        g.incrementSongCount("");
+        g.incrementSongCount("   ");
+        g.incrementAlbumCount(null);
+        g.incrementAlbumCount("");
+        g.incrementAlbumCount("   ");
+
+        assertTrue(g.getGenres().isEmpty(),
+                "blank/null tokens must not create rows");
+    }
+
+    private static Genre findGenre(Genres g, String name) {
+        return g.getGenres().stream()
+                .filter(x -> name.equals(x.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("genre row missing: " + name));
+    }
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -429,6 +429,140 @@ public class MediaScannerServiceTestCase {
         assertEquals("Sony/BMG; Columbia\nWarner", album.getRecordLabels());
     }
 
+    // updateGenres() reads the genre count table source — prefers media_file.genres (PR #134's
+    // packed multi-value column, populated alongside the scalar on audio file rows), falls back
+    // to splitting the scalar media_file.genre on the same separators when the packed column is
+    // absent (album folder rows; pre-#134 legacy rows). These tests drive the private feeder so
+    // the multi-frame, fallback, and no-genre semantics can be covered without audio fixtures.
+
+    private org.airsonic.player.domain.Genres invokeUpdateGenres(MediaFile file, String separators) {
+        // Stub locally per call so changes don't leak to unrelated tests; the spy bean's other
+        // methods (mostly DB-backed property reads) continue to pass through unchanged.
+        when(settingsService.getGenreSeparators()).thenReturn(separators);
+        org.airsonic.player.domain.Genres bin = new org.airsonic.player.domain.Genres();
+        ReflectionTestUtils.invokeMethod(mediaScannerService, "updateGenres", file, bin);
+        return bin;
+    }
+
+    private MediaFile audioFile(String genre, String packedGenres) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.MUSIC);
+        file.setGenre(genre);
+        file.setGenres(packedGenres);
+        return file;
+    }
+
+    private MediaFile albumFolder(String genre) {
+        MediaFile file = new MediaFile();
+        file.setMediaType(MediaFile.MediaType.ALBUM);
+        file.setGenre(genre);
+        // genres[] is intentionally not set — album folders never get the packed column populated.
+        return file;
+    }
+
+    private int songCountOf(org.airsonic.player.domain.Genres g, String name) {
+        return g.getGenres().stream()
+                .filter(x -> name.equals(x.getName()))
+                .findFirst()
+                .map(org.airsonic.player.domain.Genre::getSongCount)
+                .orElse(0);
+    }
+
+    private int albumCountOf(org.airsonic.player.domain.Genres g, String name) {
+        return g.getGenres().stream()
+                .filter(x -> name.equals(x.getName()))
+                .findFirst()
+                .map(org.airsonic.player.domain.Genre::getAlbumCount)
+                .orElse(0);
+    }
+
+    @Test
+    public void testUpdateGenresMultiFrameAudioFileCountsAllGenres() {
+        // PR #134's packed column carries every genre frame; the feeder must increment all rows.
+        MediaFile file = audioFile("Rock", "Rock;Pop;Indie");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, songCountOf(g, "Rock"));
+        assertEquals(1, songCountOf(g, "Pop"));
+        assertEquals(1, songCountOf(g, "Indie"));
+        assertEquals(3, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresSingleGenreAudioFileIncrementsOnce() {
+        MediaFile file = audioFile("Rock", "Rock");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, songCountOf(g, "Rock"));
+        assertEquals(1, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresAudioFileFallsBackToScalarWhenPackedNull() {
+        // Mirrors pre-#134 legacy rows where genres[] was never written: the scalar still flows.
+        MediaFile file = audioFile("Rock", null);
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, songCountOf(g, "Rock"));
+        assertEquals(1, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresScalarFallbackSplitsOnSeparators() {
+        // Legacy scalar tag containing a separator gets split via the same Genres.split idiom,
+        // so the fallback path produces the same row set as a properly packed column would.
+        MediaFile file = audioFile("Rock; Pop", null);
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, songCountOf(g, "Rock"));
+        assertEquals(1, songCountOf(g, "Pop"));
+        assertEquals(2, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresNoGenreLeavesTableUntouched() {
+        MediaFile file = audioFile(null, null);
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertTrue(g.getGenres().isEmpty());
+    }
+
+    @Test
+    public void testUpdateGenresBlankGenreLeavesTableUntouched() {
+        MediaFile file = audioFile("   ", null);
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertTrue(g.getGenres().isEmpty());
+    }
+
+    @Test
+    public void testUpdateGenresAlbumFolderIncrementsAlbumCountViaScalar() {
+        // Album folders are written by MediaFileService without the packed column, so they hit
+        // the scalar fallback. Verifies album_count increments and song_count stays zero.
+        MediaFile file = albumFolder("Rock");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, albumCountOf(g, "Rock"));
+        assertEquals(0, songCountOf(g, "Rock"));
+        assertEquals(1, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresAlbumFolderScalarSplitsOnSeparators() {
+        // Same as the audio scalar split, but exercised through the isAlbum() branch.
+        MediaFile file = albumFolder("Rock; Metal");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, albumCountOf(g, "Rock"));
+        assertEquals(1, albumCountOf(g, "Metal"));
+        assertEquals(2, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresMultipleSeparatorCharsHonoured() {
+        // The getGenreSeparators setting accepts a charset string ("'; ,'") — Genres.split honours
+        // every char. Lock that in so a future change to the default doesn't silently regress the
+        // multi-separator behaviour of the count-table feeder.
+        MediaFile file = audioFile("Rock", "Rock;Pop,Indie");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";,");
+        assertEquals(1, songCountOf(g, "Rock"));
+        assertEquals(1, songCountOf(g, "Pop"));
+        assertEquals(1, songCountOf(g, "Indie"));
+        assertEquals(3, g.getGenres().size());
+    }
+
     // Album-level ReplayGain (rg_album_gain / rg_album_peak) is aggregated from each track's
     // own rg_album_* columns during scan. Same null-guarded last-write-wins idiom as the
     // scalars/dates: a non-null track value persists; a later track with null does not clobber.


### PR DESCRIPTION
PR #212 (#134) added `media_file.genres` (multi-value array) but the genre count table backing `getGenres` was still fed from `media_file.genre` (the scalar primary), so a track tagged `Rock; Metal` contributed to the Rock count only. This PR moves the feeder onto `media_file.genres` so each track contributes to every genre it carries.

## What changed

- **`MediaScannerService.updateGenres`** resolves tokens via `Genres.split(file.getGenres(), separators)` when the packed column is non-null, falling back to `Genres.split(file.getGenre(), separators)` otherwise. Per-token iteration calls the new incrementers on `Genres`.
- **`Genres` API refactored to per-token incrementers.** New `incrementSongCount(String)` / `incrementAlbumCount(String)` replace the old `(String, String)` overloads that split internally.

## Side-effect: phantom composite-row bug fixed

The old `Genres` overloads had a pre-existing quirk: alongside the split tokens they unconditionally added the raw composite name as a third row, so a scalar `Rock; Metal` produced rows `Rock`, `Metal`, **and** a literal `Rock; Metal` entry visible to `getGenres`. The refactor removes the phantom composite rows. Reviewer verified no code anywhere reads the literal composite keys (grep-confirmed).

## Why the scalar fallback

Two reasons the packed column can be null when the scalar is set:
1. **Album-folder rows.** `MediaFileService.parseFile` calls `setGenre` for album-folder rows but never `setGenres` — see follow-up below.
2. **Legacy data.** Pre-#212 rows that haven't been rescanned since the multi-genre carrier landed have a null `genres` column but a populated scalar.

Both paths run through identical `Genres.split` token semantics (`StringUtils.split + trim + isNotBlank + distinct`); only the data source differs. Case normalization is preserved across both paths — both sources are canonicalized at parse time via `JaudiotaggerParser.mapGenre`.

## Behavior change (intended)

Counts will be higher and ordering may shift for libraries with multi-genre tracks. This is the point of the fix per the OpenSubsonic spec.

## Known limitation (follow-up)

`album_count` still derives from the album folder's `firstChild` primary scalar — multi-frame genres beyond the first frame don't reach the album row, so album_count under-counts vs song_count for multi-frame libraries. Fix is in PR #134's territory (extending `MediaFileService.parseFile` to also `setGenres(packGenres(...))` on album folders). Documented in a code comment at `MediaScannerService.java:411-413` and filed as a follow-up.

## Tests

12 new tests:
- `GenresTest` — 3 new tests on the per-token API + `findGenre` helper.
- `MediaScannerServiceTestCase` — 9 new `updateGenres` tests via `ReflectionTestUtils.invokeMethod`, covering multi-genre tracks contributing to all rows, single-genre tracks unchanged, no-genre no-op, packed-column source vs scalar fallback, and album_count vs song_count parity within each path.

HSQLDB suite green (`reuseForks=true` produces a truncated console total per the documented quirk; per-class XML sums confirm zero failures/errors). Postgres run of the touched test classes: 48/0/0/0. Analyze-only clean. WAR confirms only the new single-arg incrementers; old overloads removed.

## Follow-ups (separate issues)

- Album-folder rows should also carry the packed `genres` column so `album_count` reflects multi-frame genres.
- `getSongsByGenre` repository method still filters on the scalar column — same multi-frame blind-spot in song lookups by genre.