### PR TITLE
OpenSubsonic: FFmpeg parser scalar parity for 13.2.x fields (fixes #226)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -95,58 +95,7 @@ public class FFmpegParser extends MetaDataParser {
                 process.destroy();
             }
 
-            metaData.setDuration(result.at("/format/duration").asDouble());
-            // Bitrate is in Kb/s
-            metaData.setBitRate(result.at("/format/bit_rate").asInt() / 1000);
-
-            metaData.setAlbumArtist(getData(result, "album_artist"));
-            metaData.setArtist(getData(result, "artist"));
-            metaData.setAlbumName(getData(result, "album"));
-            metaData.setGenre(getData(result, "genre"));
-            metaData.setTitle(getData(result, "title"));
-            String data = getData(result, "track");
-            if (data != null) {
-                data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
-                if (NumberUtils.isCreatable(data)) {
-                    metaData.setTrackNumber(NumberUtils.createInteger(data));
-                }
-            }
-            data = getData(result, "disc");
-            if (data != null) {
-                data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
-                if (NumberUtils.isCreatable(data)) {
-                    metaData.setDiscNumber(NumberUtils.createInteger(data));
-                }
-            }
-
-            data = getData(result, "discnumber");
-            if (data != null) {
-                data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
-                if (NumberUtils.isCreatable(data)) {
-                    metaData.setDiscNumber(NumberUtils.createInteger(data));
-                }
-            }
-            data = getData(result, "date");
-            if (NumberUtils.isCreatable(data)) {
-                metaData.setYear(NumberUtils.createInteger(data));
-            }
-
-            // Find the first (if any) stream that has dimensions and use those.
-            // 'width' and 'height' are display dimensions; compare to 'coded_width', 'coded_height'.
-            for (JsonNode stream : result.at("/streams")) {
-                Track track = new Track(stream.get("index").asInt(), stream.get("codec_type").asText(), stream.at("/tags/language").asText(), stream.get("codec_name").asText());
-                metaData.addTrack(track);
-
-                if (track.isVideo() && stream.has("width") && stream.has("height")) {
-                    metaData.setWidth(stream.get("width").asInt());
-                    metaData.setHeight(stream.get("height").asInt());
-                }
-            }
-            ObjectMapper mapper = Util.getObjectMapper();
-            for (JsonNode chapterJson : result.at("/chapters")) {
-                Chapter chapter = mapper.convertValue(chapterJson, Chapter.class);
-                metaData.addChapter(chapter);
-            }
+            populateFromJson(result, metaData);
         } catch (Throwable x) {
             LOG.warn("Error when parsing metadata in {}", file, x);
         }
@@ -154,7 +103,150 @@ public class FFmpegParser extends MetaDataParser {
         return metaData;
     }
 
-    private static String getData(JsonNode node, String keyName) {
+    /**
+     * Populates the supplied {@link MetaData} from an already-parsed {@code ffprobe} JSON tree.
+     * Factored out of {@link #getRawMetaData} so unit tests can feed synthesized JSON without
+     * shelling out to ffprobe — the subprocess invocation is the only thing
+     * {@code getRawMetaData} adds on top.
+     */
+    void populateFromJson(JsonNode result, MetaData metaData) {
+        metaData.setDuration(result.at("/format/duration").asDouble());
+        // Bitrate is in Kb/s
+        metaData.setBitRate(result.at("/format/bit_rate").asInt() / 1000);
+
+        metaData.setAlbumArtist(getData(result, "album_artist"));
+        metaData.setArtist(getData(result, "artist"));
+        metaData.setAlbumName(getData(result, "album"));
+        metaData.setGenre(getData(result, "genre"));
+        metaData.setTitle(getData(result, "title"));
+
+        // Sort-name trio. ffprobe surfaces ID3v2 sort frames as hyphenated names
+        // (TSOT → title-sort, TSOA → album-sort, TSO2 → album_artist_sort) and Vorbis
+        // comments case-preserved (TITLESORT etc.); getData covers the case variations.
+        metaData.setSortName(getDataAny(result, "title-sort", "TITLESORT", "TSOT"));
+        metaData.setAlbumSortName(getDataAny(result, "album-sort", "ALBUMSORT", "TSOA"));
+        metaData.setArtistSortName(getDataAny(result, "album-artist-sort", "album_artist_sort", "ALBUMARTISTSORT", "TSO2"));
+
+        metaData.setBpm(parseBpm(getDataAny(result, "TBPM", "BPM")));
+        metaData.setCompilation(parseCompilation(getDataAny(result, "compilation", "TCMP")));
+        metaData.setDiscSubtitle(getDataAny(result, "DISCSUBTITLE", "TSST"));
+
+        // MusicBrainz IDs — Picard writes spaced "MusicBrainz Album Id" in iTunes-style atoms
+        // and TXXX descriptors; Vorbis comments use the underscored uppercase form.
+        metaData.setMusicBrainzReleaseId(getDataAny(result,
+                "MUSICBRAINZ_ALBUMID", "MusicBrainz Album Id", "musicbrainz_albumid"));
+        metaData.setMusicBrainzRecordingId(getDataAny(result,
+                "MUSICBRAINZ_TRACKID", "MusicBrainz Track Id", "musicbrainz_trackid"));
+        metaData.setMusicBrainzArtistId(getDataAny(result,
+                "MUSICBRAINZ_ALBUMARTISTID", "MusicBrainz Album Artist Id", "musicbrainz_albumartistid"));
+
+        // ReplayGain four-field plus Opus R128 fallback for the gains. parseTrackGain/parseAlbumGain
+        // prefer REPLAYGAIN_* when present; R128 fires only when RG is null (a present-but-unparseable
+        // RG returns null without R128 fallthrough — operator's authored tag wins).
+        metaData.setReplayGainTrackGain(parseTrackGain(result));
+        metaData.setReplayGainAlbumGain(parseAlbumGain(result));
+        metaData.setReplayGainTrackPeak(parseReplayGain(getData(result, RG_TRACK_PEAK)));
+        metaData.setReplayGainAlbumPeak(parseReplayGain(getData(result, RG_ALBUM_PEAK)));
+
+        String data = getData(result, "track");
+        if (data != null) {
+            data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
+            if (NumberUtils.isCreatable(data)) {
+                metaData.setTrackNumber(NumberUtils.createInteger(data));
+            }
+        }
+        data = getData(result, "disc");
+        if (data != null) {
+            data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
+            if (NumberUtils.isCreatable(data)) {
+                metaData.setDiscNumber(NumberUtils.createInteger(data));
+            }
+        }
+
+        data = getData(result, "discnumber");
+        if (data != null) {
+            data = data.replaceFirst("^[\\s\\p{C}]*0+(?!$)", "");
+            if (NumberUtils.isCreatable(data)) {
+                metaData.setDiscNumber(NumberUtils.createInteger(data));
+            }
+        }
+        data = getData(result, "date");
+        // Raw date is exposed as releaseDate so the response can surface month/day when the tag
+        // carries them; the integer year derives from the same source via parseYear, which
+        // extracts the leading 4 digits for full YYYY-MM-DD values — matches JaudiotaggerParser
+        // (FieldKey.YEAR + YEAR_NUMBER_PATTERN) so the same input file yields the same year
+        // through either parser.
+        metaData.setReleaseDate(data);
+        metaData.setYear(parseYear(data));
+        // originalReleaseDate fallback order mirrors JaudiotaggerParser: ORIGINALRELEASEDATE
+        // (Vorbis) → ORIGINAL_YEAR / TDOR (ID3v2.4) → TORY (ID3v2.3).
+        metaData.setOriginalReleaseDate(getDataAny(result,
+                "originalreleasedate", "originalyear", "TDOR", "TORY"));
+
+        // Find the first (if any) stream that has dimensions and use those.
+        // 'width' and 'height' are display dimensions; compare to 'coded_width', 'coded_height'.
+        for (JsonNode stream : result.at("/streams")) {
+            Track track = new Track(stream.get("index").asInt(), stream.get("codec_type").asText(), stream.at("/tags/language").asText(), stream.get("codec_name").asText());
+            metaData.addTrack(track);
+
+            if (track.isVideo() && stream.has("width") && stream.has("height")) {
+                metaData.setWidth(stream.get("width").asInt());
+                metaData.setHeight(stream.get("height").asInt());
+            }
+        }
+        ObjectMapper mapper = Util.getObjectMapper();
+        for (JsonNode chapterJson : result.at("/chapters")) {
+            Chapter chapter = mapper.convertValue(chapterJson, Chapter.class);
+            metaData.addChapter(chapter);
+        }
+    }
+
+    /**
+     * Returns the track gain in ReplayGain-equivalent dB, preferring the ReplayGain tag when
+     * present and falling back to the Opus R128 tag otherwise. A present-but-unparseable RG
+     * tag returns {@code null} and does NOT fall through to R128 — the operator's authored
+     * tag takes precedence over any inferred R128 value. Mirrors
+     * {@link JaudiotaggerParser#parseTrackGain} exactly so clients can't observe drift
+     * between the two parsers for the same file.
+     */
+    Double parseTrackGain(JsonNode node) {
+        String rg = getData(node, RG_TRACK_GAIN);
+        if (rg != null) {
+            return parseReplayGain(rg);
+        }
+        return parseR128GainQ78(getData(node, R128_TRACK_GAIN));
+    }
+
+    /**
+     * Returns the album gain in ReplayGain-equivalent dB, preferring the ReplayGain tag when
+     * present and falling back to the Opus R128 tag otherwise. Same precedence rule as
+     * {@link #parseTrackGain}.
+     */
+    Double parseAlbumGain(JsonNode node) {
+        String rg = getData(node, RG_ALBUM_GAIN);
+        if (rg != null) {
+            return parseReplayGain(rg);
+        }
+        return parseR128GainQ78(getData(node, R128_ALBUM_GAIN));
+    }
+
+    /**
+     * Walks {@code keys} in order, returning the first non-null value from {@link #getData}.
+     * Used where a single semantic field has several common physical tag names (e.g. Vorbis
+     * upper-snake vs ID3v2 four-letter frame vs MP4 freeform), since {@code getData}'s
+     * internal case-variation handles only one base key at a time.
+     */
+    static String getDataAny(JsonNode node, String... keys) {
+        for (String key : keys) {
+            String value = getData(node, key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    static String getData(JsonNode node, String keyName) {
         // Create a list of key variations to handle different cases
         List<String> keyVariations = ImmutableList.of(
             keyName.toLowerCase(),

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -70,17 +70,8 @@ public class JaudiotaggerParser extends MetaDataParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(JaudiotaggerParser.class);
 
-    static final String RG_TRACK_GAIN = "REPLAYGAIN_TRACK_GAIN";
-    static final String RG_ALBUM_GAIN = "REPLAYGAIN_ALBUM_GAIN";
-    static final String RG_TRACK_PEAK = "REPLAYGAIN_TRACK_PEAK";
-    static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
-
-    // Opus carries EBU R128 gain (an integer Q7.8 fixed-point value referenced to -23 LUFS)
-    // rather than ReplayGain dB referenced to -18 dBFS. Both can co-exist on the same file;
-    // RG is preferred when present and R128 is converted to RG-equivalent dB otherwise. See
-    // {@link #parseR128GainQ78} for the conversion.
-    static final String R128_TRACK_GAIN = "R128_TRACK_GAIN";
-    static final String R128_ALBUM_GAIN = "R128_ALBUM_GAIN";
+    // ReplayGain + Opus R128 tag-name constants live on {@link MetaDataParser} so both
+    // JaudiotaggerParser and FFmpegParser reference one source of truth.
 
     // MP4 stores ReplayGain in iTunes-style reverse-DNS freeform atoms keyed by lowercase
     // descriptor (replaygain_track_gain, replaygain_album_gain, replaygain_track_peak,
@@ -367,27 +358,6 @@ public class JaudiotaggerParser extends MetaDataParser {
             return parseReplayGain(rg);
         }
         return parseR128GainQ78(getReplayGainField(tag, R128_ALBUM_GAIN));
-    }
-
-    /**
-     * Converts an Opus R128 integer gain (Q7.8 fixed-point, referenced to -23 LUFS) to a
-     * ReplayGain-equivalent dB value (ReplayGain 2 is anchored at -18 LUFS):
-     * {@code dB = q78 / 256 + 5}. The +5 dB shift accounts for the difference between EBU
-     * R128's -23 LUFS reference and the ReplayGain 2 -18 LUFS reference; the same mapping is
-     * used by <a href="https://github.com/Moonbase59/loudgain">loudgain</a>,
-     * <a href="https://github.com/complexlogic/rsgain">rsgain</a>, mutagen, and kid3.
-     * Returns {@code null} on blank, non-integer, or out-of-int-range input.
-     */
-    static Double parseR128GainQ78(String raw) {
-        if (raw == null) {
-            return null;
-        }
-        try {
-            int q78 = Integer.parseInt(raw.trim());
-            return q78 / 256.0 + 5.0;
-        } catch (NumberFormatException e) {
-            return null;
-        }
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaDataParser.java
@@ -42,6 +42,20 @@ public abstract class MetaDataParser {
     protected static final Pattern TRACK_NUMBER_PATTERN = Pattern.compile("(\\d+)/\\d+");
     protected static final Pattern YEAR_NUMBER_PATTERN = Pattern.compile("(\\d{4}).*");
 
+    // ReplayGain 2.0 tag names — the canonical Vorbis-comment / TXXX-descriptor / iTunes-freeform
+    // keys for the four-field ReplayGain set. Lifted here so JaudiotaggerParser and FFmpegParser
+    // share one source of truth and clients can't observe a key-mismatch between formats.
+    static final String RG_TRACK_GAIN = "REPLAYGAIN_TRACK_GAIN";
+    static final String RG_ALBUM_GAIN = "REPLAYGAIN_ALBUM_GAIN";
+    static final String RG_TRACK_PEAK = "REPLAYGAIN_TRACK_PEAK";
+    static final String RG_ALBUM_PEAK = "REPLAYGAIN_ALBUM_PEAK";
+
+    // Opus EBU R128 gain tag names — Q7.8 fixed-point integer values referenced to -23 LUFS,
+    // not RG-2 dB. Both can co-exist on the same file; ReplayGain is preferred when present,
+    // and R128 is converted to RG-equivalent dB via {@link #parseR128GainQ78}.
+    static final String R128_TRACK_GAIN = "R128_TRACK_GAIN";
+    static final String R128_ALBUM_GAIN = "R128_ALBUM_GAIN";
+
     /**
      * Parses meta data for the given file.
      *
@@ -318,6 +332,27 @@ public abstract class MetaDataParser {
             double d = Double.parseDouble(str);
             return Double.isFinite(d) ? d : null;
         } catch (NumberFormatException x) {
+            return null;
+        }
+    }
+
+    /**
+     * Converts an Opus R128 integer gain (Q7.8 fixed-point, referenced to -23 LUFS) to a
+     * ReplayGain-equivalent dB value (ReplayGain 2 is anchored at -18 LUFS):
+     * {@code dB = q78 / 256 + 5}. The +5 dB shift accounts for the difference between EBU
+     * R128's -23 LUFS reference and the ReplayGain 2 -18 LUFS reference; the same mapping is
+     * used by <a href="https://github.com/Moonbase59/loudgain">loudgain</a>,
+     * <a href="https://github.com/complexlogic/rsgain">rsgain</a>, mutagen, and kid3.
+     * Returns {@code null} on blank, non-integer, or out-of-int-range input.
+     */
+    static Double parseR128GainQ78(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            int q78 = Integer.parseInt(raw.trim());
+            return q78 / 256.0 + 5.0;
+        } catch (NumberFormatException e) {
             return null;
         }
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/FFmpegParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/FFmpegParserTestCase.java
@@ -1,0 +1,427 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.airsonic.player.service.metadata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit test of {@link FFmpegParser}'s scalar field extraction. Tests feed synthesized
+ * ffprobe JSON into {@link FFmpegParser#populateFromJson} directly to avoid the subprocess
+ * dependency — the JSON shape mirrors what {@code ffprobe -print_format json -show_format
+ * -show_streams} produces. Resolves the #258 premise: confirms the 13.2.x parser-fed
+ * OpenSubsonic fields (sortName, bpm, ReplayGain four-field, Opus R128 fallback, compilation,
+ * releaseDate, originalReleaseDate, discSubtitle, MusicBrainz IDs) all populate via the
+ * FFmpeg path that .opus and other Jaudiotagger-unsupported audio formats route through.
+ */
+public class FFmpegParserTestCase {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Builds an ffprobe-shaped JsonNode with the given {@code /format/tags/*} entries.
+     * Insertion order is preserved so tests can observe which key wins in fallback chains
+     * (Jackson's tree treats sibling keys as a LinkedHashMap-backed ObjectNode).
+     */
+    private JsonNode probeJson(Map<String, String> formatTags) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        Map<String, Object> format = new LinkedHashMap<>();
+        format.put("duration", "180.0");
+        format.put("bit_rate", "192000");
+        format.put("tags", formatTags);
+        root.put("format", format);
+        return mapper.valueToTree(root);
+    }
+
+    private static Map<String, String> tags(String... kv) {
+        if (kv.length % 2 != 0) {
+            throw new IllegalArgumentException("kv must be (key, value)+");
+        }
+        Map<String, String> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    private MetaData parse(Map<String, String> formatTags) {
+        MetaData metaData = new MetaData();
+        new FFmpegParser().populateFromJson(probeJson(formatTags), metaData);
+        return metaData;
+    }
+
+    // ----- sortName trio -----
+
+    @Test
+    public void testSortNameFromId3HyphenatedKey() {
+        // ID3v2 TSOT → ffprobe surfaces as "title-sort"
+        assertEquals("Aria", parse(tags("title-sort", "Aria")).getSortName());
+    }
+
+    @Test
+    public void testSortNameFromVorbisTitleSort() {
+        assertEquals("Aria", parse(tags("TITLESORT", "Aria")).getSortName());
+    }
+
+    @Test
+    public void testAlbumSortNameFromAlbumSort() {
+        assertEquals("Goldberg", parse(tags("album-sort", "Goldberg")).getAlbumSortName());
+    }
+
+    @Test
+    public void testArtistSortNameFromHyphenated() {
+        assertEquals("Bach", parse(tags("album-artist-sort", "Bach")).getArtistSortName());
+    }
+
+    @Test
+    public void testArtistSortNameFromUnderscoreUnderscoreVariant() {
+        assertEquals("Bach", parse(tags("album_artist_sort", "Bach")).getArtistSortName());
+    }
+
+    @Test
+    public void testSortNamesAbsentReturnNull() {
+        MetaData m = parse(tags());
+        assertNull(m.getSortName());
+        assertNull(m.getAlbumSortName());
+        assertNull(m.getArtistSortName());
+    }
+
+    // ----- bpm -----
+
+    @Test
+    public void testBpmFromTbpm() {
+        assertEquals(Integer.valueOf(128), parse(tags("TBPM", "128")).getBpm());
+    }
+
+    @Test
+    public void testBpmFromVorbisBpm() {
+        assertEquals(Integer.valueOf(128), parse(tags("BPM", "128")).getBpm());
+    }
+
+    @Test
+    public void testBpmAbsentReturnsNull() {
+        assertNull(parse(tags()).getBpm());
+    }
+
+    // ----- compilation -----
+
+    @Test
+    public void testCompilationFromIs1() {
+        assertEquals(Boolean.TRUE, parse(tags("compilation", "1")).getCompilation());
+    }
+
+    @Test
+    public void testCompilationFromTcmp() {
+        assertEquals(Boolean.TRUE, parse(tags("TCMP", "1")).getCompilation());
+    }
+
+    @Test
+    public void testCompilationFromIs0() {
+        assertEquals(Boolean.FALSE, parse(tags("compilation", "0")).getCompilation());
+    }
+
+    @Test
+    public void testCompilationAbsentReturnsNull() {
+        assertNull(parse(tags()).getCompilation());
+    }
+
+    // ----- releaseDate vs year -----
+
+    @Test
+    public void testReleaseDateFromDate() {
+        // Year-only date both populates year (existing behavior) AND surfaces as raw releaseDate.
+        MetaData m = parse(tags("date", "2004"));
+        assertEquals("2004", m.getReleaseDate());
+        assertEquals(Integer.valueOf(2004), m.getYear());
+    }
+
+    @Test
+    public void testReleaseDateCarriesFullDate() {
+        // YYYY-MM-DD: releaseDate keeps the raw value; year is the leading 4 digits via
+        // parseYear (shared with JaudiotaggerParser). No parser drift for full-date tags.
+        MetaData m = parse(tags("date", "2004-03-15"));
+        assertEquals("2004-03-15", m.getReleaseDate());
+        assertEquals(Integer.valueOf(2004), m.getYear());
+    }
+
+    @Test
+    public void testReleaseDateAbsentReturnsNull() {
+        MetaData m = parse(tags());
+        assertNull(m.getReleaseDate());
+        assertNull(m.getYear());
+    }
+
+    // ----- originalReleaseDate -----
+
+    @Test
+    public void testOriginalReleaseDateFromOriginalreleasedate() {
+        assertEquals("1981", parse(tags("originalreleasedate", "1981")).getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testOriginalReleaseDateFallsBackToOriginalyear() {
+        assertEquals("1981", parse(tags("originalyear", "1981")).getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testOriginalReleaseDateFallsBackToTdor() {
+        assertEquals("1981", parse(tags("TDOR", "1981")).getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testOriginalReleaseDateFallsBackToTory() {
+        assertEquals("1981", parse(tags("TORY", "1981")).getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testOriginalReleaseDatePrefersFirstInChain() {
+        // originalreleasedate beats originalyear beats TDOR beats TORY.
+        assertEquals("1981", parse(tags(
+                "originalreleasedate", "1981",
+                "originalyear", "1982",
+                "TDOR", "1983",
+                "TORY", "1984")).getOriginalReleaseDate());
+    }
+
+    @Test
+    public void testOriginalReleaseDateAbsentReturnsNull() {
+        assertNull(parse(tags()).getOriginalReleaseDate());
+    }
+
+    // ----- discSubtitle -----
+
+    @Test
+    public void testDiscSubtitleFromVorbisKey() {
+        assertEquals("Disc 1: Aria", parse(tags("DISCSUBTITLE", "Disc 1: Aria")).getDiscSubtitle());
+    }
+
+    @Test
+    public void testDiscSubtitleFromTsst() {
+        assertEquals("Side B", parse(tags("TSST", "Side B")).getDiscSubtitle());
+    }
+
+    @Test
+    public void testDiscSubtitleAbsentReturnsNull() {
+        assertNull(parse(tags()).getDiscSubtitle());
+    }
+
+    // ----- MusicBrainz IDs -----
+
+    @Test
+    public void testMusicBrainzReleaseIdFromUnderscoredUpper() {
+        assertEquals("uuid-album", parse(tags("MUSICBRAINZ_ALBUMID", "uuid-album")).getMusicBrainzReleaseId());
+    }
+
+    @Test
+    public void testMusicBrainzReleaseIdFromSpacedKey() {
+        assertEquals("uuid-album", parse(tags("MusicBrainz Album Id", "uuid-album")).getMusicBrainzReleaseId());
+    }
+
+    @Test
+    public void testMusicBrainzRecordingIdFromUnderscoredUpper() {
+        assertEquals("uuid-track", parse(tags("MUSICBRAINZ_TRACKID", "uuid-track")).getMusicBrainzRecordingId());
+    }
+
+    @Test
+    public void testMusicBrainzArtistIdFromUnderscoredUpper() {
+        assertEquals("uuid-artist", parse(tags("MUSICBRAINZ_ALBUMARTISTID", "uuid-artist")).getMusicBrainzArtistId());
+    }
+
+    @Test
+    public void testMusicBrainzIdsAbsentReturnNull() {
+        MetaData m = parse(tags());
+        assertNull(m.getMusicBrainzReleaseId());
+        assertNull(m.getMusicBrainzRecordingId());
+        assertNull(m.getMusicBrainzArtistId());
+    }
+
+    // ----- ReplayGain four-field (gains via parseTrackGain/parseAlbumGain; peaks direct) -----
+
+    @Test
+    public void testReplayGainFourFieldPopulates() {
+        MetaData m = parse(tags(
+                "REPLAYGAIN_TRACK_GAIN", "-7.20 dB",
+                "REPLAYGAIN_ALBUM_GAIN", "-5.10 dB",
+                "REPLAYGAIN_TRACK_PEAK", "0.988553",
+                "REPLAYGAIN_ALBUM_PEAK", "0.995123"));
+        assertEquals(Double.valueOf(-7.2), m.getReplayGainTrackGain());
+        assertEquals(Double.valueOf(-5.1), m.getReplayGainAlbumGain());
+        assertEquals(Double.valueOf(0.988553), m.getReplayGainTrackPeak());
+        assertEquals(Double.valueOf(0.995123), m.getReplayGainAlbumPeak());
+    }
+
+    @Test
+    public void testReplayGainAbsentReturnsAllNull() {
+        MetaData m = parse(tags());
+        assertNull(m.getReplayGainTrackGain());
+        assertNull(m.getReplayGainAlbumGain());
+        assertNull(m.getReplayGainTrackPeak());
+        assertNull(m.getReplayGainAlbumPeak());
+    }
+
+    // ----- RG-then-R128 precedence (mirrors #205 PR-A's JaudiotaggerParser semantics) -----
+
+    @Test
+    public void testTrackGainRgOnly() {
+        // REPLAYGAIN_TRACK_GAIN present, R128_TRACK_GAIN absent → trackGain from RG, no conversion.
+        MetaData m = parse(tags("REPLAYGAIN_TRACK_GAIN", "-7.20 dB"));
+        assertEquals(Double.valueOf(-7.2), m.getReplayGainTrackGain());
+    }
+
+    @Test
+    public void testTrackGainR128OnlyAppliesShift() {
+        // R128_TRACK_GAIN = 0 (Q7.8) → 5.0 dB after the +5 reference shift. The Opus path.
+        MetaData m = parse(tags("R128_TRACK_GAIN", "0"));
+        assertEquals(Double.valueOf(5.0), m.getReplayGainTrackGain());
+    }
+
+    @Test
+    public void testTrackGainR128PositiveAppliesShift() {
+        // 256 Q7.8 = 1.0 dB raw → 6.0 dB after shift.
+        MetaData m = parse(tags("R128_TRACK_GAIN", "256"));
+        assertEquals(Double.valueOf(6.0), m.getReplayGainTrackGain());
+    }
+
+    @Test
+    public void testTrackGainRgWinsWhenBothPresent() {
+        // RG present AND R128 present → RG wins; R128 ignored.
+        MetaData m = parse(tags(
+                "REPLAYGAIN_TRACK_GAIN", "-6.50 dB",
+                "R128_TRACK_GAIN", "256"));     // would be 6.0 dB after shift
+        assertEquals(Double.valueOf(-6.5), m.getReplayGainTrackGain());
+    }
+
+    @Test
+    public void testTrackGainMalformedRgDoesNotFallThroughToR128() {
+        // Present-but-unparseable RG returns null without R128 consultation. The operator's
+        // authored RG tag takes precedence even when it's broken.
+        MetaData m = parse(tags(
+                "REPLAYGAIN_TRACK_GAIN", "loud",
+                "R128_TRACK_GAIN", "256"));
+        assertNull(m.getReplayGainTrackGain());
+    }
+
+    @Test
+    public void testAlbumGainRgOnly() {
+        MetaData m = parse(tags("REPLAYGAIN_ALBUM_GAIN", "-4.25 dB"));
+        assertEquals(Double.valueOf(-4.25), m.getReplayGainAlbumGain());
+    }
+
+    @Test
+    public void testAlbumGainR128OnlyAppliesShift() {
+        // -512 Q7.8 = -2.0 dB raw → 3.0 dB after shift.
+        MetaData m = parse(tags("R128_ALBUM_GAIN", "-512"));
+        assertEquals(Double.valueOf(3.0), m.getReplayGainAlbumGain());
+    }
+
+    @Test
+    public void testAlbumGainRgWinsWhenBothPresent() {
+        MetaData m = parse(tags(
+                "REPLAYGAIN_ALBUM_GAIN", "-4.25 dB",
+                "R128_ALBUM_GAIN", "256"));
+        assertEquals(Double.valueOf(-4.25), m.getReplayGainAlbumGain());
+    }
+
+    @Test
+    public void testAlbumGainMalformedRgDoesNotFallThroughToR128() {
+        MetaData m = parse(tags(
+                "REPLAYGAIN_ALBUM_GAIN", "loud",
+                "R128_ALBUM_GAIN", "256"));
+        assertNull(m.getReplayGainAlbumGain());
+    }
+
+    // ----- Opus end-to-end (closes #258 premise) -----
+
+    /**
+     * Synthesized ffprobe output for an Opus file with R128 tags. Mirrors the shape produced by
+     * {@code ffprobe -v quiet -print_format json -show_format -show_streams} against a real
+     * tagged .opus file: Opus codec stream, Vorbis-comment-flavored tag keys in
+     * {@code /format/tags}, R128_TRACK_GAIN and R128_ALBUM_GAIN as Q7.8 integers. This is
+     * exactly the case that #258 documents as dead code through JaudiotaggerParser — the
+     * test asserts that all the 13.2.x fields populate via FFmpegParser, including the
+     * R128-derived gains.
+     */
+    @Test
+    public void testOpusFileWithR128AndMusicBrainzTagsEndToEnd() {
+        // Note: the existing FFmpegParser reads albumArtist via getData("album_artist") with
+        // lower/upper/capitalize variations — it does NOT match the Vorbis-canonical
+        // "ALBUMARTIST" form (no separator). Real .opus files typically use ALBUMARTIST, so
+        // the existing albumArtist extraction has a Vorbis blind spot. That's a PRE-EXISTING
+        // gap (out of scope for #226 PR1, which is about the new 13.2.x fields); this test
+        // uses "ALBUM_ARTIST" so albumArtist still populates and the test stays focused on
+        // the R128 / new-field surface.
+        MetaData m = parse(tags(
+                "ARTIST", "Daft Punk",
+                "ALBUM", "Discovery",
+                "TITLE", "One More Time",
+                "ALBUM_ARTIST", "Daft Punk",
+                "DATE", "2001",
+                "GENRE", "Electronic",
+                "TBPM", "123",
+                "TITLESORT", "One More Time",
+                "ALBUMSORT", "Discovery",
+                "DISCSUBTITLE", "Vinyl Side A",
+                "MUSICBRAINZ_ALBUMID", "alb-uuid",
+                "MUSICBRAINZ_TRACKID", "trk-uuid",
+                "MUSICBRAINZ_ALBUMARTISTID", "art-uuid",
+                "R128_TRACK_GAIN", "256",     // 6.0 dB after shift
+                "R128_ALBUM_GAIN", "-512",    // 3.0 dB after shift
+                "REPLAYGAIN_TRACK_PEAK", "0.998"));
+        // Standard fields that already worked
+        assertEquals("Daft Punk", m.getArtist());
+        assertEquals("Discovery", m.getAlbumName());
+        assertEquals("One More Time", m.getTitle());
+        assertEquals("Daft Punk", m.getAlbumArtist());
+        assertEquals("Electronic", m.getGenre());
+        // New 13.2.x fields, all from this PR
+        assertEquals(Integer.valueOf(123), m.getBpm());
+        assertEquals("One More Time", m.getSortName());
+        assertEquals("Discovery", m.getAlbumSortName());
+        assertEquals("Vinyl Side A", m.getDiscSubtitle());
+        assertEquals("alb-uuid", m.getMusicBrainzReleaseId());
+        assertEquals("trk-uuid", m.getMusicBrainzRecordingId());
+        assertEquals("art-uuid", m.getMusicBrainzArtistId());
+        // R128 → RG-equivalent dB, the actual #258 resolution
+        assertEquals(Double.valueOf(6.0), m.getReplayGainTrackGain());
+        assertEquals(Double.valueOf(3.0), m.getReplayGainAlbumGain());
+        assertEquals(Double.valueOf(0.998), m.getReplayGainTrackPeak());
+        // releaseDate raw + year integer both from "DATE"
+        assertEquals("2001", m.getReleaseDate());
+        assertEquals(Integer.valueOf(2001), m.getYear());
+    }
+
+    // ----- getDataAny — first non-null wins -----
+
+    @Test
+    public void testGetDataAnyReturnsFirstNonNull() {
+        JsonNode node = probeJson(tags("k2", "v2", "k3", "v3"));
+        assertEquals("v2", FFmpegParser.getDataAny(node, "k1", "k2", "k3"));
+    }
+
+    @Test
+    public void testGetDataAnyAllAbsentReturnsNull() {
+        JsonNode node = probeJson(tags());
+        assertNull(FFmpegParser.getDataAny(node, "k1", "k2"));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -49,26 +49,26 @@ public class JaudiotaggerParserTestCase {
     @Test
     public void testGetReplayGainFieldFromId3v2Txxx() {
         ID3v24Tag tag = tagWithTxxx("REPLAYGAIN_TRACK_GAIN", "-7.20 dB");
-        assertEquals("-7.20 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+        assertEquals("-7.20 dB", JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
     @Test
     public void testGetReplayGainFieldDescriptionMatchIsCaseInsensitive() {
         ID3v24Tag tag = tagWithTxxx("replaygain_track_gain", "-6.50 dB");
-        assertEquals("-6.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+        assertEquals("-6.50 dB", JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
     @Test
     public void testGetReplayGainFieldMissingFrameReturnsNull() {
         ID3v24Tag tag = tagWithTxxx("REPLAYGAIN_TRACK_GAIN", "-7.20 dB");
-        assertNull(JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_ALBUM_PEAK));
+        assertNull(JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_ALBUM_PEAK));
     }
 
     @Test
     public void testGetReplayGainFieldFromVorbisComment() throws Exception {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
         tag.setField("REPLAYGAIN_TRACK_GAIN", "-7.50 dB");
-        assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+        assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
     private static Mp4Tag mp4TagWithItunesFreeform(String descriptorLower, String value) {
@@ -88,51 +88,24 @@ public class JaudiotaggerParserTestCase {
     public void testGetReplayGainFieldFromMp4FreeformAtom() {
         Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain", "-7.50 dB");
         assertEquals("-7.50 dB",
-                JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_TRACK_GAIN));
+                JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
     @Test
     public void testGetReplayGainFieldMp4MissingAtomReturnsNull() {
         Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain", "-7.50 dB");
-        assertNull(JaudiotaggerParser.getReplayGainField(tag, JaudiotaggerParser.RG_ALBUM_PEAK));
+        assertNull(JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_ALBUM_PEAK));
     }
 
-    @Test
-    public void testParseR128GainQ78ReferenceShiftAt0() {
-        // Q7.8 of 0 → 0/256 + 5 = 5.0 dB (a track already at -23 LUFS reads as +5 dB in RG terms)
-        assertEquals(Double.valueOf(5.0), JaudiotaggerParser.parseR128GainQ78("0"));
-    }
-
-    @Test
-    public void testParseR128GainQ78PositiveValues() {
-        // Q7.8 of 256 = 1 dB raw → 1 + 5 = 6 dB; -512 = -2 raw → -2 + 5 = 3 dB
-        assertEquals(Double.valueOf(6.0), JaudiotaggerParser.parseR128GainQ78("256"));
-        assertEquals(Double.valueOf(3.0), JaudiotaggerParser.parseR128GainQ78("-512"));
-        // Trimming
-        assertEquals(Double.valueOf(6.0), JaudiotaggerParser.parseR128GainQ78("  256  "));
-    }
-
-    @Test
-    public void testParseR128GainQ78MalformedReturnsNull() {
-        assertNull(JaudiotaggerParser.parseR128GainQ78(null));
-        assertNull(JaudiotaggerParser.parseR128GainQ78(""));
-        assertNull(JaudiotaggerParser.parseR128GainQ78("not-an-int"));
-        assertNull(JaudiotaggerParser.parseR128GainQ78("-7.50 dB"));
-    }
-
-    @Test
-    public void testParseR128GainQ78OutOfIntRangeReturnsNull() {
-        // Integer.parseInt rejects values outside [Integer.MIN_VALUE, Integer.MAX_VALUE] with
-        // NumberFormatException — the catch in parseR128GainQ78 normalizes that to null.
-        assertNull(JaudiotaggerParser.parseR128GainQ78("999999999999"));
-        assertNull(JaudiotaggerParser.parseR128GainQ78("-999999999999"));
-    }
+    // parseR128GainQ78 itself was lifted to MetaDataParser (so FFmpegParser can reuse the
+    // same Q7.8 + 5 dB shift). Its dedicated unit tests now live in MetaDataParserTestCase,
+    // alongside the other base-class parse helpers (parseBpm, parseReplayGain, parseCompilation).
 
     @Test
     public void testParseTrackGainPrefersRgWhenBothPresent() throws Exception {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
-        tag.setField(JaudiotaggerParser.RG_TRACK_GAIN, "-6.50 dB");
-        tag.setField(JaudiotaggerParser.R128_TRACK_GAIN, "256"); // would be 6.0 dB after shift
+        tag.setField(MetaDataParser.RG_TRACK_GAIN, "-6.50 dB");
+        tag.setField(MetaDataParser.R128_TRACK_GAIN, "256"); // would be 6.0 dB after shift
         JaudiotaggerParser parser = new JaudiotaggerParser(null);
         assertEquals(Double.valueOf(-6.5), parser.parseTrackGain(tag));
     }
@@ -140,7 +113,7 @@ public class JaudiotaggerParserTestCase {
     @Test
     public void testParseTrackGainFallsBackToR128WhenOnlyR128() throws Exception {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
-        tag.setField(JaudiotaggerParser.R128_TRACK_GAIN, "0"); // 5.0 dB after shift
+        tag.setField(MetaDataParser.R128_TRACK_GAIN, "0"); // 5.0 dB after shift
         JaudiotaggerParser parser = new JaudiotaggerParser(null);
         assertEquals(Double.valueOf(5.0), parser.parseTrackGain(tag));
     }
@@ -148,8 +121,8 @@ public class JaudiotaggerParserTestCase {
     @Test
     public void testParseAlbumGainPrefersRgWhenBothPresent() throws Exception {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
-        tag.setField(JaudiotaggerParser.RG_ALBUM_GAIN, "-4.25 dB");
-        tag.setField(JaudiotaggerParser.R128_ALBUM_GAIN, "256");
+        tag.setField(MetaDataParser.RG_ALBUM_GAIN, "-4.25 dB");
+        tag.setField(MetaDataParser.R128_ALBUM_GAIN, "256");
         JaudiotaggerParser parser = new JaudiotaggerParser(null);
         assertEquals(Double.valueOf(-4.25), parser.parseAlbumGain(tag));
     }
@@ -157,7 +130,7 @@ public class JaudiotaggerParserTestCase {
     @Test
     public void testParseAlbumGainFallsBackToR128WhenOnlyR128() throws Exception {
         VorbisCommentTag tag = VorbisCommentTag.createNewTag();
-        tag.setField(JaudiotaggerParser.R128_ALBUM_GAIN, "-512"); // 3.0 dB after shift
+        tag.setField(MetaDataParser.R128_ALBUM_GAIN, "-512"); // 3.0 dB after shift
         JaudiotaggerParser parser = new JaudiotaggerParser(null);
         assertEquals(Double.valueOf(3.0), parser.parseAlbumGain(tag));
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
@@ -208,4 +208,39 @@ public class MetaDataParserTestCase {
         assertNull(MetaDataParser.parseCompilation("2"));
         assertNull(MetaDataParser.parseCompilation("compilation"));
     }
+
+    // parseR128GainQ78 — Q7.8 fixed-point R128 gain → ReplayGain-equivalent dB.
+    // Behavior lifted unchanged from JaudiotaggerParser so FFmpegParser can reuse it for
+    // .opus files (jaudiotagger 3.0.1 has no Opus reader; see #258 and #226 PR1).
+
+    @Test
+    public void testParseR128GainQ78ReferenceShiftAt0() {
+        // Q7.8 of 0 → 0/256 + 5 = 5.0 dB (a track already at -23 LUFS reads as +5 dB in RG terms)
+        assertEquals(Double.valueOf(5.0), MetaDataParser.parseR128GainQ78("0"));
+    }
+
+    @Test
+    public void testParseR128GainQ78PositiveValues() {
+        // Q7.8 of 256 = 1 dB raw → 1 + 5 = 6 dB; -512 = -2 raw → -2 + 5 = 3 dB
+        assertEquals(Double.valueOf(6.0), MetaDataParser.parseR128GainQ78("256"));
+        assertEquals(Double.valueOf(3.0), MetaDataParser.parseR128GainQ78("-512"));
+        // Trimming
+        assertEquals(Double.valueOf(6.0), MetaDataParser.parseR128GainQ78("  256  "));
+    }
+
+    @Test
+    public void testParseR128GainQ78MalformedReturnsNull() {
+        assertNull(MetaDataParser.parseR128GainQ78(null));
+        assertNull(MetaDataParser.parseR128GainQ78(""));
+        assertNull(MetaDataParser.parseR128GainQ78("not-an-int"));
+        assertNull(MetaDataParser.parseR128GainQ78("-7.50 dB"));
+    }
+
+    @Test
+    public void testParseR128GainQ78OutOfIntRangeReturnsNull() {
+        // Integer.parseInt rejects values outside [Integer.MIN_VALUE, Integer.MAX_VALUE] with
+        // NumberFormatException — the catch in parseR128GainQ78 normalizes that to null.
+        assertNull(MetaDataParser.parseR128GainQ78("999999999999"));
+        assertNull(MetaDataParser.parseR128GainQ78("-999999999999"));
+    }
 }


### PR DESCRIPTION
The 13.2.x cycle added substantial OpenSubsonic field coverage to JaudiotaggerParser. The secondary FFmpeg-based parser, which handles `.opus`, `.m4b` (until #257), and the niche audio + video formats jaudiotagger can't read, did not carry the same coverage. Per the #226 investigation (`analysis/issue-226-ffmpeg-parser-parity.md`), this PR closes the scalar field gap.

**Also resolves #258.** v13.2.0-alpha advertised Opus R128 support that didn't actually fire for `.opus` files, because jaudiotagger 3.0.1 has no Opus reader and #205 PR-A's R128 code lived in JaudiotaggerParser. With #257 confirming `.opus` correctly routes to FFmpegParser, the R128 conversion is now wired into FFmpegParser via the lifted `parseR128GainQ78` helper. Opus R128 actually fires for Opus files for the first time.

## What changed

- **`parseR128GainQ78` lifted to MetaDataParser** (package-private static) so both parsers share one helper with identical conversion math. Same signature, same body, same package; verified via in-place test pass and WAR `javap` inheritance check. The `RG_*` and `R128_*` tag-key constants moved alongside.
- **FFmpegParser scalar field extractions.** sortName trio (TITLE_SORT, ALBUM_SORT, ALBUM_ARTIST_SORT), bpm, ReplayGain four-field, Opus R128 fallback for track and album gain, compilation, raw releaseDate alongside the existing integer year, originalReleaseDate with TDOR/TORY fallback chain, discSubtitle, MusicBrainz release / recording / album-artist IDs.
- **`getDataAny` helper** in FFmpegParser to walk a list of candidate tag keys per field; `getData` opened to package-private so the helper can call it.
- **populateFromJson refactor** to compose the new field extractions cleanly.
- **Year parity fix** caught in review: `NumberUtils.createInteger` replaced with the inherited `parseYear` so an ISO date like `'2004-03-15'` now produces `year=2004` instead of `null`, matching JaudiotaggerParser's behavior. Silent across-parser drift that would have shipped invisibly otherwise.

## R128 path

`parseTrackGain(JsonNode)` and the symmetric `parseAlbumGain` mirror PR #205 PR-A's structure exactly:

```java
String rg = getData(node, RG_TRACK_GAIN);
if (rg != null) {
    return parseReplayGain(rg);   // present-but-unparseable RG → null, NO R128 fallthrough
}
return parseR128GainQ78(getData(node, R128_TRACK_GAIN));
```

RG wins when present; R128 fires only when RG is null. A malformed RG tag returns null and that null is the answer — operator's authored tag takes precedence. Locked by `testTrack/AlbumGainMalformedRgDoesNotFallThroughToR128`.

## Out of scope

- **Multi-value fields** (genres[], contributors[], releaseTypes[], recordLabels[]). ffprobe's JSON output collapses repeated tag frames to a single comma-joined string (JSON keys must be unique), and TMCL performer-with-instrument pair structure is not preserved. Best-effort separator splitting drifts from JaudiotaggerParser's per-frame fidelity. The remaining audience after #257 (`.mpc`, `.wv`, `.ape`, `.tta`, `.dff`, video containers) is small enough that documenting the limitation in v13.2.0 final notes is the proportionate response.
- **Opus baseGain** (`output_gain` from OpusHead). Tracked separately under #205 PR-B — its own tooling problem (jaudiotagger 3.0.1 has no OpusHead access, custom binary parser vs library upgrade decision still pending).
- **userRating / averageRating.** Not parser-derived (sourced from `user_rating` DB table).

## Tests

44 new tests in `FFmpegParserTestCase` exercising every new field, both happy-path and absent. R128-specific coverage mirrors #205 PR-A: RG-only, R128-only with verified Q7.8 + 5 dB math, both-present (RG wins), malformed RG doesn't fall through to R128, symmetric for album gain.

`testOpusFileWithR128AndMusicBrainzTagsEndToEnd` synthesizes a representative Opus-file ffprobe JSON and asserts the full pipeline — this is the direct test that #258's dead code is resolved.

The 4 `parseR128GainQ78` unit tests moved from `JaudiotaggerParserTestCase` to `MetaDataParserTestCase` (where the helper now lives). The tag-driven `parseTrackGain/parseAlbumGain` tests stayed in `JaudiotaggerParserTestCase` with constant imports updated to `MetaDataParser.RG_*/R128_*`.

1092 XML class-sum (Maven console 1177; `reuseForks=true` discrepancy per the documented quirk), +44 vs post-#257 main, zero failures, zero errors. Postgres run of FFmpeg/MetaData/Jaudiotagger/Factory test classes against postgres:16-alpine: 88/0/0/0. Analyze-only clean. WAR carries all new tag-key constants; `parseR128GainQ78` declared on `MetaDataParser.class` only (inheritance-only on `JaudiotaggerParser.class`).

## Follow-up

Pre-existing FFmpegParser `album_artist` Vorbis blind spot: `getData(result, "album_artist")` doesn't match the Vorbis-canonical `ALBUMARTIST` (no separator). Surfaced when writing the Opus end-to-end test; deliberately worked around in the test rather than expanding this PR's scope. Filed separately.