### PR TITLE
fix: IndexManagerTestCase.testExpunge isolation under matrix DBs (post-#55)

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientIntegrationTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientIntegrationTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -144,6 +145,12 @@ public class PodcastDownloadClientIntegrationTest {
                     folder.setPath(Path.of(folderPath));
                     musicFolderRepository.saveAndFlush(folder);
                 });
+        // Clean up any MediaFile child rows the download created under the channel path —
+        // testDownload writes "test/Test.mp3" as a child of channelMediaFile; without this,
+        // a PODCAST media_file row with present=false is left behind, breaking the pre-state
+        // assertion in IndexManagerTestCase.testExpunge:177 under matrix-DB ordering.
+        mediaFileRepository.findByFolderAndParentPath(channelMediaFile.getFolder(), "test", Sort.unsorted())
+                .forEach(mediaFileRepository::delete);
         mediaFileRepository.delete(channelMediaFile);
         podcastEpisodeRepository.delete(podcastEpisode);
         deleteDirectory(tempFolder.resolve("test"));

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/IndexManagerTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/IndexManagerTestCase.java
@@ -94,6 +94,14 @@ public class IndexManagerTestCase {
     public void beforeEach() {
         mediaFolderService.clearMusicFolderCache();
         mediaFolderService.clearMediaFileCache();
+        // Sweep present=false Artist/Album orphans left behind by earlier test classes whose
+        // @AfterEach deletes their music folder but not the Artist/Album rows the scan created.
+        // testExpunge's zero-state pre-assertions at lines 189 and 208 require this — HSQLDB
+        // tolerates the residue (in-memory + fresh per run), Postgres/MariaDB do not. The
+        // underlying multi-offender cleanup antipattern is tracked separately as a hygiene
+        // audit; this sweep keeps testExpunge robust under any suite ordering.
+        artistRepository.deleteAll(artistRepository.findByPresentFalse());
+        albumRepository.deleteAll(albumRepository.findByPresentFalse());
         Path musicDir = MusicFolderTestData.resolveMusicFolderPath();
         MusicFolder folder = new MusicFolder(musicDir, "Music", Type.MEDIA, true, Instant.now().truncatedTo(ChronoUnit.MICROS));
         musicFolders.add(folder);


### PR DESCRIPTION
#55 re-enabled the search test surface. pm_ci on Postgres and MariaDB then failed at `IndexManagerTestCase.testExpunge:177` with `expected: <0> but was: <1>`. HSQLDB was green. Investigation showed the full-suite ordering on matrix DBs (which #55's targeted Postgres run did not exercise) surfaces inter-class state residue that testExpunge's pre-state assertions observe.

## Three failures, not one

`testExpunge` has three pre-state sanity checks before it begins marking its own rows not-present:

| Line | Assertion | Entity counted | Pre-fix leaks |
|---|---|---|---|
| 177 | `findByMediaTypeInAndPresentFalse(playableTypes()).size() == 0` | playable MediaFiles | 1 |
| 189 | `artistRepository.findByPresentFalse().size() == 0` | Artists | 5 |
| 208 | `albumRepository.findByPresentFalse().size() == 0` | Albums | 5 |

The line-177 failure was masking the subsequent two — the test bails on first failure.

## Hybrid fix

**Source-fix in `PodcastDownloadClientIntegrationTest.@AfterEach`** for the line-177 leak. `testDownload` downloads an episode that writes a child MediaFile under the PODCAST channel; the existing tearDown deletes the parent channel, the episode, and the temp directory, but never the child MediaFile row. The file vanishes from disk; the `present=false` row stays. Fixed by sweeping the child rows before deleting the parent — uses the same `findByFolderAndParentPath` query the test's own assertion at line 167 already uses.

**Victim-fix in `IndexManagerTestCase.@BeforeEach`** for the line-189 / 208 leaks. These come from a class of antipattern across 3-4 other test classes (MediaScannerServiceTestCase, SearchServiceSpecialGenreTestCase, SearchServiceStartWithStopwardsTestCase, plus one more contributing the \`Williams\` Artist row) whose `@AfterEach` deletes the MusicFolder but not the Artist/Album entity rows the scan created. Rather than hunt each offender in this PR's scope, a two-line sweep in `IndexManagerTestCase.@BeforeEach` defends the only class in the codebase that asserts on global `present=false` counts. The underlying hygiene gap across the offenders is tracked separately for a focused audit pass.

Why hybrid rather than pure source-fix everywhere: the PODCAST case has a single clear offender we understood end-to-end, so the source-fix carries the local knowledge. The Artist/Album case is a multi-offender pattern across multiple test classes — capturing all the offenders here would widen the PR's reviewable surface from \"unblock pm_ci\" to \"audit cleanup hygiene across the suite,\" which is a different concern at a different cadence.

## Verification

- HSQLDB full suite: 1125/0/0/0.
- Postgres full-suite x 3 (postgres:16-alpine, pr_ci.yml env vars): the three target assertions at lines 177/189/208 all pass across all three runs. The Postgres error count moves 67 → 68 locally; the 67 pre-existing are a local-environment divergence unrelated to these edits, and the +1 (`TranscodingServiceIntTest` lazy-init under full-suite ordering) is another latent isolation issue surfaced because testExpunge now completes successfully rather than bailing. None of these reproduce in CI per pm_ci on main, so canonical verification is what pm_ci shows on push to this PR.
- MariaDB: deferred to pm_ci.
- Analyze-only clean. WAR packages.