### PR TITLE
fix: PlaylistFileService logger bound to wrong class (PlaylistService -> PlaylistFileService)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistFileService.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 @Service
 public class PlaylistFileService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PlaylistService.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PlaylistFileService.class);
 
     private final PlaylistService playlistService;
     private final SettingsService settingsService;


### PR DESCRIPTION
`PlaylistFileService` was extracted from `PlaylistService` during the #215 playlist watcher work. Its static logger declaration was carried over verbatim and never updated to the new class:

```java
private static final Logger LOG = LoggerFactory.getLogger(PlaylistService.class);
```

The result is that log lines emitted by `PlaylistFileService` appear under the `PlaylistService` category, which makes filtering and tracing harder and obscures which class is actually emitting which message.

Both classes live in the same package (`org.airsonic.player.service`), so no import existed to clean up. `PlaylistService` remains legitimately referenced in `PlaylistFileService` as a constructor-injected dependency, so the symbol stays in scope.

Pure metadata fix; no behavior change, no test changes, floor stays at 1125. Verified at the WAR layer via `javap` that the bytecode's static initializer loads the corrected class literal (`PlaylistFileService`), not the stale one.

fixes #245