### PR TITLE
fix: FFmpegParser missing ALBUMARTIST Vorbis-comment alias for album-artist

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -114,7 +114,11 @@ public class FFmpegParser extends MetaDataParser {
         // Bitrate is in Kb/s
         metaData.setBitRate(result.at("/format/bit_rate").asInt() / 1000);
 
-        metaData.setAlbumArtist(getData(result, "album_artist"));
+        // Vorbis comments (FLAC/OGG/Opus) use the no-separator canonical key ALBUMARTIST;
+        // ID3v2 TPE2 and MP4 aART are normalized to album_artist by ffprobe. getData's
+        // case-variation covers the lower/upper/capitalize forms of one base key but
+        // can't bridge the separator difference, so both aliases are listed explicitly.
+        metaData.setAlbumArtist(getDataAny(result, "album_artist", "ALBUMARTIST"));
         metaData.setArtist(getData(result, "artist"));
         metaData.setAlbumName(getData(result, "album"));
         metaData.setGenre(getData(result, "genre"));

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/FFmpegParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/FFmpegParserTestCase.java
@@ -107,6 +107,25 @@ public class FFmpegParserTestCase {
         assertNull(m.getArtistSortName());
     }
 
+    // ----- albumArtist (Vorbis canonical ALBUMARTIST vs ID3/MP4 album_artist, fixes #261) -----
+
+    @Test
+    public void testAlbumArtistFromVorbisAlbumartist() {
+        // Vorbis comments (FLAC/OGG/Opus): canonical key is ALBUMARTIST, no separator.
+        assertEquals("Daft Punk", parse(tags("ALBUMARTIST", "Daft Punk")).getAlbumArtist());
+    }
+
+    @Test
+    public void testAlbumArtistFromId3Mp4Normalized() {
+        // ID3v2 TPE2 and MP4 aART surface as album_artist after ffprobe normalization.
+        assertEquals("Daft Punk", parse(tags("album_artist", "Daft Punk")).getAlbumArtist());
+    }
+
+    @Test
+    public void testAlbumArtistAbsentReturnsNull() {
+        assertNull(parse(tags()).getAlbumArtist());
+    }
+
     // ----- bpm -----
 
     @Test
@@ -364,18 +383,14 @@ public class FFmpegParserTestCase {
      */
     @Test
     public void testOpusFileWithR128AndMusicBrainzTagsEndToEnd() {
-        // Note: the existing FFmpegParser reads albumArtist via getData("album_artist") with
-        // lower/upper/capitalize variations — it does NOT match the Vorbis-canonical
-        // "ALBUMARTIST" form (no separator). Real .opus files typically use ALBUMARTIST, so
-        // the existing albumArtist extraction has a Vorbis blind spot. That's a PRE-EXISTING
-        // gap (out of scope for #226 PR1, which is about the new 13.2.x fields); this test
-        // uses "ALBUM_ARTIST" so albumArtist still populates and the test stays focused on
-        // the R128 / new-field surface.
+        // Uses the Vorbis-canonical ALBUMARTIST key (no separator) — see the
+        // dedicated alias-resolution tests above for the album_artist / ALBUMARTIST
+        // pairing (fixes #261).
         MetaData m = parse(tags(
                 "ARTIST", "Daft Punk",
                 "ALBUM", "Discovery",
                 "TITLE", "One More Time",
-                "ALBUM_ARTIST", "Daft Punk",
+                "ALBUMARTIST", "Daft Punk",
                 "DATE", "2001",
                 "GENRE", "Electronic",
                 "TBPM", "123",


### PR DESCRIPTION
ffprobe surfaces tag keys differently across containers. ID3 (`TPE2`) and MP4 (`aART`) get normalised to `album_artist` (with underscore) in the ffprobe tag map. Vorbis comments in OGG and Opus files surface as `ALBUMARTIST` (single word, no separator), since ffprobe does not normalise across the separator difference.

`FFmpegParser` previously called `getData(result, "album_artist")` for the album-artist field, which silently dropped any Vorbis-tagged `ALBUMARTIST` value. `JaudiotaggerParser` handles all three forms via `FieldKey.ALBUM_ARTIST`'s per-format mapping; `FFmpegParser` now does too via `getDataAny(result, "album_artist", "ALBUMARTIST")`. Precedence matches the multi-variant lookups #226 PR1 established for other fields: the normalised key wins when both are present.

## Workaround retired

`testOpusFileWithR128AndMusicBrainzTagsEndToEnd` previously used the synthetic key `ALBUM_ARTIST` (with separator, doesn't exist in any real container) as a stand-in for the actual Vorbis form, with a "PRE-EXISTING gap" comment block acknowledging the workaround. The end-to-end test now exercises the canonical `ALBUMARTIST` shape, upgrading regression coverage at no extra cost.

## Adjacent blind-spot scan

Reviewed every single-key `getData(...)` call in `populateFromJson` (lines 117-188). `album_artist` was the only one with a separator-difference Vorbis pattern — other fields are either single-word keys with no Vorbis variation (`artist`, `album`, `title`, `genre`, `track`, `disc`, `date`), already canonical Vorbis form (`REPLAYGAIN_TRACK_PEAK` etc.), or already multi-variant via `getDataAny` from #226 PR1 (sortName trio, MusicBrainz triple, originalReleaseDate, discSubtitle). No follow-up issue needed.

## Tests

Three new focused tests in `FFmpegParserTestCase`:
- `testAlbumArtistFromVorbisAlbumartist` — ALBUMARTIST returns the value
- `testAlbumArtistFromId3Mp4Normalized` — album_artist returns the value
- `testAlbumArtistAbsentReturnsNull` — null when absent

Plus `testOpusFileWithR128AndMusicBrainzTagsEndToEnd` refreshed (workaround retired).

Test floor 1125 → 1128. Bytecode-confirmed both `album_artist` and `ALBUMARTIST` literals are present in the packaged class.

fixes #261