### PR TITLE
fix: SearchServiceTestCase leaks music_folder rows under matrix DBs

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -117,6 +117,16 @@ public class MediaScannerServiceTestCase {
         jdbcTemplate.execute("DELETE FROM media_file");
         jdbcTemplate.execute("DELETE FROM album");
         jdbcTemplate.execute("DELETE FROM artist");
+        // Defensive sweep against leaked music_folder rows from earlier test classes whose
+        // @AfterEach failed to delete by the JPA-assigned ID. The shared MEDIAS/Music and
+        // MEDIAS/Music2 paths conflict with idx_music_folder_path on matrix DBs (Postgres,
+        // MariaDB) and crash the saveAll below as DataIntegrityViolation; HSQLDB tolerates
+        // the residue. The wider multi-offender cleanup antipattern is tracked in #266.
+        Path baseMediaPath = MusicFolderTestData.resolveBaseMediaPath();
+        musicFolderRepository.deleteAll(
+            musicFolderRepository.findAll().stream()
+                .filter(f -> f.getPath().startsWith(baseMediaPath))
+                .toList());
         TestCaseUtils.waitForScanFinish(mediaScannerService);
         mediaFolderService.clearMusicFolderCache();
         mediaFolderService.clearMediaFileCache();

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/IndexManagerTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/IndexManagerTestCase.java
@@ -102,7 +102,15 @@ public class IndexManagerTestCase {
         // audit; this sweep keeps testExpunge robust under any suite ordering.
         artistRepository.deleteAll(artistRepository.findByPresentFalse());
         albumRepository.deleteAll(albumRepository.findByPresentFalse());
+        // Defensive sweep against leaked music_folder rows on the MEDIAS/Music path from
+        // earlier test classes whose @AfterEach failed to delete by the JPA-assigned ID.
+        // Same matrix-DB failure mode as the Artist/Album sweep above (duplicate-key under
+        // idx_music_folder_path); HSQLDB tolerates the residue.
         Path musicDir = MusicFolderTestData.resolveMusicFolderPath();
+        musicFolderRepository.deleteAll(
+            musicFolderRepository.findAll().stream()
+                .filter(f -> f.getPath().equals(musicDir))
+                .toList());
         MusicFolder folder = new MusicFolder(musicDir, "Music", Type.MEDIA, true, Instant.now().truncatedTo(ChronoUnit.MICROS));
         musicFolders.add(folder);
         musicFolderRepository.saveAndFlush(folder);

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceTestCase.java
@@ -31,6 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.subsonic.restapi.ArtistID3;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -63,18 +64,27 @@ public class SearchServiceTestCase {
         System.setProperty("airsonic.home", airsonicHome.toString());
     }
 
+    // Holds the persisted MusicFolder references so cleanup can use the IDs JPA assigned at
+    // persist time. The original code called MusicFolderTestData.getTestMusicFolders() in
+    // @AfterEach too, which returned fresh id-less instances; deleteMusicFolder(null) is a
+    // no-op, so the rows leaked across test classes and broke any subsequent INSERT against
+    // the same path on matrix DBs with idx_music_folder_path unique constraint.
+    private List<MusicFolder> persistedFolders;
+
     @BeforeEach
     public void setup() {
+        persistedFolders = new ArrayList<>();
         for (MusicFolder musicFolder : MusicFolderTestData.getTestMusicFolders()) {
             mediaFolderService.createMusicFolder(musicFolder);
+            persistedFolders.add(musicFolder);
         }
         TestCaseUtils.execScan(mediaScannerService);
     }
 
     @AfterEach
     public void cleanup() {
-        for (MusicFolder musicFolder : MusicFolderTestData.getTestMusicFolders()) {
-            mediaFolderService.deleteMusicFolder(musicFolder.getId());
+        for (MusicFolder folder : persistedFolders) {
+            mediaFolderService.deleteMusicFolder(folder.getId());
         }
         mediaFolderService.expunge();
     }


### PR DESCRIPTION
`SearchServiceTestCase.@AfterEach` iterated `MusicFolderTestData.getTestMusicFolders()` to delete the folders it had created, but that factory returns fresh `MusicFolder` instances on every call (no-id constructor). The `@BeforeEach` persisted folders (JPA mutated them to set ids) but the loop variable went out of scope; the `@AfterEach` got new id-less instances and called `deleteMusicFolder(null)` — a no-op. The persisted rows for `MEDIAS/Music` and `MEDIAS/Music2` leaked every run.

Subsequent test classes hitting the same paths crashed with `DataIntegrityViolation` on `idx_music_folder_path`:
MediaScannerServiceTestCase.testScanLibrary:142 (saveAll)
IndexManagerTestCase.beforeEach:108 (saveAndFlush)

## Hybrid fix (matches post-#55 testExpunge pattern)

**(A) Source-fix in `SearchServiceTestCase`**: capture persisted folders in a new `private List<MusicFolder> persistedFolders` instance field; `@AfterEach` iterates that field so `folder.getId()` is the JPA-assigned id, not null.

**(B) Defensive sweep in `MediaScannerServiceTestCase.@BeforeEach` and `IndexManagerTestCase.@BeforeEach`**: query `musicFolderRepository.findAll()`, filter by the test's target path, delete any pre-existing rows before inserting. Protects against future regressions of the same antipattern. Uses only standard `JpaRepository` methods; no production code change.

## Why this stayed latent

`pm_ci.yml` runs HSQLDB only; `pr_ci.yml` is the only workflow exercising the matrix (HSQLDB + Postgres + MariaDB), and only on PR push. The bug also requires surefire's fork distribution to put `SearchServiceTestCase` before one of the victim classes — prior pr_ci runs apparently used orderings on the safe side. #261's `+3` `FFmpegParserTestCase` tests plausibly shifted the distribution enough to surface it.

## Verification

- HSQLDB full suite: 1128/0/0/0
- Local Postgres full suite: pre-fix had the `DataIntegrityViolation` plus 67 pre-existing local-env errors; post-fix has 0 `idx_music_folder_path` violations and the same 67-error local-env baseline (no regressions attributable to this PR)
- Targeted offender + victims run: 40/0/0
- Analyze: clean
- WAR: packages

## Adjacent

`SearchServiceSpecialPathTestCase` uses a similar fragile factory pattern but correctly captures `folder.getId()`, so it doesn't leak. Flagged on #266 as close-call evidence justifying the audit chore.

Three test files modified (+30/-2), zero production code touched.

fixes #270