### PR TITLE
fix: populate packed genres column on album-folder rows

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1071,6 +1071,7 @@ public class MediaFileService {
                             mediaFile.setAlbumName(metaData.getAlbumName());
                             mediaFile.setYear(metaData.getYear());
                             mediaFile.setGenre(metaData.getGenre());
+                            mediaFile.setGenres(packGenres(metaData.getGenres()));
                         }
                     } else {
                         mediaFile.setArtist(file.getFileName().toString());

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -466,7 +466,14 @@ public class MediaScannerServiceTestCase {
         MediaFile file = new MediaFile();
         file.setMediaType(MediaFile.MediaType.ALBUM);
         file.setGenre(genre);
-        // genres[] is intentionally not set — album folders never get the packed column populated.
+        // genres[] left null to model pre-#255 legacy rows (or un-rescanned rows after upgrade).
+        // Post-#255 newly-scanned album folders write the packed column too — see overload below.
+        return file;
+    }
+
+    private MediaFile albumFolder(String genre, String packedGenres) {
+        MediaFile file = albumFolder(genre);
+        file.setGenres(packedGenres);
         return file;
     }
 
@@ -557,6 +564,31 @@ public class MediaScannerServiceTestCase {
         org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
         assertEquals(1, albumCountOf(g, "Rock"));
         assertEquals(1, albumCountOf(g, "Metal"));
+        assertEquals(2, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresMultiFramePackedAlbumFolderCountsAllAsAlbumCount() {
+        // Post-#255 album folders carry the packed column; the feeder must increment every
+        // album_count row in the packed value, mirroring the multi-frame audio file behaviour.
+        MediaFile file = albumFolder("Rock", "Rock;Pop;Indie");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, albumCountOf(g, "Rock"));
+        assertEquals(1, albumCountOf(g, "Pop"));
+        assertEquals(1, albumCountOf(g, "Indie"));
+        assertEquals(0, songCountOf(g, "Rock"));
+        assertEquals(3, g.getGenres().size());
+    }
+
+    @Test
+    public void testUpdateGenresPackedAlbumFolderPrefersPackedOverScalar() {
+        // When both packed and scalar are present, packed wins — same precedence as audio files.
+        // Scalar carries only "Rock" but packed carries "Rock;Pop"; the feeder should produce
+        // album_count rows for both, proving the scalar is ignored when packed is non-null.
+        MediaFile file = albumFolder("Rock", "Rock;Pop");
+        org.airsonic.player.domain.Genres g = invokeUpdateGenres(file, ";");
+        assertEquals(1, albumCountOf(g, "Rock"));
+        assertEquals(1, albumCountOf(g, "Pop"));
         assertEquals(2, g.getGenres().size());
     }
 


### PR DESCRIPTION
`MediaFileService.parseFile` was writing both `media_file.genre` (scalar) and `media_file.genres` (packed multi-frame) for audio-file rows (lines 1022-1023), but only `media_file.genre` for album-folder rows (line 1073 area). The packed column on album folders stayed null, so #213's count-table feeder dropped every multi-frame genre when processing albums — undercounting `album_count` vs `song_count` for multi-genre libraries.

The parsers were already fine. `MetaData.getGenres()` returns the full `List<String>` from both `JaudiotaggerParser` and `FFmpegParser`. The bug was a forgotten setter call on the consumer side, not anything to do with extraction. The fix is one new line at the album-folder branch, mirroring what the audio-file branch already does:

```java
mediaFile.setGenres(packGenres(metaData.getGenres()));
```

Same helper, same source, same column. No parser changes, no schema changes, no domain-model changes.

## Tests

- `testUpdateGenresMultiFramePackedAlbumFolderCountsAllAsAlbumCount` — packed `"Rock;Pop;Indie"` on an album folder produces `album_count = 1` for each genre, `song_count = 0`. Direct regression coverage for what the fix enables.
- `testUpdateGenresPackedAlbumFolderPrefersPackedOverScalar` — when both packed and scalar are present on an album folder, the feeder reads packed (mirrors the audio-file precedence already verified).

Helper comment on `albumFolder()` updated to reflect the new steady state. Existing scalar-fallback tests stay valid as legacy-path coverage for un-rescanned album rows.

Test floor: 1130 → 1132.

## Rescan-on-upgrade caveat

Existing album rows with `genres = NULL` won't auto-populate until their folder mtime changes or a forced rescan runs. Operators wanting immediate retroactive correction after upgrade should run a full rescan. This will be called out in the 13.2.0 release notes.

## Read-side complement

#256 (`getSongsByGenre` filters only the scalar column, misses multi-frame matches) is the natural companion bug and is coming as a separate PR.

fixes #255