### PR TITLE
fix: MediaFile genre queries match multi-frame genres on packed column

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/repository/MediaFileRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/MediaFileRepository.java
@@ -65,9 +65,39 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Integer> {
 
     public List<MediaFile> findByFolderInAndMediaTypeAndPresentTrue(List<MusicFolder> folders, MediaType mediaType, Pageable page);
 
-    public List<MediaFile> findByFolderInAndMediaTypeAndGenreAndPresentTrue(List<MusicFolder> folders, MediaType mediaType, String genre, Pageable page);
+    // Genre filter: prefer the packed multi-frame `genres` column (PR #213 / #255) so secondary
+    // genres also match; fall back to the scalar `genre` column for un-rescanned legacy rows
+    // where `genres IS NULL`. The four-way LIKE handles the token's position in the packed
+    // value (sole / first / middle / last) with `;` as the delimiter — same join character
+    // `MediaFileService.packGenres` writes. No substring false-positives (Metal does not match
+    // Heavy Metal or Metalcore). Case-sensitive, preserving the prior derived-query semantics.
+    @Query("""
+            SELECT m FROM MediaFile m
+            WHERE m.folder IN :folders
+              AND m.mediaType = :mediaType
+              AND m.present = true
+              AND ((m.genres IS NOT NULL AND (
+                       m.genres = :genre
+                    OR m.genres LIKE CONCAT(:genre, ';%')
+                    OR m.genres LIKE CONCAT('%;', :genre, ';%')
+                    OR m.genres LIKE CONCAT('%;', :genre)))
+                   OR (m.genres IS NULL AND m.genre = :genre))
+            """)
+    public List<MediaFile> findByFolderInAndMediaTypeAndGenreAndPresentTrue(@Param("folders") List<MusicFolder> folders, @Param("mediaType") MediaType mediaType, @Param("genre") String genre, Pageable page);
 
-    public List<MediaFile> findByFolderInAndMediaTypeInAndGenreAndPresentTrue(List<MusicFolder> folders, Iterable<MediaType> mediaType, String genre, Pageable page);
+    @Query("""
+            SELECT m FROM MediaFile m
+            WHERE m.folder IN :folders
+              AND m.mediaType IN :mediaTypes
+              AND m.present = true
+              AND ((m.genres IS NOT NULL AND (
+                       m.genres = :genre
+                    OR m.genres LIKE CONCAT(:genre, ';%')
+                    OR m.genres LIKE CONCAT('%;', :genre, ';%')
+                    OR m.genres LIKE CONCAT('%;', :genre)))
+                   OR (m.genres IS NULL AND m.genre = :genre))
+            """)
+    public List<MediaFile> findByFolderInAndMediaTypeInAndGenreAndPresentTrue(@Param("folders") List<MusicFolder> folders, @Param("mediaTypes") Iterable<MediaType> mediaTypes, @Param("genre") String genre, Pageable page);
 
     public List<MediaFile> findByFolderInAndMediaTypeAndYearBetweenAndPresentTrue(List<MusicFolder> folders, MediaType mediaType, Integer startYear,
             Integer endYear, Pageable page);

--- a/airsonic-main/src/test/java/org/airsonic/player/repository/MediaFileRepositoryTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/repository/MediaFileRepositoryTest.java
@@ -34,6 +34,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -41,8 +43,10 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test of {@link MediaFileDao}.
@@ -138,6 +142,107 @@ public class MediaFileRepositoryTest {
 
         List<MediaFile> wrongPathTracks = mediaFileRepository.findByFolderAndPath(testFolder, "wrong.wav");
         assertEquals(0, wrongPathTracks.size());
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Genre filter — packed `genres` column with delimiter-aware LIKE + scalar `genre` fallback
+    // for legacy rows where `genres IS NULL`. Covers both repository methods (singular and
+    // plural MediaType). Fixes #256.
+    // ----------------------------------------------------------------------------------------
+
+    private MediaFile saveGenreFixture(String name, MediaType mediaType, String scalarGenre, String packedGenres) {
+        MediaFile file = new MediaFile();
+        file.setFolder(testFolder);
+        file.setPath(name);
+        file.setMediaType(mediaType);
+        file.setGenre(scalarGenre);
+        file.setGenres(packedGenres);
+        file.setPresent(true);
+        file.setStartPosition(MediaFile.NOT_INDEXED);
+        Instant now = Instant.now();
+        file.setCreated(now);
+        file.setChanged(now);
+        file.setLastScanned(now);
+        file.setChildrenLastUpdated(now);
+        return mediaFileRepository.save(file);
+    }
+
+    private List<String> namesOf(List<MediaFile> rows) {
+        return rows.stream().map(MediaFile::getPath).sorted().collect(Collectors.toList());
+    }
+
+    @Test
+    public void testFindByGenreSongsMatchesMultiFramePositions() {
+        // PR #256: the packed `genres` column carries every frame. The four-way LIKE must
+        // match the queried token at any position (sole / first / middle / last) and at no
+        // substring-only position (Heavy Metal, Metalcore must not match Metal).
+        saveGenreFixture("sole.mp3", MediaType.MUSIC, "Metal", "Metal");
+        saveGenreFixture("first.mp3", MediaType.MUSIC, "Metal", "Metal;Rock");
+        saveGenreFixture("middle.mp3", MediaType.MUSIC, "Rock", "Rock;Metal;Indie");
+        saveGenreFixture("last.mp3", MediaType.MUSIC, "Rock", "Rock;Metal");
+        saveGenreFixture("heavy.mp3", MediaType.MUSIC, "Heavy Metal", "Heavy Metal");
+        saveGenreFixture("core.mp3", MediaType.MUSIC, "Metalcore", "Metalcore");
+        saveGenreFixture("unrelated.mp3", MediaType.MUSIC, "Rock", "Rock;Pop");
+
+        Pageable page = PageRequest.of(0, 100);
+        List<MediaFile> hits = mediaFileRepository
+                .findByFolderInAndMediaTypeInAndGenreAndPresentTrue(
+                        List.of(testFolder), List.of(MediaType.MUSIC), "Metal", page);
+
+        assertEquals(List.of("first.mp3", "last.mp3", "middle.mp3", "sole.mp3"), namesOf(hits));
+    }
+
+    @Test
+    public void testFindByGenreSongsFallsBackToScalarWhenPackedNull() {
+        // Legacy / un-rescanned rows have `genres IS NULL`. The fallback arm must keep them
+        // queryable via the scalar `genre` column so the fix doesn't make pre-fix data invisible
+        // until the next rescan populates the packed column.
+        saveGenreFixture("legacy.mp3", MediaType.MUSIC, "Metal", null);
+        saveGenreFixture("modern.mp3", MediaType.MUSIC, "Rock", "Rock;Metal");
+
+        Pageable page = PageRequest.of(0, 100);
+        List<MediaFile> hits = mediaFileRepository
+                .findByFolderInAndMediaTypeInAndGenreAndPresentTrue(
+                        List.of(testFolder), List.of(MediaType.MUSIC), "Metal", page);
+
+        assertEquals(List.of("legacy.mp3", "modern.mp3"), namesOf(hits));
+    }
+
+    @Test
+    public void testFindByGenreSongsExcludesNonMatches() {
+        // Negative: a row whose packed value lacks the queried token and whose scalar (only
+        // consulted when packed IS NULL) also lacks it must not appear in the result.
+        saveGenreFixture("only-rock.mp3", MediaType.MUSIC, "Rock", "Rock;Pop");
+
+        Pageable page = PageRequest.of(0, 100);
+        List<MediaFile> hits = mediaFileRepository
+                .findByFolderInAndMediaTypeInAndGenreAndPresentTrue(
+                        List.of(testFolder), List.of(MediaType.MUSIC), "Metal", page);
+
+        assertTrue(hits.isEmpty());
+    }
+
+    @Test
+    public void testFindByGenreAlbumsUsesSamePredicate() {
+        // The singular-MediaType variant powers getAlbumsByGenre (folder rows). Post-#255 the
+        // packed column is populated on album folders too, so the same multi-frame fan-out must
+        // apply. Mirror the positional cases plus a substring guard.
+        saveGenreFixture("album-sole", MediaType.ALBUM, "Metal", "Metal");
+        saveGenreFixture("album-first", MediaType.ALBUM, "Metal", "Metal;Rock");
+        saveGenreFixture("album-middle", MediaType.ALBUM, "Rock", "Rock;Metal;Indie");
+        saveGenreFixture("album-last", MediaType.ALBUM, "Rock", "Rock;Metal");
+        saveGenreFixture("album-heavy", MediaType.ALBUM, "Heavy Metal", "Heavy Metal");
+        saveGenreFixture("album-legacy", MediaType.ALBUM, "Metal", null);
+        saveGenreFixture("album-other", MediaType.ALBUM, "Pop", "Pop;Indie");
+
+        Pageable page = PageRequest.of(0, 100);
+        List<MediaFile> hits = mediaFileRepository
+                .findByFolderInAndMediaTypeAndGenreAndPresentTrue(
+                        List.of(testFolder), MediaType.ALBUM, "Metal", page);
+
+        assertEquals(
+                List.of("album-first", "album-last", "album-legacy", "album-middle", "album-sole"),
+                namesOf(hits));
     }
 
 }


### PR DESCRIPTION
Closes the read-side complement to #213 + #255.

## Bug shape

`MediaFileRepository.findByFolderInAndMediaType[In]AndGenreAndPresentTrue` were Spring Data derived queries filtering the scalar `media_file.genre` column. After #213 (count-table feeder) and #255 (album-folder packed-column population), the packed `media_file.genres` column carries every frame (`"Rock;Metal;Indie"`) but the query side still matched only the primary frame. Querying `Metal` missed every song/album where Metal was a secondary genre.

## Fix

Add `@Query` JPQL to both methods with a four-way `LIKE` on `m.genres` plus a NULL-fallback arm to the scalar:

```jpql
((m.genres IS NOT NULL AND (
     m.genres = :genre
  OR m.genres LIKE CONCAT(:genre, ';%')
  OR m.genres LIKE CONCAT('%;', :genre, ';%')
  OR m.genres LIKE CONCAT('%;', :genre)))
 OR (m.genres IS NULL AND m.genre = :genre))
```

The four `LIKE` arms cover the queried token's possible positions in the packed value (sole / first / middle / last). Every non-sole arm requires a `;` adjacent to the token, so substring false-positives are excluded: `Metal` does not match `Heavy Metal` or `Metalcore`.

The NULL-fallback arm keeps legacy un-rescanned rows queryable via the scalar column until rescan populates the packed value. Mirrors the prefer-packed-fall-back-to-scalar pattern from #213's count-table feeder.

## Why both methods are fixed together

`getAlbumsByGenre` (folder variant, the singular-MediaType repository method) is bundled because post-#255 the packed column is populated on album folders too. Fixing only `getSongsByGenre` would leave `getAlbumsByGenre` with data it can't query — strictly worse than the pre-#255 state. Both methods now use the same predicate shape.

## Notes

**Hardcoded `;` delimiter** matches the join character `MediaFileService.packGenres` writes (`getGenreSeparators().substring(0, 1)`, defaulting to `;`). Runtime separator-binding is deferred — non-default first-separator configurations are not in 13.2.x's supported set.

**Method signatures unchanged**; callers untouched.

**Case-sensitivity preserved** (no `LOWER`/`UPPER` wrapping) — inherits the DB collation behavior, identical to the pre-fix derived-query semantics.

**No SQL injection surface** — all references via `:genre` JPA-bound parameter, including inside `CONCAT(...)`.

## Adjacent — out of scope

`AlbumService.getAlbumsByGenre` (the ID3 path via `albumRepository.findByGenreAndFolderInAndPresentTrue`) filters `album.genre`, which is scalar-only. The `Album` entity has no packed column. Fixing this requires a schema migration plus scanner-side population — separate concern, separate PR.

## Verification

- HSQLDB full suite: 1136/0/0/0
- Local Postgres 16-alpine (via `pr_ci.yml` env vars): `MediaFileRepositoryTest` 5/5 passing
- `pr_ci` will confirm across HSQLDB + Postgres + MariaDB on push
- WAR bytecode confirms both JPQL queries packaged

Test floor: 1132 → 1136 (+4 new tests covering positional fan-out, NULL fallback, negative case, and the singular-MediaType ALBUM variant).

fixes #256