### PR TITLE
fix: extract performer-with-instrument from MP4 iTunes freeform atoms

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -50,6 +50,7 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,6 +79,13 @@ public class JaudiotaggerParser extends MetaDataParser {
     // replaygain_album_peak). jaudiotagger 3.0.1 exposes them through Mp4Tag.getFields()
     // with the prefix below; no Mp4FieldKey enum value covers them.
     static final String MP4_ITUNES_FREEFORM_PREFIX = "----:com.apple.iTunes:";
+
+    // MP4 per-instrument performer credits (Picard convention) live in per-instrument freeform
+    // atoms whose Mp4TagReverseDnsField descriptor takes this prefix — e.g. atom id
+    // "----:com.apple.iTunes:PERFORMER:Guitar" has descriptor "PERFORMER:Guitar" and the
+    // instrument is the suffix after the colon. The standard ----:com.apple.iTunes:Performer
+    // atom is read separately via FieldKey.PERFORMER in the Vorbis-style branch.
+    static final String MP4_PERFORMER_DESCRIPTOR_PREFIX = "PERFORMER:";
 
     // Clean-FieldKey contributor roles — each FieldKey is read via tag.getAll(...) and every
     // returned value becomes one Contributor with the given role label and no subRole. Performer
@@ -222,10 +230,12 @@ public class JaudiotaggerParser extends MetaDataParser {
      * plus performer credits that carry an optional instrument as the subRole. Clean roles come
      * from {@link #CONTRIBUTOR_ROLES} via {@link #getAllTagFields}. Performer extraction is
      * format-dispatched: ID3v2 reads the dedicated TMCL musician-credits frame (v2.4) for
-     * (instrument, performer) pairs; everything else (Vorbis on FLAC/Ogg/Opus, MP4, etc.) reads
+     * (instrument, performer) pairs; MP4 reads per-instrument iTunes freeform atoms (the
+     * {@code ----:com.apple.iTunes:PERFORMER:<instrument>} Picard convention) alongside the
+     * standard {@code Performer} atom; everything else (Vorbis on FLAC/Ogg/Opus) reads
      * {@code FieldKey.PERFORMER} and parses the common {@code "Name (Instrument)"} convention.
      * ID3v2.3 IPLS (combined musicians+people in one frame, no spec-mandated key vocabulary)
-     * and MP4 freeform performer atoms are out of scope here.
+     * is out of scope here.
      */
     static List<Contributor> getContributors(Tag tag) {
         List<Contributor> result = new ArrayList<>();
@@ -242,9 +252,14 @@ public class JaudiotaggerParser extends MetaDataParser {
      * Appends performer Contributors with the instrument carried as {@code subRole}. ID3v2.4 keeps
      * (instrument, performer) pairs in the dedicated TMCL frame; reading them through the
      * generic {@code FieldKey.PERFORMER} accessor flattens the pairs and loses the instrument,
-     * so frame-level access is required. Non-ID3 formats expose performer values directly under
-     * {@code FieldKey.PERFORMER}, with the {@code "Name (Instrument)"} convention parsed below.
-     * Wraps any jaudiotagger throwable so a malformed frame can't break the scan for one file.
+     * so frame-level access is required. MP4 also stores per-instrument credits out-of-band of
+     * the standard FieldKey, via the {@code ----:com.apple.iTunes:PERFORMER:<instrument>}
+     * freeform-atom convention — {@link #addMp4FreeformPerformers} reads those before falling
+     * through to the generic {@code FieldKey.PERFORMER} loop (which on MP4 also reads the
+     * standard {@code ----:com.apple.iTunes:Performer} atom). Non-ID3 formats expose performer
+     * values directly under {@code FieldKey.PERFORMER}, with the {@code "Name (Instrument)"}
+     * convention parsed below. Wraps any jaudiotagger throwable so a malformed frame can't break
+     * the scan for one file.
      */
     private static void addPerformers(List<Contributor> sink, Tag tag) {
         try {
@@ -275,6 +290,11 @@ public class JaudiotaggerParser extends MetaDataParser {
                 }
                 return;
             }
+            if (tag instanceof Mp4Tag mp4) {
+                addMp4FreeformPerformers(sink, mp4);
+                // Fall through to the generic FieldKey.PERFORMER loop below so the standard
+                // ----:com.apple.iTunes:Performer atom (Vorbis-style values) is still read.
+            }
             for (String raw : getAllTagFields(tag, FieldKey.PERFORMER)) {
                 Matcher m = VORBIS_PERFORMER_PATTERN.matcher(raw);
                 if (m.matches()) {
@@ -289,6 +309,39 @@ public class JaudiotaggerParser extends MetaDataParser {
             }
         } catch (Exception x) {
             // Ignored.
+        }
+    }
+
+    /**
+     * Reads MP4 per-instrument performer credits from iTunes freeform atoms — the Picard
+     * convention where each instrument is its own atom keyed by
+     * {@code ----:com.apple.iTunes:PERFORMER:<instrument>}. The descriptor (the suffix after the
+     * issuer prefix) carries the instrument name; the atom content carries the performer name(s),
+     * comma-delimited for multiple performers on the same instrument (mirrors the ID3v2.4 TMCL
+     * semantics in {@link #addPerformers}).
+     */
+    private static void addMp4FreeformPerformers(List<Contributor> sink, Mp4Tag tag) {
+        Iterator<TagField> it = tag.getFields();
+        while (it.hasNext()) {
+            TagField field = it.next();
+            if (!(field instanceof Mp4TagReverseDnsField rdns)) {
+                continue;
+            }
+            String descriptor = rdns.getDescriptor();
+            if (descriptor == null || !descriptor.startsWith(MP4_PERFORMER_DESCRIPTOR_PREFIX)) {
+                continue;
+            }
+            String instrument = StringUtils.trimToNull(descriptor.substring(MP4_PERFORMER_DESCRIPTOR_PREFIX.length()));
+            String content = rdns.getContent();
+            if (instrument == null || content == null) {
+                continue;
+            }
+            for (String name : content.split(",")) {
+                String cleaned = StringUtils.trimToNull(name);
+                if (cleaned != null) {
+                    sink.add(new Contributor("performer", instrument, cleaned));
+                }
+            }
         }
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -321,4 +321,81 @@ public class JaudiotaggerParserTestCase {
                 new Contributor("performer", "Drums", "Ginger Baker")),
                 JaudiotaggerParser.getContributors(tag));
     }
+
+    // ----------------------------------------------------------------------------------------
+    // MP4 per-instrument freeform performer atoms (fixes #232). Picard convention writes one
+    // atom per instrument under ----:com.apple.iTunes:PERFORMER:<instrument>; the standard
+    // ----:com.apple.iTunes:Performer atom (Vorbis-style "Name (Instrument)" values) is read
+    // via the existing FieldKey.PERFORMER fall-through and the two must coexist without
+    // clobbering or double-counting.
+    // ----------------------------------------------------------------------------------------
+
+    private static Mp4Tag tagWithMp4PerformerAtoms(String... pairs) {
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("pairs must be (instrument, name)+");
+        }
+        Mp4Tag tag = new Mp4Tag();
+        for (int i = 0; i < pairs.length; i += 2) {
+            String descriptor = "PERFORMER:" + pairs[i];
+            String atomId = "----:com.apple.iTunes:" + descriptor;
+            tag.addField(new Mp4TagReverseDnsField(atomId, "com.apple.iTunes", descriptor, pairs[i + 1]));
+        }
+        return tag;
+    }
+
+    @Test
+    public void testGetContributorsExtractsPerformersFromMp4FreeformAtoms() {
+        Mp4Tag tag = tagWithMp4PerformerAtoms("Guitar", "Jimi Hendrix", "Bass", "Noel Redding");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("performer", "Bass", "Noel Redding")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsSplitsCommaDelimitedMp4PerformersForOneInstrument() {
+        // Mirror the ID3v2.4 TMCL semantics: a single atom value may carry a comma-delimited
+        // list of performers, all sharing the same instrument descriptor.
+        Mp4Tag tag = tagWithMp4PerformerAtoms("Vocals", "John Lennon, Paul McCartney");
+        assertEquals(List.of(
+                new Contributor("performer", "Vocals", "John Lennon"),
+                new Contributor("performer", "Vocals", "Paul McCartney")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsMp4FreeformCoexistsWithStandardPerformerAtom() throws Exception {
+        // Per-instrument freeform atoms emit first (in iteration order from the MP4 branch);
+        // the standard ----:com.apple.iTunes:Performer atom (mapped from FieldKey.PERFORMER)
+        // follows via the fall-through and is parsed with the Vorbis "Name (Instrument)"
+        // convention. Both contribute; nothing double-counts.
+        Mp4Tag tag = tagWithMp4PerformerAtoms("Guitar", "Jimi Hendrix");
+        tag.setField(FieldKey.PERFORMER, "Eric Clapton (Guitar)");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsMp4WithoutFreeformPerformerAtomsEmitsViaFallThrough() throws Exception {
+        // Regression guard: an MP4 tag with only the standard Performer atom (no per-instrument
+        // freeform atoms) still works via the fall-through to the Vorbis-style FieldKey loop.
+        Mp4Tag tag = new Mp4Tag();
+        tag.setField(FieldKey.PERFORMER, "Eric Clapton (Guitar)");
+        assertEquals(List.of(new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsMp4FreeformPerformerAlongsideCleanFieldKeys() throws Exception {
+        // Clean-FieldKey roles emit first (CONTRIBUTOR_ROLES order), MP4 per-instrument
+        // freeform performers follow via addPerformers — canonical order preserved.
+        Mp4Tag tag = tagWithMp4PerformerAtoms("Guitar", "Eric Clapton");
+        tag.setField(FieldKey.COMPOSER, "George Harrison");
+        assertEquals(List.of(
+                new Contributor("composer", null, "George Harrison"),
+                new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
 }


### PR DESCRIPTION
Follow-up to #144.

## Bug shape

`JaudiotaggerParser.addPerformers` handled performer-with-instrument credits for ID3v2.4 (TMCL frame) and Vorbis (`FieldKey.PERFORMER` + `Name (Instrument)` pattern), but missed MP4's per-instrument freeform atom convention. Picard and other taggers write each instrument as its own reverse-DNS atom under `----:com.apple.iTunes:PERFORMER:<instrument>`, with the performer name(s) as the content. These atoms never reached `FieldKey.PERFORMER` — jaudiotagger maps that `FieldKey` only to the standard `----:com.apple.iTunes:Performer` atom.

Result: M4A/AAC/ALAC files lost all per-instrument performer credits. The bug was silent because the standard atom (when present) still produced output, masking the per-instrument gap.

## Fix

New MP4 branch in `addPerformers` reading `Mp4Tag.getFields()`, filtering to `Mp4TagReverseDnsField` whose descriptor starts with `"PERFORMER:"`, extracting the instrument from the descriptor suffix and the performer name(s) from the atom content. Content is comma-split per the same multi-performers-per-instrument convention already used by the ID3v2.4 TMCL branch.

## Coexistence — not a contract change

The new branch runs alongside the existing fall-through to `FieldKey.PERFORMER`, not in place of it. The standard `----:com.apple.iTunes:Performer` atom (Vorbis-style values) still works as before. Files with both per-instrument freeform atoms AND a standard `Performer` atom now surface both, in canonical order (per-instrument first, standard fall-through second). No double-counting — the two atom keys are disjoint in jaudiotagger.

Same format-coverage shape as the ReplayGain MP4 follow-up (#205) — a parser extension along the established MP4 freeform-atom convention (`getReplayGainField` lines 317-326), not a model or wire-format change.

## Tests

5 new tests using a new `tagWithMp4PerformerAtoms(...)` helper that mirrors `tagWithTmcl(...)`:

- Multi-instrument freeform extraction
- Comma-split multi-performers-per-instrument (mirrors TMCL semantics)
- Coexistence with the standard `Performer` atom (no clobbering, no double-counting)
- Regression guard: MP4 with only the standard atom still works via the fall-through
- Coexistence with clean-FieldKey roles (composer + per-instrument performer → both, canonical order preserved)

Test floor: 1136 → 1141.

## Out of scope

- **#231** (ID3v2.3 IPLS) — the parallel-issue follow-up to #144. Needs a key-classification heuristic (instrument vs function) and warrants its own dedicated review. Coming as a separate PR.
- `Mp4FieldKey.PERFORMER_NAME` atom (artist credit, not instrument-scoped). Different semantic; not in #232's framing.
- `FFmpegParser` has no contributor extraction at all (ffprobe doesn't surface TMCL pair structure). Tracked as a separate concern.

fixes #232