### PR TITLE
fix: extract contributors from ID3v2.3 IPLS frame (instruments and functions)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -35,6 +35,7 @@ import org.jaudiotagger.tag.TagField;
 import org.jaudiotagger.tag.datatype.Pair;
 import org.jaudiotagger.tag.id3.AbstractID3v2Frame;
 import org.jaudiotagger.tag.id3.AbstractID3v2Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyIPLS;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.images.Artwork;
@@ -52,12 +53,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.LogManager;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Parses meta data from audio files using the Jaudiotagger library
@@ -103,6 +106,16 @@ public class JaudiotaggerParser extends MetaDataParser {
             Map.entry(FieldKey.ORCHESTRA, "orchestra"),
             Map.entry(FieldKey.CHOIR, "choir"),
             Map.entry(FieldKey.ENSEMBLE, "ensemble"));
+
+    // Function-role keys recognised inside an ID3v2.3 IPLS frame, derived from the canonical
+    // CONTRIBUTOR_ROLES labels so the two stay in lockstep. Keyed by the lowercased label for
+    // case-insensitive lookup; the value is the canonical label emitted as the Contributor role.
+    // IPLS pairs whose key is NOT in this set are treated as instrument credits (performer with
+    // the key as subRole) — see addId3IplsContributors().
+    private static final Map<String, String> IPLS_FUNCTION_KEYS = CONTRIBUTOR_ROLES.stream()
+            .collect(Collectors.toUnmodifiableMap(
+                    e -> e.getValue().toLowerCase(Locale.ROOT),
+                    Map.Entry::getValue));
 
     // Vorbis PERFORMER convention: "Name (Instrument)" — capture the bare name and a single
     // trailing parenthetical as instrument. No parens → whole string is the name.
@@ -229,13 +242,14 @@ public class JaudiotaggerParser extends MetaDataParser {
      * Builds the per-track contributor list — clean-FieldKey credits (composer, lyricist, etc.)
      * plus performer credits that carry an optional instrument as the subRole. Clean roles come
      * from {@link #CONTRIBUTOR_ROLES} via {@link #getAllTagFields}. Performer extraction is
-     * format-dispatched: ID3v2 reads the dedicated TMCL musician-credits frame (v2.4) for
-     * (instrument, performer) pairs; MP4 reads per-instrument iTunes freeform atoms (the
-     * {@code ----:com.apple.iTunes:PERFORMER:<instrument>} Picard convention) alongside the
-     * standard {@code Performer} atom; everything else (Vorbis on FLAC/Ogg/Opus) reads
-     * {@code FieldKey.PERFORMER} and parses the common {@code "Name (Instrument)"} convention.
-     * ID3v2.3 IPLS (combined musicians+people in one frame, no spec-mandated key vocabulary)
-     * is out of scope here.
+     * format-dispatched: ID3v2.4 reads the dedicated TMCL musician-credits frame for
+     * (instrument, performer) pairs; ID3v2.3 reads the combined IPLS frame for both instrument
+     * and function credits (jaudiotagger surfaces none of IPLS through the clean FieldKeys above,
+     * so both categories are recovered there — see {@link #addId3IplsContributors}); MP4 reads
+     * per-instrument iTunes freeform atoms (the {@code ----:com.apple.iTunes:PERFORMER:<instrument>}
+     * Picard convention) alongside the standard {@code Performer} atom; everything else (Vorbis on
+     * FLAC/Ogg/Opus) reads {@code FieldKey.PERFORMER} and parses the common
+     * {@code "Name (Instrument)"} convention.
      */
     static List<Contributor> getContributors(Tag tag) {
         List<Contributor> result = new ArrayList<>();
@@ -264,30 +278,34 @@ public class JaudiotaggerParser extends MetaDataParser {
     private static void addPerformers(List<Contributor> sink, Tag tag) {
         try {
             if (tag instanceof AbstractID3v2Tag id3v2) {
+                // ID3v2.4 musician credits: TMCL pairs (instrument -> performer).
                 List<TagField> frames = id3v2.getFrame("TMCL");
-                if (frames == null) {
-                    return;
-                }
-                for (TagField field : frames) {
-                    if (!(field instanceof AbstractID3v2Frame frame)
-                            || !(frame.getBody() instanceof FrameBodyTMCL tmcl)) {
-                        continue;
-                    }
-                    for (Pair pair : tmcl.getPairing().getMapping()) {
-                        String instrument = StringUtils.trimToNull(pair.getKey());
-                        String rawNames = pair.getValue();
-                        if (rawNames == null) {
+                if (frames != null) {
+                    for (TagField field : frames) {
+                        if (!(field instanceof AbstractID3v2Frame frame)
+                                || !(frame.getBody() instanceof FrameBodyTMCL tmcl)) {
                             continue;
                         }
-                        // ID3v2.4 spec allows a comma-delimited list of performers per instrument.
-                        for (String name : rawNames.split(",")) {
-                            String cleaned = StringUtils.trimToNull(name);
-                            if (cleaned != null) {
-                                sink.add(new Contributor("performer", instrument, cleaned));
+                        for (Pair pair : tmcl.getPairing().getMapping()) {
+                            String instrument = StringUtils.trimToNull(pair.getKey());
+                            String rawNames = pair.getValue();
+                            if (rawNames == null) {
+                                continue;
+                            }
+                            // ID3v2.4 spec allows a comma-delimited list of performers per instrument.
+                            for (String name : rawNames.split(",")) {
+                                String cleaned = StringUtils.trimToNull(name);
+                                if (cleaned != null) {
+                                    sink.add(new Contributor("performer", instrument, cleaned));
+                                }
                             }
                         }
                     }
                 }
+                // ID3v2.3 combined credits: IPLS pairs (instrument-or-function -> name). No-op on
+                // tags without an IPLS frame (e.g. v2.4 files, which use TMCL above + TIPL-backed
+                // FieldKeys read in getContributors).
+                addId3IplsContributors(sink, id3v2);
                 return;
             }
             if (tag instanceof Mp4Tag mp4) {
@@ -340,6 +358,47 @@ public class JaudiotaggerParser extends MetaDataParser {
                 String cleaned = StringUtils.trimToNull(name);
                 if (cleaned != null) {
                     sink.add(new Contributor("performer", instrument, cleaned));
+                }
+            }
+        }
+    }
+
+    /**
+     * Reads ID3v2.3 contributor credits from the IPLS (Involved People List) frame. ID3v2.3 has
+     * no TMCL/TIPL split — IPLS combines musician credits (instrument -> performer) and involved
+     * people (function -> name) in one paired list with no spec-mandated key vocabulary, and
+     * jaudiotagger does NOT surface any of it through the FieldKey accessors that
+     * {@link #getContributors} relies on for the v2.4 TIPL-backed roles. So both categories are
+     * extracted here by classifying each pair's key: a key matching a canonical function label in
+     * {@link #IPLS_FUNCTION_KEYS} (case-insensitively) becomes a Contributor with that role and no
+     * subRole; any other key is treated as an instrument and becomes a {@code performer} credit
+     * carrying the original key (verbatim case) as the subRole. The value may be a comma-delimited
+     * list of names, mirroring the TMCL handling. No-op when the tag has no IPLS frame.
+     */
+    private static void addId3IplsContributors(List<Contributor> sink, AbstractID3v2Tag tag) {
+        List<TagField> frames = tag.getFrame("IPLS");
+        if (frames == null) {
+            return;
+        }
+        for (TagField field : frames) {
+            if (!(field instanceof AbstractID3v2Frame frame)
+                    || !(frame.getBody() instanceof FrameBodyIPLS ipls)) {
+                continue;
+            }
+            for (Pair pair : ipls.getPairing().getMapping()) {
+                String rawKey = StringUtils.trimToNull(pair.getKey());
+                String rawNames = pair.getValue();
+                if (rawKey == null || rawNames == null) {
+                    continue;
+                }
+                String functionRole = IPLS_FUNCTION_KEYS.get(rawKey.toLowerCase(Locale.ROOT));
+                String role = functionRole != null ? functionRole : "performer";
+                String subRole = functionRole != null ? null : rawKey;
+                for (String name : rawNames.split(",")) {
+                    String cleaned = StringUtils.trimToNull(name);
+                    if (cleaned != null) {
+                        sink.add(new Contributor(role, subRole, cleaned));
+                    }
                 }
             }
         }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -18,8 +18,11 @@ package org.airsonic.player.service.metadata;
 
 import org.airsonic.player.domain.Contributor;
 import org.jaudiotagger.tag.FieldKey;
+import org.jaudiotagger.tag.id3.ID3v23Frame;
+import org.jaudiotagger.tag.id3.ID3v23Tag;
 import org.jaudiotagger.tag.id3.ID3v24Frame;
 import org.jaudiotagger.tag.id3.ID3v24Tag;
+import org.jaudiotagger.tag.id3.framebody.FrameBodyIPLS;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTMCL;
 import org.jaudiotagger.tag.id3.framebody.FrameBodyTXXX;
 import org.jaudiotagger.tag.id3.valuepair.TextEncoding;
@@ -396,6 +399,127 @@ public class JaudiotaggerParserTestCase {
         assertEquals(List.of(
                 new Contributor("composer", null, "George Harrison"),
                 new Contributor("performer", "Guitar", "Eric Clapton")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // ID3v2.3 IPLS frame (fixes #231). v2.3 has no TMCL/TIPL split — IPLS combines instrument
+    // credits (instrument -> performer) and function credits (producer/mixer/... -> name) in one
+    // paired list. The probe in the PR confirmed jaudiotagger surfaces NONE of this through the
+    // FieldKey accessors, so getContributors must extract both categories from the frame here,
+    // classifying each pair's key against the canonical function vocabulary.
+    // ----------------------------------------------------------------------------------------
+
+    private static ID3v23Tag tagWithIpls(String... pairs) {
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("pairs must be (key, name)+");
+        }
+        ID3v23Tag tag = new ID3v23Tag();
+        FrameBodyIPLS body = new FrameBodyIPLS();
+        for (int i = 0; i < pairs.length; i += 2) {
+            body.addPair(pairs[i], pairs[i + 1]);
+        }
+        ID3v23Frame frame = new ID3v23Frame("IPLS");
+        frame.setBody(body);
+        tag.addFrame(frame);
+        return tag;
+    }
+
+    @Test
+    public void testGetContributorsExtractsInstrumentPerformerFromIpls() {
+        ID3v23Tag tag = tagWithIpls("Guitar", "Jimi Hendrix");
+        assertEquals(List.of(new Contributor("performer", "Guitar", "Jimi Hendrix")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsExtractsMultipleInstrumentsFromIpls() {
+        ID3v23Tag tag = tagWithIpls("Guitar", "Jimi Hendrix", "Bass", "Noel Redding");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("performer", "Bass", "Noel Redding")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsSplitsCommaDelimitedIplsPerformers() {
+        // Mirrors the TMCL comma-split: a single IPLS value may list multiple performers all
+        // sharing one instrument key.
+        ID3v23Tag tag = tagWithIpls("Vocals", "John Lennon, Paul McCartney");
+        assertEquals(List.of(
+                new Contributor("performer", "Vocals", "John Lennon"),
+                new Contributor("performer", "Vocals", "Paul McCartney")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsRoutesIplsFunctionKeyToCanonicalRole() {
+        // A function key (one of the canonical CONTRIBUTOR_ROLES labels) becomes a Contributor
+        // with that role and no subRole — not a performer credit.
+        ID3v23Tag tag = tagWithIpls("producer", "George Martin");
+        assertEquals(List.of(new Contributor("producer", null, "George Martin")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsIplsFunctionKeyIsCaseInsensitive() {
+        // Taggers choose the IPLS key casing freely; classification lowercases for lookup so
+        // "PRODUCER", "Producer", "producer" all route to role "producer".
+        assertEquals(List.of(new Contributor("producer", null, "George Martin")),
+                JaudiotaggerParser.getContributors(tagWithIpls("PRODUCER", "George Martin")));
+        assertEquals(List.of(new Contributor("producer", null, "George Martin")),
+                JaudiotaggerParser.getContributors(tagWithIpls("Producer", "George Martin")));
+    }
+
+    @Test
+    public void testGetContributorsIplsMixesInstrumentAndFunctionPairsInOrder() {
+        // Both categories in one IPLS frame, emitted in iteration order, each classified
+        // independently.
+        ID3v23Tag tag = tagWithIpls(
+                "Guitar", "Jimi Hendrix",
+                "producer", "George Martin",
+                "Bass", "Noel Redding",
+                "mixer", "Andy Wallace");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("producer", null, "George Martin"),
+                new Contributor("performer", "Bass", "Noel Redding"),
+                new Contributor("mixer", null, "Andy Wallace")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsIplsUnknownKeyBecomesPerformerWithKeyAsSubRole() {
+        // Pattern-based default: a key that is neither a known function nor an obvious instrument
+        // is still recovered as a performer credit carrying the original key (verbatim) as the
+        // subRole — recovering the credit rather than silently dropping it.
+        ID3v23Tag tag = tagWithIpls("backing tracks", "Studio Crew");
+        assertEquals(List.of(new Contributor("performer", "backing tracks", "Studio Crew")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsId3v23WithoutIplsEmitsNoPerformers() {
+        // Bare v2.3 tag with only a clean FieldKey role: the clean-FieldKey loop emits it; the
+        // IPLS branch is a no-op (no frame) and contributes nothing spurious.
+        ID3v23Tag tag = new ID3v23Tag();
+        try {
+            tag.setField(FieldKey.COMPOSER, "John Williams");
+        } catch (Exception x) {
+            throw new AssertionError(x);
+        }
+        assertEquals(List.of(new Contributor("composer", null, "John Williams")),
+                JaudiotaggerParser.getContributors(tag));
+    }
+
+    @Test
+    public void testGetContributorsV24TmclStillWorksAlongsideIplsBranch() {
+        // Regression guard: adding the IPLS branch must not disturb the v2.4 TMCL path. A v2.4
+        // tag has no IPLS frame, so only the TMCL performers emit.
+        ID3v24Tag tag = tagWithTmcl("Guitar", "Jimi Hendrix", "Bass", "Noel Redding");
+        assertEquals(List.of(
+                new Contributor("performer", "Guitar", "Jimi Hendrix"),
+                new Contributor("performer", "Bass", "Noel Redding")),
                 JaudiotaggerParser.getContributors(tag));
     }
 }


### PR DESCRIPTION
Follow-up to #144; sibling of #232 (MP4 freeform atoms, just landed).

## The finding that set the scope

An empirical probe — building an `ID3v23Tag` with an IPLS frame (both in-memory and round-tripped through a real `.mp3`) and then querying every contributor `FieldKey` — confirmed that jaudiotagger 3.0.1 surfaces **none** of the IPLS frame through any `FieldKey` accessor. `tag.getAll(FieldKey.PRODUCER / ENGINEER / MIXER / …)` all return empty on v2.3 IPLS data.

This is not just legacy-format polish: **every v2.3 file written by a tagger that uses IPLS** — foobar2000, Mp3tag's default, dBpoweramp, legacy Picard (pre-2014) — has been silently losing every function role (producer, engineer, mixer, etc.) and every performer-with-instrument credit.

## Fix

ID3v2.3 has no TMCL/TIPL split — it packs musician credits (instrument → performer) and involved-people (function → name) into one IPLS paired list with no spec-mandated key vocabulary. The fix reads the frame via `FrameBodyIPLS` (same `getPairing().getMapping()` shape as the existing TMCL reader) and classifies each pair's key:

- **Function key** (matches one of the 12 canonical `CONTRIBUTOR_ROLES` labels, case-insensitively) → `Contributor(role, null, name)`.
- **Anything else** → treated as an instrument → `Contributor("performer", key, name)` with the original key verbatim as the subRole.

### Pattern-based classifier, deliberately

The function set is derived dynamically from `CONTRIBUTOR_ROLES` so the two never drift; the instrument side is open-ended ("not a known function → instrument") rather than a hardcoded list. Its failure mode is cosmetic — an unusual IPLS key like `"mastering"` would surface as `performer / mastering` rather than being classified as a dedicated role — which is strictly better than the current silent drop. Values are comma-split for multiple names per key, mirroring the TMCL handling.

## Unaffected paths

jaudiotagger's write convention for v2.3 (TCOM / TEXT / TPE3 / TPE4 for roles with a dedicated frame, TXXX for the eight without one) is a separate read path and is untouched. Files tagged by jaudiotagger / modern Picard keep working exactly as before.

## v2.4 regression guard

The existing TMCL branch was restructured to be null-safe — the old early-return on absent TMCL is what dropped IPLS. A v2.4 file has no IPLS frame, so the new helper no-ops and TMCL extraction is unchanged. Covered by `testGetContributorsV24TmclStillWorksAlongsideIplsBranch`.

## Out of scope (future hygiene, not bundled)

A v2.3 file that redundantly stored the same credit in both IPLS and a separately-readable frame could double-count. The probe established that real v2.3 files surface nothing via FieldKeys, so this is hypothetical today; a de-dup pass in `getContributors` would be the clean fix if it ever matters.

## Tests

9 new tests using a new `tagWithIpls(...)` helper: instrument extraction, multi-instrument, comma-split, function routing, case-insensitivity, mixed pairs in iteration order, unknown-key default, no-IPLS no-op, and the v2.4 regression guard.

Test floor: 1141 → 1150. Parser-only change; pr_ci confirms across the HSQLDB + Postgres + MariaDB matrix on push.

fixes #231