### PR TITLE
feat: add per-user password_auth_enabled flag to disable legacy auth per account

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
@@ -53,6 +53,14 @@ public class User {
     @Column(name = "ldap_authenticated")
     private boolean ldapAuthenticated;
 
+    // Per-user legacy-auth switch (#233). When false, the user has opted out of Subsonic
+    // username/password and token+salt authentication for their own account (having migrated to
+    // apiKey) — the REST legacy filter rejects those attempts with PASSWORD_AUTH_NOT_SUPPORTED.
+    // Defaults true so existing and new accounts keep legacy auth until they explicitly opt out;
+    // this bridges toward the global removal in #56.
+    @Column(name = "password_auth_enabled", nullable = false)
+    private boolean passwordAuthEnabled = true;
+
     @Column(name = "bytes_streamed")
     private long bytesStreamed;
 
@@ -113,6 +121,14 @@ public class User {
 
     public void setLdapAuthenticated(boolean ldapAuthenticated) {
         this.ldapAuthenticated = ldapAuthenticated;
+    }
+
+    public boolean isPasswordAuthEnabled() {
+        return passwordAuthEnabled;
+    }
+
+    public void setPasswordAuthEnabled(boolean passwordAuthEnabled) {
+        this.passwordAuthEnabled = passwordAuthEnabled;
     }
 
     public long getBytesStreamed() {

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -148,6 +148,7 @@ public class GlobalSecurityConfig {
         RESTRequestParameterProcessingFilter restAuthenticationFilter = new RESTRequestParameterProcessingFilter(jaxbWriter);
         restAuthenticationFilter.setAuthenticationManager(authenticationManager);
         restAuthenticationFilter.setLegacyAuthWarningCache(legacyAuthWarningCache);
+        restAuthenticationFilter.setSecurityService(securityService);
 
         // The apiKey filter runs BEFORE the legacy REST filter so that:
         //   1. An apiKey request short-circuits the legacy u/p/t/s reads (the legacy filter

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
@@ -23,7 +23,9 @@ import org.airsonic.player.controller.JAXBWriter;
 import org.airsonic.player.controller.SubsonicRESTController;
 import org.airsonic.player.controller.SubsonicRESTController.APIException;
 import org.airsonic.player.controller.SubsonicRESTController.ErrorCode;
+import org.airsonic.player.domain.User;
 import org.airsonic.player.domain.Version;
+import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.cache.LegacyAuthWarningCache;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
@@ -73,6 +75,7 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
     static final String LEGACY_METHOD_SALTED_TOKEN = "legacy token+salt";
 
     private LegacyAuthWarningCache legacyAuthWarningCache;
+    private SecurityService securityService;
 
     protected RESTRequestParameterProcessingFilter(RequestMatcher requiresAuthenticationRequestMatcher, JAXBWriter jaxbWriter) {
         super(requiresAuthenticationRequestMatcher);
@@ -91,6 +94,16 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
      */
     public void setLegacyAuthWarningCache(LegacyAuthWarningCache legacyAuthWarningCache) {
         this.legacyAuthWarningCache = legacyAuthWarningCache;
+    }
+
+    /**
+     * Wire the per-user legacy-auth gate (#233). Optional — when unset, the gate is skipped and
+     * legacy auth behaves as before (used by tests that exercise only the raw auth path). When
+     * set, a successful legacy {@code u/p} or {@code t/s} authentication is rejected if the
+     * resolved user has opted out of password auth ({@code password_auth_enabled = false}).
+     */
+    public void setSecurityService(SecurityService securityService) {
+        this.securityService = securityService;
     }
 
     @Override
@@ -129,7 +142,37 @@ public class RESTRequestParameterProcessingFilter extends AbstractAuthentication
 
         authRequest.setDetails(authenticationDetailsSource.buildDetails(request));
 
-        return this.getAuthenticationManager().authenticate(authRequest);
+        Authentication result = this.getAuthenticationManager().authenticate(authRequest);
+        rejectIfPasswordAuthDisabled(result);
+        return result;
+    }
+
+    /**
+     * Per-user legacy-auth gate (#233). Reached only for genuine legacy {@code u/p} or {@code t/s}
+     * attempts: an apiKey- or Basic-pre-authenticated request returns early via the
+     * {@code previousAuth} short-circuit in {@link #attemptAuthentication} and never builds an
+     * {@code authRequest}, so it never reaches here. Form-login / session auth uses a different
+     * filter entirely. The check runs <em>after</em> the credentials have been validated, so it
+     * never reveals the flag to a caller without valid credentials (no enumeration oracle). When
+     * the resolved user has disabled password auth, the attempt is rejected with the same generic
+     * {@code PASSWORD_AUTH_NOT_SUPPORTED} envelope the apiKey work (#145) already defines.
+     */
+    private void rejectIfPasswordAuthDisabled(Authentication result) {
+        if (this.securityService == null || result == null) {
+            return;
+        }
+        String username = StringUtils.trimToNull(result.getName());
+        if (username == null) {
+            return;
+        }
+        // Fail open on an unresolved user: the principal already passed credential validation, so
+        // a null lookup here (effectively impossible) must not gate auth. Do NOT tighten this into
+        // a reject — that would turn a transient lookup miss into an account lockout.
+        User user = this.securityService.getUserByName(username);
+        if (user != null && !user.isPasswordAuthEnabled()) {
+            LOG.debug("Rejected legacy password/token auth for user {}: password auth disabled for this account", username);
+            throw new AuthenticationServiceException("", new APIException(ErrorCode.PASSWORD_AUTH_NOT_SUPPORTED));
+        }
     }
 
     private void checkAPIVersion(String version) {

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-user-password-auth-enabled.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-user-password-auth-enabled.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-user-password-auth-enabled" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="users" columnName="password_auth_enabled" />
+            </not>
+        </preConditions>
+        <addColumn tableName="users">
+            <column name="password_auth_enabled" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -19,4 +19,5 @@
     <include file="add-media-file-contributors.xml" relativeToChangelogFile="true"/>
     <include file="add-api-key-table.xml" relativeToChangelogFile="true"/>
     <include file="add-album-replaygain.xml" relativeToChangelogFile="true"/>
+    <include file="add-user-password-auth-enabled.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/security/PasswordAuthToggleTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/PasswordAuthToggleTest.java
@@ -1,0 +1,221 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.security;
+
+import org.airsonic.player.config.AirsonicHomeConfig;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.repository.UserRepository;
+import org.airsonic.player.service.ApiKeyService;
+import org.airsonic.player.service.cache.UserCache;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for the per-user {@code password_auth_enabled} gate (#233). Exercises the full
+ * security chain against a real database with the {@code admin}/{@code admin} seed user, proving:
+ * the default (flag enabled) leaves legacy {@code u/p} and {@code t/s} auth untouched; flipping the
+ * flag off rejects both legacy methods with {@code PASSWORD_AUTH_NOT_SUPPORTED(42)}; and the gate
+ * does NOT over-reach — apiKey auth and form-login session auth succeed regardless of the flag, so
+ * an admin who disables their own legacy auth is never locked out of the UI where they would re-enable
+ * it.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest
+@EnableConfigurationProperties({AirsonicHomeConfig.class})
+public class PasswordAuthToggleTest {
+
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "admin";
+    private static final String API_VERSION = "1.16.1";
+
+    @TempDir
+    private static Path tempDir;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Autowired
+    private UserCache userCache;
+
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty("airsonic.home", tempDir.toString());
+    }
+
+    @AfterEach
+    public void resetFlag() {
+        // The seed user is shared across the class; restore the default so tests don't leak state.
+        setPasswordAuthEnabled(true);
+    }
+
+    private void setPasswordAuthEnabled(boolean enabled) {
+        User user = userRepository.findByUsername(USERNAME).orElseThrow();
+        user.setPasswordAuthEnabled(enabled);
+        userRepository.saveAndFlush(user);
+        // The gate resolves the user via SecurityService.getUserByName, which is UserCache-backed;
+        // a raw repository write does not evict it. Evict so the gate sees the new flag value.
+        // (The deferred settings-UI write path must do the same — tracked in the follow-up.)
+        userCache.removeUser(USERNAME);
+    }
+
+    /** Builds a Subsonic salted-token pair (t = md5(password + salt)) for the given salt. */
+    private static String saltedToken(String password, String salt) {
+        return DigestUtils.md5Hex(password + salt);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // default ON — legacy auth unchanged (regression guard)
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void legacyPassword_succeeds_whenFlagEnabledByDefault() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("u", USERNAME).param("p", PASSWORD)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void legacyToken_succeeds_whenFlagEnabledByDefault() throws Exception {
+        String salt = "saltsalt";
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("u", USERNAME).param("s", salt).param("t", saltedToken(PASSWORD, salt))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // flag OFF — legacy auth rejected with code 42 (the enforcement core)
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void legacyPassword_rejectedWith42_whenFlagDisabled() throws Exception {
+        setPasswordAuthEnabled(false);
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("u", USERNAME).param("p", PASSWORD)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(42));
+    }
+
+    @Test
+    public void legacyToken_rejectedWith42_whenFlagDisabled() throws Exception {
+        setPasswordAuthEnabled(false);
+        String salt = "saltsalt";
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("u", USERNAME).param("s", salt).param("t", saltedToken(PASSWORD, salt))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(42));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // no over-reach — apiKey auth succeeds regardless of the flag
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void apiKey_succeeds_whenFlagEnabled() throws Exception {
+        String key = apiKeyService.generate(USERNAME, "toggle-on", null).rawKey();
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("apiKey", key)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void apiKey_succeeds_whenFlagDisabled() throws Exception {
+        // The over-reach guard: disabling legacy password auth must NOT disable apiKey auth.
+        setPasswordAuthEnabled(false);
+        String key = apiKeyService.generate(USERNAME, "toggle-off", null).rawKey();
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION).param("c", "test").param("f", "json")
+                .param("apiKey", key)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // no admin lockout — form-login session auth succeeds regardless of the flag
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void formLogin_succeeds_whenFlagDisabled() throws Exception {
+        // The admin-lockout guard: the web UI uses form-login session auth on a different filter,
+        // so disabling legacy REST auth must leave the path to re-enable it reachable.
+        setPasswordAuthEnabled(false);
+        mvc.perform(formLogin("/login")
+                .user("j_username", USERNAME).password("j_password", PASSWORD))
+                .andExpect(authenticated().withUsername(USERNAME));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // persistence + default value
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void passwordAuthEnabled_persistsRoundTrip() throws Exception {
+        setPasswordAuthEnabled(false);
+        assertFalse(userRepository.findByUsername(USERNAME).orElseThrow().isPasswordAuthEnabled(),
+                "flag must survive a save + reload round-trip");
+        setPasswordAuthEnabled(true);
+        assertTrue(userRepository.findByUsername(USERNAME).orElseThrow().isPasswordAuthEnabled());
+    }
+
+    @Test
+    public void seedUser_defaultsToPasswordAuthEnabled() {
+        // The column default (TRUE) and the entity field default must agree: existing/new accounts
+        // keep legacy auth until they explicitly opt out.
+        assertTrue(userRepository.findByUsername(USERNAME).orElseThrow().isPasswordAuthEnabled(),
+                "seed user must default to password auth enabled (non-disruptive on upgrade)");
+    }
+}


### PR DESCRIPTION
Follow-up to #145 (apiKey auth, closed). Bridges toward #56.

## Per-user, not global

Adds `users.password_auth_enabled` (default `TRUE`). A user who has migrated to the apiKey extension can disable legacy Subsonic username/password (`u`/`p`) and token+salt (`t`/`s`) auth **for their own account**, while other accounts are unaffected. This turns #56's eventual legacy-auth removal from an all-or-nothing flag day into a graceful per-account migration runway.

## Gate placement — the load-bearing design choice

The gate lives in `RESTRequestParameterProcessingFilter` (the REST-only legacy entry point), **not** in `MultipleCredsMatchingAuthenticationProvider`. That provider is shared with form login (the admin web UI) — both emit `UsernamePasswordAuthenticationToken` through the same `AuthenticationManager`. Gating in the provider would lock admins out of the very settings page they'd use to re-enable auth. The REST filter is `/rest/**`-scoped and never sees form login.

## Post-credential placement for anti-enumeration

The gate runs **after** `authenticate()` succeeds. A wrong password still returns the normal code 40 from the provider before the gate is reached; the new code 42 (`PASSWORD_AUTH_NOT_SUPPORTED`) is observable only to a caller who already holds valid credentials for that account. No pre-auth username/flag oracle.

## Non-interference (verified by tests)

- **apiKey auth** succeeds regardless of the flag — the apiKey filter runs first and short-circuits the REST filter before the gate is reached.
- **form-login / session auth** succeeds regardless — different filter entirely.
- **JWT** is a separate `@Order(1)` chain — untouched.

## Details

- Error code 42 (`PASSWORD_AUTH_NOT_SUPPORTED`) reused from #145 — no new code.
- Default `TRUE` — zero behavior change on upgrade; existing users keep legacy auth until they personally opt out.
- When the flag rejects an attempt, the gate throws before `successfulAuthentication`, so no deprecation warning fires (the rejection logs at DEBUG for diagnostics).

## UI deferred — and a security note for the follow-up

The self-service settings checkbox is deferred to a separate issue. That follow-up **must evict the `UserCache` on flag change** — `SecurityService.getUserByName` is cache-backed, so a write that bypasses cache eviction won't take effect until cache expiry, leaving the gate bypassable for the TTL window. Surfaced during the security audit; the test evicts manually as the reference pattern.

## Verification

- Security-audited: no bypass, no over-reach, no admin lockout, no enumeration oracle — all confirmed.
- HSQLDB full suite: 1159/0/0/0
- Local Postgres 16 (auth-path subset: PasswordAuthToggleTest + RESTAuthTest + APIKeyAuthTest): 33/33 — the `BOOLEAN DEFAULT TRUE NOT NULL` column and gate behave identically to HSQLDB
- pr_ci confirms the full HSQLDB + Postgres + MariaDB matrix on push

Test floor: 1150 → 1159 (+9 tests covering both default-on regression guards, both disabled-rejection cases, apiKey-succeeds-regardless over-reach guard, form-login-succeeds-regardless admin-lockout guard, persistence round-trip, and seed-user default).

fixes #233