### PR TITLE
fix: read embedded lyrics tag as a fallback source (FieldKey.LYRICS, unsynced)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/parser/lyrics/EmbeddedLyricsParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/parser/lyrics/EmbeddedLyricsParser.java
@@ -1,0 +1,71 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.parser.lyrics;
+
+import org.apache.commons.lang.StringUtils;
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.audio.AudioFileIO;
+import org.jaudiotagger.tag.FieldKey;
+import org.jaudiotagger.tag.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Reads the embedded <em>unsynced</em> lyrics tag ({@link FieldKey#LYRICS}) from an audio file —
+ * the ID3v2 {@code USLT}, Vorbis {@code LYRICS}, or MP4 {@code ©lyr} frame as mapped by
+ * jaudiotagger. This is the request-time fallback source consulted by
+ * {@link org.airsonic.player.service.LyricsService} only when both the DB cache and the LRC
+ * sidecar miss. Synced lyrics ({@code SYLT} / LRC timing) are out of scope here.
+ */
+@Component
+public class EmbeddedLyricsParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedLyricsParser.class);
+
+    /**
+     * Returns the embedded unsynced lyrics for the given audio file, or {@code null} when the file
+     * has no readable lyrics tag (or cannot be read at all). Any jaudiotagger failure is swallowed
+     * and treated as "no lyrics" so a single malformed file never breaks a lyrics request.
+     *
+     * @param file the audio file to read.
+     * @return the trimmed lyrics text, or {@code null} if absent/unreadable.
+     */
+    @Nullable
+    public String getLyrics(@Nullable Path file) {
+        if (file == null) {
+            return null;
+        }
+        try {
+            AudioFile audioFile = AudioFileIO.read(file.toFile());
+            Tag tag = audioFile.getTag();
+            if (tag == null) {
+                return null;
+            }
+            return StringUtils.trimToNull(tag.getFirst(FieldKey.LYRICS));
+        } catch (Exception e) {
+            LOG.debug("Could not read embedded lyrics from {}", file, e);
+            return null;
+        }
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
@@ -3,6 +3,7 @@ package org.airsonic.player.service;
 import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.parser.lyrics.EmbeddedLyricsParser;
 import org.airsonic.player.parser.lyrics.LrcFile;
 import org.airsonic.player.parser.lyrics.LrcParser;
 import org.airsonic.player.parser.lyrics.LyricsLine;
@@ -28,22 +29,29 @@ public class LyricsService {
     private final LrcParser lrcParser;
     private final LyricsRepository lyricsRepository;
     private final MediaFileService mediaFileService;
+    private final EmbeddedLyricsParser embeddedLyricsParser;
 
-    public LyricsService(LyricsRepository lyricsRepository, MediaFileService mediaFileService) {
+    public LyricsService(LyricsRepository lyricsRepository, MediaFileService mediaFileService,
+            EmbeddedLyricsParser embeddedLyricsParser) {
         this.lrcParser = new LrcParser();
         this.lyricsRepository = lyricsRepository;
         this.mediaFileService = mediaFileService;
+        this.embeddedLyricsParser = embeddedLyricsParser;
     }
 
     /**
-     * Create lyrics from a MediaFile object.
-     * This method checks if the MediaFile is a valid file type and then attempts to find
-     * the corresponding LRC file. If found, it parses the LRC file and creates
-     * a Lyrics object which is then saved to the repository.
+     * Resolves lyrics for a MediaFile, consulting sources in precedence order:
+     * DB cache → LRC sidecar → embedded tag → null. The DB cache wins outright. On a cache miss,
+     * an LRC sidecar ({@code *.lrc}/{@code *.LRC} beside the audio file) is preferred over the
+     * embedded tag — a sidecar is a deliberate user override of whatever is baked into the file.
+     * Only when both miss is the embedded {@link org.jaudiotagger.tag.FieldKey#LYRICS} tag read
+     * (so files with cached or sidecar lyrics never pay the per-request file open). Sidecar and
+     * embedded hits are both cached to the repository, tagged {@code "file"} and {@code "tag"}
+     * respectively.
      *
-     * @param mediaFile the MediaFile object from which to create lyrics
+     * @param mediaFile the MediaFile object from which to resolve lyrics
      *                  (should not be a directory or indexed track)
-     * @return the created Lyrics object, or null if the MediaFile is not valid or no LRC file is found
+     * @return the resolved Lyrics object, or null if the MediaFile is not valid or has no lyrics
      */
     @Nullable
     @Transactional
@@ -73,8 +81,17 @@ public class LyricsService {
             } else if (Files.exists(lrcPathUpper)) {
                 targetLrcPath = lrcPathUpper;
             } else {
-                LOG.debug("LRC file does not exist for media: {}", mediaFile.getId());
-                return null;
+                // No sidecar — fall back to the embedded unsynced lyrics tag (#158). This is the
+                // only place the file is opened for an embedded read, and only on a cache+sidecar
+                // miss, so songs with cached or sidecar lyrics never pay the per-request open.
+                LOG.debug("LRC sidecar does not exist for media: {}, trying embedded lyrics tag", mediaFile.getId());
+                String embedded = embeddedLyricsParser.getLyrics(filePath);
+                if (embedded == null) {
+                    LOG.debug("No embedded lyrics tag for media: {}", mediaFile.getId());
+                    return null;
+                }
+                Lyrics newLyrics = new Lyrics(embedded, mediaFile.getId(), "tag");
+                return lyricsRepository.save(newLyrics);
             }
             LrcFile lrcFile = lrcParser.parse(targetLrcPath);
             if (lrcFile == null || lrcFile.getLyricsLines().isEmpty()) {

--- a/airsonic-main/src/test/java/org/airsonic/player/parser/lyrics/EmbeddedLyricsParserTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/parser/lyrics/EmbeddedLyricsParserTest.java
@@ -1,0 +1,103 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.parser.lyrics;
+
+import org.airsonic.player.util.MusicFolderTestData;
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.audio.AudioFileIO;
+import org.jaudiotagger.tag.FieldKey;
+import org.jaudiotagger.tag.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies the real jaudiotagger read in {@link EmbeddedLyricsParser}. The lyrics tag is written
+ * programmatically into a copy of a real fixture mp3 (mirroring the in-test tag construction used
+ * by the JaudiotaggerParser contributor tests) so no binary fixture needs committing.
+ */
+class EmbeddedLyricsParserTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private final EmbeddedLyricsParser parser = new EmbeddedLyricsParser();
+
+    private Path copyFixture(String name) throws Exception {
+        Path src = MusicFolderTestData.resolveBaseMediaPath().resolve("piano.mp3");
+        Path dest = tempDir.resolve(name);
+        Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
+        return dest;
+    }
+
+    @Test
+    void getLyrics_readsEmbeddedLyricsTag() throws Exception {
+        Path file = copyFixture("embedded.mp3");
+        AudioFile audioFile = AudioFileIO.read(file.toFile());
+        Tag tag = audioFile.getTagOrCreateAndSetDefault();
+        tag.setField(FieldKey.LYRICS, "line one\nline two");
+        audioFile.commit();
+
+        assertEquals("line one\nline two", parser.getLyrics(file));
+    }
+
+    @Test
+    void getLyrics_returnsNullWhenNoLyricsTag() throws Exception {
+        Path file = copyFixture("nolyrics.mp3");
+        AudioFile audioFile = AudioFileIO.read(file.toFile());
+        Tag tag = audioFile.getTag();
+        if (tag != null) {
+            tag.deleteField(FieldKey.LYRICS);
+            audioFile.commit();
+        }
+
+        assertNull(parser.getLyrics(file));
+    }
+
+    @Test
+    void getLyrics_returnsNullForBlankLyricsTag() throws Exception {
+        // A present-but-blank LYRICS frame must read as null (trimToNull), so LyricsService never
+        // caches an empty lyrics string.
+        Path file = copyFixture("blanklyrics.mp3");
+        AudioFile audioFile = AudioFileIO.read(file.toFile());
+        Tag tag = audioFile.getTagOrCreateAndSetDefault();
+        tag.setField(FieldKey.LYRICS, "   ");
+        audioFile.commit();
+
+        assertNull(parser.getLyrics(file));
+    }
+
+    @Test
+    void getLyrics_returnsNullForNullPath() {
+        assertNull(parser.getLyrics(null));
+    }
+
+    @Test
+    void getLyrics_returnsNullForUnreadableFile() throws Exception {
+        Path notAudio = tempDir.resolve("notaudio.mp3");
+        Files.writeString(notAudio, "this is not an audio file");
+        assertNull(parser.getLyrics(notAudio));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
@@ -2,6 +2,7 @@ package org.airsonic.player.service;
 
 import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.parser.lyrics.EmbeddedLyricsParser;
 import org.airsonic.player.repository.LyricsRepository;
 import org.airsonic.player.util.MusicFolderTestData;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ class LyricsServiceTest {
     private LyricsRepository lyricsRepository;
     @Mock
     private MediaFileService mediaFileService;
+    @Mock
+    private EmbeddedLyricsParser embeddedLyricsParser;
     @InjectMocks
     private LyricsService lyricsService;
 
@@ -182,5 +185,85 @@ class LyricsServiceTest {
         assertEquals(11, lyrics.getMediaFileId());
         assertEquals("user", lyrics.getSource());
         verify(lyricsRepository).save(lyrics);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Embedded lyrics tier (#158): DB cache -> LRC sidecar -> embedded tag -> null.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void getLyricsFromMediaFile_shouldReturnEmbeddedLyricsWhenNoCacheAndNoSidecar() {
+        // A path with no .lrc/.LRC sibling forces the embedded fallback. The embedded result is
+        // cached with source "tag" (distinct from the "file" sidecar source).
+        Path path = Path.of("no-sidecar-embedded.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(20);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(20))).thenReturn(Optional.empty());
+        when(embeddedLyricsParser.getLyrics(path)).thenReturn("embedded lyrics");
+        when(lyricsRepository.save(any(Lyrics.class))).thenAnswer(invocation -> {
+            Lyrics saved = invocation.getArgument(0);
+            saved.setId(7);
+            return saved;
+        });
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        assertNotNull(result);
+        assertEquals("embedded lyrics", result.getLyrics());
+        assertEquals(20, result.getMediaFileId());
+        assertEquals("tag", result.getSource());
+        verify(lyricsRepository).save(any(Lyrics.class));
+    }
+
+    @Test
+    void getLyricsFromMediaFile_shouldPreferSidecarOverEmbedded() {
+        // A real .lrc sidecar exists beside this fixture: the sidecar wins and the embedded reader
+        // is never consulted (a sidecar is a deliberate user override of the embedded tag).
+        Path path = MusicFolderTestData.resolveLyricsFolderPath().resolve("simple.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(21);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(21))).thenReturn(Optional.empty());
+        when(lyricsRepository.save(any(Lyrics.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        assertNotNull(result);
+        assertEquals("file", result.getSource());
+        verifyNoInteractions(embeddedLyricsParser);
+    }
+
+    @Test
+    void getLyricsFromMediaFile_shouldPreferCacheOverEmbedded() {
+        // A DB cache hit short-circuits everything — neither sidecar nor embedded is consulted.
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(22);
+        Lyrics cached = new Lyrics("cached lyrics", 22, "tag");
+        when(lyricsRepository.findByMediaFileId(eq(22))).thenReturn(Optional.of(cached));
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        assertEquals(cached, result);
+        verifyNoInteractions(embeddedLyricsParser);
+        verify(lyricsRepository, never()).save(any(Lyrics.class));
+    }
+
+    @Test
+    void getLyricsFromMediaFile_shouldReturnNullWhenNoCacheNoSidecarNoEmbedded() {
+        Path path = Path.of("no-lyrics-anywhere.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(23);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(23))).thenReturn(Optional.empty());
+        when(embeddedLyricsParser.getLyrics(path)).thenReturn(null);
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        assertNull(result);
+        verify(lyricsRepository, never()).save(any(Lyrics.class));
     }
 }


### PR DESCRIPTION
Adds an embedded-tag tier to LyricsService's lookup, giving the precedence chain **DB cache → LRC sidecar → embedded tag → null**. When the DB cache misses and no `.lrc`/`.LRC` sidecar exists, the embedded unsynced `FieldKey.LYRICS` tag (ID3 USLT / Vorbis LYRICS / MP4 `©lyr`, via jaudiotagger) is read at request time and returned. Both `/getLyrics` and `/getLyricsBySongId` route through the single `getLyricsFromMediaFile` method, so both endpoints are satisfied by one change.

## Sidecar wins over embedded

An `.lrc` file is a deliberate user override of whatever's baked into the tag, so the sidecar takes precedence. The embedded read fires **only** on a cache miss AND a sidecar miss, so songs with cached or sidecar lyrics never pay a per-request file open — guarded by `verifyNoInteractions` assertions (the load-bearing no-regression guard).

## Request-time, not scan-time

Matches the existing sidecar tier and the issue's spec, and satisfies the acceptance criterion's explicit "no scan-time regression": the scan path is untouched, no `MetaData` change, no schema change.

## Caching

The embedded result is cached like sidecar lyrics, tagged `source="tag"` (distinct from `"file"` sidecar and `"user"` manual edits). The lyrics cache has no staleness/invalidation today — a pre-existing limitation shared with the sidecar path, **not introduced here**; flagged for the #140 (synced-storage) design to address properly.

## Tests

- 4 service-level precedence tests: embedded hit → `source="tag"` + cached; sidecar wins (reader never invoked); cache wins (reader never invoked); embedded miss → null
- 5 `EmbeddedLyricsParser` tests: real read via programmatically-written tag, no-tag, blank-tag, null-path, non-audio

Test floor: 1159 → 1168. New injected `EmbeddedLyricsParser` seam (vs the internally-new'd `LrcParser`) for testability. No schema change; pr_ci covers the HSQLDB + Postgres + MariaDB matrix on push.

fixes #158