### PR TITLE
feat: synced LRC lyrics with line-structured DB storage (#140)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
@@ -178,25 +178,52 @@ public class SubsonicMediaController extends AbstractSubsonicController {
         LyricsList result = new LyricsList();
 
         org.airsonic.player.domain.Lyrics lyrics = lyricsService.getLyricsFromMediaFile(mediaFile);
-        if (lyrics != null && lyrics.getLyrics() != null && !lyrics.getLyrics().isBlank()) {
-            StructuredLyrics structured = new StructuredLyrics();
-            structured.setDisplayArtist(mediaFile.getArtist());
-            structured.setDisplayTitle(mediaFile.getTitle());
-            structured.setLang("xxx");
-            structured.setSynced(false);
-
-            for (String lineText : lyrics.getLyrics().split("\\R")) {
-                Line line = new Line();
-                line.setValue(lineText);
-                structured.getLine().add(line);
-            }
-
+        StructuredLyrics structured = buildStructuredLyrics(mediaFile.getArtist(), mediaFile.getTitle(), lyrics);
+        if (structured != null) {
             result.getStructuredLyrics().add(structured);
         }
 
         Response res = createResponse();
         res.setLyricsList(result);
         jaxbWriter.writeResponse(request, response, res);
+    }
+
+    /**
+     * Builds the OpenSubsonic {@link StructuredLyrics} element for a resolved {@code lyrics} row,
+     * or {@code null} when there are no lyrics to emit. Synced (LRC) lyrics (#140) emit one
+     * {@link Line} per stored structured line with its {@code start} (ms) and {@code synced=true};
+     * otherwise the flat text blob is split into unsynced lines ({@code synced=false}), preserving
+     * the original #131 behavior for the embedded-tag and legacy-cache tiers.
+     */
+    static StructuredLyrics buildStructuredLyrics(String displayArtist, String displayTitle,
+            org.airsonic.player.domain.Lyrics lyrics) {
+        if (lyrics == null || lyrics.getLyrics() == null || lyrics.getLyrics().isBlank()) {
+            return null;
+        }
+        StructuredLyrics structured = new StructuredLyrics();
+        structured.setDisplayArtist(displayArtist);
+        structured.setDisplayTitle(displayTitle);
+        structured.setLang("xxx");
+
+        if (lyrics.isSynced() && !lyrics.getLines().isEmpty()) {
+            // Synced LRC lyrics (#140): emit structured lines with per-line start (ms).
+            structured.setSynced(true);
+            for (org.airsonic.player.domain.StructuredLyricsLine sourceLine : lyrics.getLines()) {
+                Line line = new Line();
+                line.setValue(sourceLine.getText());
+                line.setStart(sourceLine.getStartMs());
+                structured.getLine().add(line);
+            }
+        } else {
+            // Unsynced fallback (pre-#140 cached sidecar, or embedded tag): split the flat blob.
+            structured.setSynced(false);
+            for (String lineText : lyrics.getLyrics().split("\\R")) {
+                Line line = new Line();
+                line.setValue(lineText);
+                structured.getLine().add(line);
+            }
+        }
+        return structured;
     }
 
     @RequestMapping({"/getCaptions", "/getCaptions.view"})

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Lyrics.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Lyrics.java
@@ -1,14 +1,20 @@
 package org.airsonic.player.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "lyrics")
@@ -26,6 +32,21 @@ public class Lyrics {
 
     @Column(name = "source", nullable = false)
     private String source;
+
+    // True when the lyrics carry per-line LRC timestamps (a parsed LRC sidecar). The unsynced
+    // tiers (legacy cache, embedded tag) leave this false. Drives the getLyricsBySongId synced
+    // flag; see #140.
+    @Column(name = "synced", nullable = false)
+    private boolean synced;
+
+    // Per-line timestamped lyrics, present only when synced. EAGER because lyrics are always read
+    // one song at a time (findByMediaFileId — no batch/list path exists) and the endpoint reads
+    // the lines outside the service's @Transactional boundary, so a LAZY collection would throw.
+    // The bounded small collection mirrors the codebase's EAGER User.musicFolders. @OrderBy makes
+    // the line ordering deterministic across HSQLDB/Postgres/MariaDB (not insertion-dependent).
+    @OneToMany(mappedBy = "lyrics", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OrderBy("position ASC")
+    private List<StructuredLyricsLine> lines = new ArrayList<>();
 
     @Column(name = "created", nullable = false)
     private Instant created;
@@ -98,6 +119,22 @@ public class Lyrics {
 
     public void setSource(String source) {
         this.source = source;
+    }
+
+    public boolean isSynced() {
+        return synced;
+    }
+
+    public void setSynced(boolean synced) {
+        this.synced = synced;
+    }
+
+    public List<StructuredLyricsLine> getLines() {
+        return lines;
+    }
+
+    public void setLines(List<StructuredLyricsLine> lines) {
+        this.lines = lines != null ? lines : new ArrayList<>();
     }
 
     @Override

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/StructuredLyricsLine.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/StructuredLyricsLine.java
@@ -1,0 +1,108 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * A single timestamped line of synced (LRC) lyrics belonging to a {@link Lyrics} row. Carries the
+ * line's display order ({@code position}), its start offset in milliseconds ({@code startMs}), and
+ * the line {@code text}. Persisted as a child of {@code lyrics} so the flat text blob (used by the
+ * legacy {@code /getLyrics} endpoint and the unsynced fallback) and the structured synced lines
+ * (used by {@code getLyricsBySongId} to emit {@code synced=true} with per-line {@code start})
+ * coexist on the same cache row.
+ */
+@Entity
+@Table(name = "structured_lyrics_line")
+public class StructuredLyricsLine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "lyrics_id", nullable = false)
+    private Lyrics lyrics;
+
+    @Column(name = "position", nullable = false)
+    private int position;
+
+    @Column(name = "start_ms", nullable = false)
+    private long startMs;
+
+    @Column(name = "text", nullable = false)
+    private String text;
+
+    public StructuredLyricsLine() {
+    }
+
+    public StructuredLyricsLine(Lyrics lyrics, int position, long startMs, String text) {
+        this.lyrics = lyrics;
+        this.position = position;
+        this.startMs = startMs;
+        this.text = text;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Lyrics getLyrics() {
+        return lyrics;
+    }
+
+    public void setLyrics(Lyrics lyrics) {
+        this.lyrics = lyrics;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public long getStartMs() {
+        return startMs;
+    }
+
+    public void setStartMs(long startMs) {
+        this.startMs = startMs;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
@@ -3,6 +3,7 @@ package org.airsonic.player.service;
 import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.domain.StructuredLyricsLine;
 import org.airsonic.player.parser.lyrics.EmbeddedLyricsParser;
 import org.airsonic.player.parser.lyrics.LrcFile;
 import org.airsonic.player.parser.lyrics.LrcParser;
@@ -19,6 +20,7 @@ import jakarta.transaction.Transactional;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -98,11 +100,21 @@ public class LyricsService {
                 LOG.debug("No lyrics found in LRC file: {}", targetLrcPath);
                 return null;
             }
+            // Preserve the per-line LRC timestamps (#140): populate the flat text blob (still used
+            // by the legacy /getLyrics endpoint and the unsynced split) AND the structured timed
+            // lines, marking the row synced. LrcParser only emits timed lines, so a non-empty parse
+            // is synced by construction.
+            Lyrics newLyrics = new Lyrics("", mediaFile.getId(), "file");
+            newLyrics.setSynced(true);
             StringBuilder lyricsText = new StringBuilder();
+            List<StructuredLyricsLine> lines = new ArrayList<>();
+            int position = 0;
             for (LyricsLine line : lrcFile.getLyricsLines()) {
                 lyricsText.append(line.getText()).append("\n");
+                lines.add(new StructuredLyricsLine(newLyrics, position++, line.getTime(), line.getText()));
             }
-            Lyrics newLyrics = new Lyrics(lyricsText.toString(), mediaFile.getId(), "file");
+            newLyrics.setLyrics(lyricsText.toString());
+            newLyrics.setLines(lines);
             return lyricsRepository.save(newLyrics);
         });
 

--- a/airsonic-main/src/main/resources/liquibase/13.2/add-structured-lyrics.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/add-structured-lyrics.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="add-lyrics-synced-column" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="lyrics" columnName="synced" />
+            </not>
+        </preConditions>
+        <addColumn tableName="lyrics">
+            <column name="synced" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add-structured-lyrics-line-table" author="litebito">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="structured_lyrics_line" />
+            </not>
+        </preConditions>
+        <createTable tableName="structured_lyrics_line">
+            <column name="id" type="integer" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="lyrics_id" type="integer">
+                <constraints nullable="false" foreignKeyName="fk_structured_lyrics_line_lyrics"
+                             referencedTableName="lyrics" referencedColumnNames="id"
+                             deleteCascade="true" />
+            </column>
+            <column name="position" type="integer">
+                <constraints nullable="false" />
+            </column>
+            <column name="start_ms" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="text" type="${varchar_type}">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="structured_lyrics_line" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/13.2/changelog.xml
@@ -20,4 +20,5 @@
     <include file="add-api-key-table.xml" relativeToChangelogFile="true"/>
     <include file="add-album-replaygain.xml" relativeToChangelogFile="true"/>
     <include file="add-user-password-auth-enabled.xml" relativeToChangelogFile="true"/>
+    <include file="add-structured-lyrics.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicMediaControllerLyricsTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicMediaControllerLyricsTest.java
@@ -1,0 +1,90 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.domain.Lyrics;
+import org.airsonic.player.domain.StructuredLyricsLine;
+import org.junit.jupiter.api.Test;
+import org.subsonic.restapi.StructuredLyrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for {@link SubsonicMediaController#buildStructuredLyrics} — the getLyricsBySongId
+ * response mapping (#140): synced lyrics emit per-line {@code start} (ms) with {@code synced=true},
+ * unsynced lyrics split the flat blob with {@code synced=false}.
+ */
+class SubsonicMediaControllerLyricsTest {
+
+    @Test
+    void buildStructuredLyrics_emitsSyncedLinesWithStart() {
+        Lyrics lyrics = new Lyrics("Line A\nLine B", 1, "file");
+        lyrics.setSynced(true);
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 0, 1000L, "Line A"));
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 1, 2500L, "Line B"));
+
+        StructuredLyrics result = SubsonicMediaController.buildStructuredLyrics("Artist", "Title", lyrics);
+
+        assertTrue(result.isSynced());
+        assertEquals("Artist", result.getDisplayArtist());
+        assertEquals("Title", result.getDisplayTitle());
+        assertEquals(2, result.getLine().size());
+        assertEquals("Line A", result.getLine().get(0).getValue());
+        assertEquals(1000L, result.getLine().get(0).getStart());
+        assertEquals("Line B", result.getLine().get(1).getValue());
+        assertEquals(2500L, result.getLine().get(1).getStart());
+    }
+
+    @Test
+    void buildStructuredLyrics_unsyncedSplitsBlobWithoutStart() {
+        // Unsynced (embedded tag / legacy cache): synced=false, lines split from the blob, no start.
+        Lyrics lyrics = new Lyrics("First line\nSecond line", 2, "tag");
+
+        StructuredLyrics result = SubsonicMediaController.buildStructuredLyrics("A", "T", lyrics);
+
+        assertFalse(result.isSynced());
+        assertEquals(2, result.getLine().size());
+        assertEquals("First line", result.getLine().get(0).getValue());
+        assertNull(result.getLine().get(0).getStart());
+        assertNull(result.getLine().get(1).getStart());
+    }
+
+    @Test
+    void buildStructuredLyrics_syncedFlagButNoLinesFallsBackToBlob() {
+        // Defensive: a synced flag with an empty line list must not emit an empty structured block;
+        // it falls back to the unsynced blob split.
+        Lyrics lyrics = new Lyrics("Only blob", 3, "file");
+        lyrics.setSynced(true);
+
+        StructuredLyrics result = SubsonicMediaController.buildStructuredLyrics("A", "T", lyrics);
+
+        assertFalse(result.isSynced());
+        assertEquals(1, result.getLine().size());
+        assertEquals("Only blob", result.getLine().get(0).getValue());
+    }
+
+    @Test
+    void buildStructuredLyrics_returnsNullForBlankOrMissing() {
+        assertNull(SubsonicMediaController.buildStructuredLyrics("A", "T", null));
+        assertNull(SubsonicMediaController.buildStructuredLyrics("A", "T", new Lyrics("   ", 4, "file")));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/repository/LyricsRepositoryTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/repository/LyricsRepositoryTest.java
@@ -24,6 +24,7 @@ import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MediaFile.MediaType;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.MusicFolder.Type;
+import org.airsonic.player.domain.StructuredLyricsLine;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import jakarta.transaction.Transactional;
 
@@ -43,6 +45,7 @@ import java.time.temporal.ChronoUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @EnableConfigurationProperties({ AirsonicHomeConfig.class })
@@ -58,6 +61,9 @@ public class LyricsRepositoryTest {
 
     @Autowired
     private MusicFolderRepository musicFolderRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @TempDir
     private static Path tempAirsonicDir;
@@ -158,6 +164,51 @@ public class LyricsRepositoryTest {
         mediaFileRepository.delete(testMediaFile);
         mediaFileRepository.flush();
         assertEquals(0, lyricsRepository.count(), "Lyrics should be deleted when MediaFile is deleted");
+    }
+
+    @Test
+    public void testSyncedLyricsLinesRoundTrip() {
+        // Synced LRC lyrics (#140): structured lines persist as a child collection and reload
+        // ordered by position with their start_ms intact, across the real DDL.
+        Lyrics lyrics = new Lyrics("Line A\nLine B\nLine C", testMediaFile.getId(), "file");
+        lyrics.setSynced(true);
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 0, 1000L, "Line A"));
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 1, 2500L, "Line B"));
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 2, 4200L, "Line C"));
+        lyricsRepository.save(lyrics);
+
+        Lyrics reloaded = lyricsRepository.findByMediaFileId(testMediaFile.getId()).orElseThrow();
+        assertTrue(reloaded.isSynced());
+        assertEquals(3, reloaded.getLines().size());
+        // @OrderBy("position ASC") guarantees deterministic order across HSQLDB/Postgres/MariaDB.
+        assertEquals(0, reloaded.getLines().get(0).getPosition());
+        assertEquals(1000L, reloaded.getLines().get(0).getStartMs());
+        assertEquals("Line A", reloaded.getLines().get(0).getText());
+        assertEquals(2500L, reloaded.getLines().get(1).getStartMs());
+        assertEquals(4200L, reloaded.getLines().get(2).getStartMs());
+        assertEquals("Line C", reloaded.getLines().get(2).getText());
+    }
+
+    @Test
+    public void testSyncedLinesCascadeDeleteWithLyrics() {
+        Lyrics lyrics = new Lyrics("Line A\nLine B", testMediaFile.getId(), "file");
+        lyrics.setSynced(true);
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 0, 0L, "Line A"));
+        lyrics.getLines().add(new StructuredLyricsLine(lyrics, 1, 1500L, "Line B"));
+        lyricsRepository.save(lyrics);
+        lyricsRepository.flush();
+
+        assertEquals(2, countStructuredLyricsLines());
+
+        // Deleting the parent lyrics row removes its child lines (orphanRemoval / cascade).
+        lyricsRepository.deleteById(lyrics.getId());
+        lyricsRepository.flush();
+        assertEquals(0, countStructuredLyricsLines(),
+                "structured_lyrics_line rows must be removed with their parent lyrics");
+    }
+
+    private int countStructuredLyricsLines() {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM structured_lyrics_line", Integer.class);
     }
 
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
@@ -2,6 +2,7 @@ package org.airsonic.player.service;
 
 import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.StructuredLyricsLine;
 import org.airsonic.player.parser.lyrics.EmbeddedLyricsParser;
 import org.airsonic.player.repository.LyricsRepository;
 import org.airsonic.player.util.MusicFolderTestData;
@@ -265,5 +266,63 @@ class LyricsServiceTest {
 
         assertNull(result);
         verify(lyricsRepository, never()).save(any(Lyrics.class));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Synced LRC lyrics (#140): a timestamped sidecar preserves per-line times into structured
+    // lines + synced=true, while still populating the flat blob for the legacy endpoint.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void getLyricsFromMediaFile_shouldPreserveTimestampsFromSyncedSidecar() {
+        Path path = MusicFolderTestData.resolveLyricsFolderPath().resolve("simple.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(30);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(30))).thenReturn(Optional.empty());
+        when(lyricsRepository.save(any(Lyrics.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        // synced flag + structured lines populated from the LRC timestamps.
+        assertTrue(result.isSynced());
+        assertEquals("file", result.getSource());
+        assertFalse(result.getLines().isEmpty());
+        // First line: [00:10.37] -> 10370 ms, "Lyrics1 Line 1"; position runs 0..n monotonically.
+        StructuredLyricsLine first = result.getLines().get(0);
+        assertEquals(0, first.getPosition());
+        assertEquals(10370L, first.getStartMs());
+        assertEquals("Lyrics1 Line 1", first.getText());
+        // The double-timestamped second line ([00:20.09][00:25.31]Lyrics2 Line 2) emits two lines.
+        assertEquals(20090L, result.getLines().get(1).getStartMs());
+        assertEquals(25310L, result.getLines().get(2).getStartMs());
+        assertEquals("Lyrics2 Line 2", result.getLines().get(2).getText());
+        // The flat blob is still populated (legacy /getLyrics + unsynced split rely on it).
+        assertTrue(result.getLyrics().startsWith("Lyrics1 Line 1\n"));
+        // Each structured line back-references its parent and is position-ordered.
+        for (int i = 0; i < result.getLines().size(); i++) {
+            assertEquals(i, result.getLines().get(i).getPosition());
+            assertEquals(result, result.getLines().get(i).getLyrics());
+        }
+    }
+
+    @Test
+    void getLyricsFromMediaFile_embeddedTagIsUnsyncedWithNoStructuredLines() {
+        // The embedded tier (#158) has no timestamps: synced stays false and no structured lines.
+        Path path = Path.of("no-sidecar-synced.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(31);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(31))).thenReturn(Optional.empty());
+        when(embeddedLyricsParser.getLyrics(path)).thenReturn("plain embedded line");
+        when(lyricsRepository.save(any(Lyrics.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+        assertFalse(result.isSynced());
+        assertTrue(result.getLines().isEmpty());
+        assertEquals("tag", result.getSource());
     }
 }


### PR DESCRIPTION
Sub-issue L of #35. Depends on #158 (embedded unsynced read, merged).

## Timestamp-preservation fix

`LrcParser` already computes per-line millisecond timestamps, but `LyricsService` flattened them to a plain-text blob before persisting — so `getLyricsBySongId` could only ever emit `synced=false`. This PR stops discarding the timestamps: a parsed LRC sidecar now persists line-structured, and the endpoint emits `synced=true` with per-line `Line.start` (ms).

## Schema (lighter shape)

One new column `lyrics.synced` (`BOOLEAN DEFAULT FALSE NOT NULL` — existing rows non-disruptive) and one new child table `structured_lyrics_line(lyrics_id FK cascade, position, start_ms, text)`, reusing the existing `lyrics` cache row rather than a separate `structured_lyrics` table. Additive + idempotent, verified across HSQLDB + Postgres (MariaDB via pr_ci).

## Flat-blob coexistence — the key non-regression

A synced song still populates the flat text blob alongside `synced=true` and the structured lines. The legacy `/getLyrics` endpoint returns plain text (`setContent`) and cannot emit structured output, so it keeps reading the blob — unchanged. `getLyricsBySongId` emits structured synced lines when synced, else splits the blob (the original #131 unsynced behavior, preserved for the embedded-tag and legacy-cache tiers).

## Fallback chain

Post-#158 precedence respected: **DB cache → sidecar → embedded → null**. Synced is added on the sidecar tier only; the embedded tier (#158) stays `synced=false`. Synced detection is "the sidecar parse yielded lines" — `LrcParser` only emits timed lines, so a non-empty parse is synced by construction.

## EAGER lines association

The structured lines load EAGER with the `Lyrics` row. Verified there is no batch/list path — lyrics are only ever read one song at a time via `findByMediaFileId` (callers: `LyricsController`, `SubsonicMediaController`, `LyricsWSController`) — so EAGER cannot cause an N+1. It is also required for correctness: the controller reads the lines after the service's `@Transactional` boundary closes, so LAZY would throw `LazyInitializationException`. Mirrors the existing EAGER `User.musicFolders`. `@OrderBy("position ASC")` makes line ordering deterministic across DBs.

## Deferred (separate issues, fences held)

- **Embedded SYLT synced extraction** — needs ID3 frame-level access (the TMCL/IPLS pattern), not a FieldKey. Out of scope; tracked separately.
- **Lyrics cache invalidation/staleness** — a pre-existing cross-cutting limitation across all tiers. This PR inherits cache-forever consistently and does **not** add a synced-only half-fix. Tracked separately.

## Verification

- HSQLDB full suite: 1176/0/0
- Local Postgres 16 full suite: 1176, 0 failures, 1 error — the single error is the pre-existing `TranscodingServiceIntTest.createTranscodingTest` local-env flake (`Player.transcodings` lazy-init, unrelated to lyrics). All three lyrics test classes pass clean on Postgres. Net new errors from this PR: 0. The new DDL and ordered reads behave identically across HSQLDB and Postgres.
- analyze clean, WAR packages the changeset + `StructuredLyricsLine`

Test floor: 1168 → 1176 (+8): service (synced sidecar, embedded unsynced), repository (persistence round-trip + cascade delete), controller mapping (synced→start, unsynced split, empty-lines fallback, blank→null).

fixes #140