### PR TITLE
feat: operator audit log for apiKey authentication failures

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationProvider.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/APIKeyAuthenticationProvider.java
@@ -21,6 +21,8 @@ package org.airsonic.player.security;
 import org.airsonic.player.domain.ApiKey;
 import org.airsonic.player.service.ApiKeyService;
 import org.airsonic.player.service.SecurityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
@@ -37,8 +39,17 @@ import java.util.Optional;
  * unknown user). All failure paths collapse to the same generic exception — no enumeration
  * oracle distinguishes "no such key" from "disabled key" from "expired key" from "user gone".
  * The raw key is never logged or included in exception messages.
+ * <p>
+ * Each failure path additionally emits an operator-only audit log at INFO recording the actual
+ * reason (#237). The audit log is keyed on {@link ApiKey#getId()} where a key resolved (the
+ * user-gone / user-disabled paths); the unresolved paths (blank credentials, unknown/disabled/
+ * expired key) have no {@code ApiKey} object and log the reason with no key material — never the
+ * raw key or its hash. The audit log distinguishes the modes for forensics; the thrown exception
+ * stays opaque so the client-facing response reveals nothing (the enumeration-oracle defence).
  */
 public class APIKeyAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(APIKeyAuthenticationProvider.class);
 
     private final ApiKeyService apiKeyService;
     private final SecurityService securityService;
@@ -53,11 +64,17 @@ public class APIKeyAuthenticationProvider implements AuthenticationProvider {
         APIKeyAuthenticationToken token = (APIKeyAuthenticationToken) authentication;
         Object credentials = token.getCredentials();
         if (!(credentials instanceof String rawKey) || rawKey.isBlank()) {
+            // No ApiKey resolved — no id exists; log the reason only, never the raw value.
+            LOG.info("API key authentication failed: blank or absent credentials");
             throw new BadCredentialsException("Invalid API key");
         }
 
         Optional<ApiKey> resolved = apiKeyService.resolve(rawKey);
         if (resolved.isEmpty()) {
+            // ApiKeyService.resolve already filters disabled + expired keys, so unknown, disabled,
+            // and expired all collapse here indistinguishably — there is no ApiKey object and no
+            // id to log, and the raw key must never be logged.
+            LOG.info("API key authentication failed: unknown or unresolvable API key (unknown, disabled, or expired)");
             throw new BadCredentialsException("Invalid API key");
         }
         ApiKey apiKey = resolved.get();
@@ -68,10 +85,12 @@ public class APIKeyAuthenticationProvider implements AuthenticationProvider {
         } catch (UsernameNotFoundException x) {
             // Key references a user that no longer exists. Collapse to the same generic error so
             // an attacker cannot distinguish "user gone" from "no such key".
+            LOG.info("API key authentication failed: key references a user that no longer exists [apiKeyId={}]", apiKey.getId());
             throw new BadCredentialsException("Invalid API key");
         }
         if (!user.isEnabled() || !user.isAccountNonLocked() || !user.isAccountNonExpired()
                 || !user.isCredentialsNonExpired()) {
+            LOG.info("API key authentication failed: user account is disabled, locked, or expired [apiKeyId={}]", apiKey.getId());
             throw new BadCredentialsException("Invalid API key");
         }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthenticationProviderTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/APIKeyAuthenticationProviderTest.java
@@ -18,14 +18,20 @@
  */
 package org.airsonic.player.security;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.airsonic.player.domain.ApiKey;
 import org.airsonic.player.service.ApiKeyService;
 import org.airsonic.player.service.SecurityService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -54,6 +60,34 @@ class APIKeyAuthenticationProviderTest {
 
     @InjectMocks
     private APIKeyAuthenticationProvider provider;
+
+    private ch.qos.logback.classic.Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+    private Level previousLevel;
+
+    @BeforeEach
+    void attachAppender() {
+        logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(APIKeyAuthenticationProvider.class);
+        previousLevel = logger.getLevel();
+        // Ensure INFO audit events reach the appender regardless of the ambient log config.
+        logger.setLevel(Level.INFO);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        logger.detachAppender(appender);
+        logger.setLevel(previousLevel);
+    }
+
+    private List<String> infoMessages() {
+        return appender.list.stream()
+                .filter(e -> e.getLevel() == Level.INFO)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
 
     private UserDetails activeUser() {
         return new User("alice", "n/a", true, true, true, true,
@@ -136,5 +170,103 @@ class APIKeyAuthenticationProviderTest {
                 () -> provider.authenticate(new APIKeyAuthenticationToken(null, "")));
         assertThrows(BadCredentialsException.class,
                 () -> provider.authenticate(new APIKeyAuthenticationToken(null, "   ")));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Operator audit log (#237): each failure path logs the reason (+ apiKeyId where a key
+    // resolved) at INFO, while the thrown response stays opaque across every mode.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void auditLog_blankCredentials_logsReasonNoId() {
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "   ")));
+
+        assertThat(infoMessages()).hasSize(1);
+        assertThat(infoMessages().get(0)).contains("blank or absent credentials");
+        // No id exists on this path, and no key material may appear.
+        assertThat(infoMessages().get(0)).doesNotContain("apiKeyId=");
+    }
+
+    @Test
+    void auditLog_unknownKey_logsReasonNoIdAndNoRawKey() {
+        when(apiKeyService.resolve("ap_unknown_secret")).thenReturn(Optional.empty());
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_unknown_secret")));
+
+        assertThat(infoMessages()).hasSize(1);
+        assertThat(infoMessages().get(0)).contains("unknown or unresolvable API key");
+        assertThat(infoMessages().get(0)).doesNotContain("apiKeyId=");
+        // The presented raw key must never reach any log sink.
+        assertThat(infoMessages().get(0)).doesNotContain("ap_unknown_secret");
+    }
+
+    @Test
+    void auditLog_userGone_logsReasonWithApiKeyId() {
+        when(apiKeyService.resolve("ap_orphaned")).thenReturn(Optional.of(aliceKey()));
+        when(securityService.loadUserByUsername("alice"))
+                .thenThrow(new UsernameNotFoundException("alice"));
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_orphaned")));
+
+        assertThat(infoMessages()).hasSize(1);
+        assertThat(infoMessages().get(0)).contains("user that no longer exists");
+        assertThat(infoMessages().get(0)).contains("apiKeyId=7");
+    }
+
+    @Test
+    void auditLog_disabledUser_logsReasonWithApiKeyId() {
+        when(apiKeyService.resolve("ap_alpha")).thenReturn(Optional.of(aliceKey()));
+        UserDetails locked = new User("alice", "n/a", false, true, true, true,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        when(securityService.loadUserByUsername("alice")).thenReturn(locked);
+
+        assertThrows(BadCredentialsException.class,
+                () -> provider.authenticate(new APIKeyAuthenticationToken(null, "ap_alpha")));
+
+        assertThat(infoMessages()).hasSize(1);
+        assertThat(infoMessages().get(0)).contains("disabled, locked, or expired");
+        assertThat(infoMessages().get(0)).contains("apiKeyId=7");
+    }
+
+    @Test
+    void responseStaysOpaque_acrossAllFailureModes() {
+        // The enumeration-oracle defence: every failure mode must throw the identical opaque
+        // exception — same type, same message, no distinguishing cause — regardless of the
+        // (distinguishing) audit log. This is the test that proves the defence wasn't weakened.
+        when(apiKeyService.resolve("ap_unknown")).thenReturn(Optional.empty());
+        when(apiKeyService.resolve("ap_orphaned")).thenReturn(Optional.of(aliceKey()));
+        when(apiKeyService.resolve("ap_disabled_user")).thenReturn(Optional.of(aliceKey()));
+        UserDetails lockedUser = new User("bob", "n/a", false, true, true, true,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        when(securityService.loadUserByUsername("alice"))
+                .thenThrow(new UsernameNotFoundException("alice"))
+                .thenReturn(lockedUser);
+
+        List<APIKeyAuthenticationToken> failingTokens = List.of(
+                new APIKeyAuthenticationToken(null, "   "),
+                new APIKeyAuthenticationToken(null, "ap_unknown"),
+                new APIKeyAuthenticationToken(null, "ap_orphaned"),
+                new APIKeyAuthenticationToken(null, "ap_disabled_user"));
+
+        for (APIKeyAuthenticationToken token : failingTokens) {
+            BadCredentialsException ex = assertThrows(BadCredentialsException.class,
+                    () -> provider.authenticate(token));
+            assertThat(ex.getMessage()).isEqualTo("Invalid API key");
+            assertThat(ex.getCause()).isNull();
+        }
+    }
+
+    @Test
+    void auditLog_successPath_emitsNoFailureAudit() {
+        when(apiKeyService.resolve("ap_alpha")).thenReturn(Optional.of(aliceKey()));
+        when(securityService.loadUserByUsername("alice")).thenReturn(activeUser());
+
+        Authentication result = provider.authenticate(new APIKeyAuthenticationToken(null, "ap_alpha"));
+
+        assertTrue(result.isAuthenticated());
+        assertThat(infoMessages()).isEmpty();
     }
 }


### PR DESCRIPTION
Follow-up from #145 PR-B (security-auditor Minor #2).

## Operator forensics without weakening the enumeration defense

`APIKeyAuthenticationProvider` deliberately collapses every auth failure — blank credentials, unknown/disabled/expired key, user gone, user disabled — to one identical `BadCredentialsException("Invalid API key")` with no cause, so a client can't tell why auth failed (the enumeration-oracle defense). That left operators blind to which key failed and why. This PR adds an operator-only INFO audit log on each failure path recording the real reason — while the client-facing response stays byte-identical.

## Both halves of the contract hold

- **The log distinguishes the actionable modes**: blank-credentials / unknown-or-unresolvable-key / user-gone / user-disabled. The user-gone and user-disabled lines carry `apiKeyId={}` (the opaque internal key id) so an operator can correlate to a specific key row.
- **The response stays opaque**: every path still throws the identical `BadCredentialsException("Invalid API key")`, no cause, no message change. The logs are purely additive, inserted before each existing throw. A dedicated test (`responseStaysOpaque_acrossAllFailureModes`) asserts the thrown exception is identical across all four failure modes.

## No key material is ever logged

The id-keyed paths log only `apiKey.getId()` (an opaque integer surrogate — never the raw key or its HMAC hash). The id-less paths (blank, unknown) log a constant reason string with no key material; a test asserts the presented raw key never appears in the log.

## Honest note on the failure-mode collapse

Unknown, disabled, and expired keys are indistinguishable at the provider because `ApiKeyService.resolve` filters disabled+expired upstream and returns empty — they share one audit line. This is pre-existing (the resolve layer), not changed here. Surfacing disabled-vs-expired in the audit log would be a separate resolve-layer change (noted as a possible follow-up).

## Verification

- Security-audited: client-facing response byte-identical across all failure modes, no sensitive token in any log sink, audit log distinguishes the actionable modes — all three confirmed.
- HSQLDB full suite: 1182/0/0
- No schema change; pr_ci covers the matrix.

6 new tests; floor 1176 → 1182.

fixes #237