### PR TITLE
fix: clamp search count/offset to bound Lucene TopDocs allocation (#262)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSearchController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSearchController.java
@@ -52,6 +52,19 @@ import static org.springframework.web.bind.ServletRequestUtils.getIntParameter;
 @RequestMapping(value = {"/rest", "/ext"}, method = {RequestMethod.GET, RequestMethod.POST})
 public class SubsonicSearchController extends AbstractSubsonicController {
 
+    /**
+     * Upper bound for any per-request count or offset on the search endpoints (#262). Both flow to
+     * {@code SearchServiceImpl} as {@code searcher.search(query, offset + count)}, which makes
+     * Lucene pre-allocate a {@code TopDocs} collector sized to {@code offset + count} before
+     * collecting any document — an authenticated client passing {@code songCount=2147483647} could
+     * OOM the JVM (and an abusive {@code offset} could overflow {@code offset + count} to a
+     * negative). Clamping both to this ceiling bounds the allocation to {@code 2 * MAX_COUNT} and
+     * removes the overflow. The value matches the existing getAlbumList / getAlbumList2 size
+     * ceiling, keeping the Subsonic surface consistent; it is comfortably above any legitimate
+     * client search request (clients page 20–100 at a time) and below memory pressure.
+     */
+    static final int MAX_COUNT = 500;
+
     @Autowired
     private SearchService searchService;
     @Autowired
@@ -92,8 +105,8 @@ public class SubsonicSearchController extends AbstractSubsonicController {
 
         SearchCriteria criteria = new SearchCriteria();
         criteria.setQuery(query.toString().trim());
-        criteria.setCount(getIntParameter(request, "count", 20));
-        criteria.setOffset(getIntParameter(request, "offset", 0));
+        criteria.setCount(clamp(getIntParameter(request, "count", 20)));
+        criteria.setOffset(clamp(getIntParameter(request, "offset", 0)));
         List<org.airsonic.player.domain.MusicFolder> musicFolders = mediaFolderService.getMusicFoldersForUser(username);
 
         org.airsonic.player.domain.SearchResult result = searchService.search(criteria, musicFolders, IndexType.SONG);
@@ -122,22 +135,22 @@ public class SubsonicSearchController extends AbstractSubsonicController {
         String query = request.getParameter("query");
         SearchCriteria criteria = new SearchCriteria();
         criteria.setQuery(StringUtils.trimToEmpty(query));
-        criteria.setCount(getIntParameter(request, "artistCount", 20));
-        criteria.setOffset(getIntParameter(request, "artistOffset", 0));
+        criteria.setCount(clamp(getIntParameter(request, "artistCount", 20)));
+        criteria.setOffset(clamp(getIntParameter(request, "artistOffset", 0)));
         org.airsonic.player.domain.SearchResult artists = searchService.search(criteria, musicFolders, IndexType.ARTIST);
         for (MediaFile mediaFile : artists.getMediaFiles()) {
             searchResult.getArtist().add(jaxbContentService.createJaxbArtist(mediaFile, username));
         }
 
-        criteria.setCount(getIntParameter(request, "albumCount", 20));
-        criteria.setOffset(getIntParameter(request, "albumOffset", 0));
+        criteria.setCount(clamp(getIntParameter(request, "albumCount", 20)));
+        criteria.setOffset(clamp(getIntParameter(request, "albumOffset", 0)));
         org.airsonic.player.domain.SearchResult albums = searchService.search(criteria, musicFolders, IndexType.ALBUM);
         for (MediaFile mediaFile : albums.getMediaFiles()) {
             searchResult.getAlbum().add(jaxbContentService.createJaxbChild(player, mediaFile, username));
         }
 
-        criteria.setCount(getIntParameter(request, "songCount", 20));
-        criteria.setOffset(getIntParameter(request, "songOffset", 0));
+        criteria.setCount(clamp(getIntParameter(request, "songCount", 20)));
+        criteria.setOffset(clamp(getIntParameter(request, "songOffset", 0)));
         org.airsonic.player.domain.SearchResult songs = searchService.search(criteria, musicFolders, IndexType.SONG);
         for (MediaFile mediaFile : songs.getMediaFiles()) {
             searchResult.getSong().add(jaxbContentService.createJaxbChild(player, mediaFile, username));
@@ -161,12 +174,12 @@ public class SubsonicSearchController extends AbstractSubsonicController {
         String query = request.getParameter("query");
         // replace empty string with null
         query = "\"\"".equals(query) ? null : query;
-        int songCount = getIntParameter(request, "songCount", 20);
-        int songOffset = getIntParameter(request, "songOffset", 0);
-        int albumCount = getIntParameter(request, "albumCount", 20);
-        int albumOffset = getIntParameter(request, "albumOffset", 0);
-        int artistCount = getIntParameter(request, "artistCount", 20);
-        int artistOffset = getIntParameter(request, "artistOffset", 0);
+        int songCount = clamp(getIntParameter(request, "songCount", 20));
+        int songOffset = clamp(getIntParameter(request, "songOffset", 0));
+        int albumCount = clamp(getIntParameter(request, "albumCount", 20));
+        int albumOffset = clamp(getIntParameter(request, "albumOffset", 0));
+        int artistCount = clamp(getIntParameter(request, "artistCount", 20));
+        int artistOffset = clamp(getIntParameter(request, "artistOffset", 0));
         if (StringUtils.isEmpty(query)) {
             if (artistCount > 0) {
                 artistService.getArtists(musicFolders, artistCount, artistOffset).forEach(artist -> searchResult.getArtist().add(jaxbContentService.createJaxbArtist(new ArtistID3(), artist, username)));
@@ -205,6 +218,15 @@ public class SubsonicSearchController extends AbstractSubsonicController {
         Response res = createResponse();
         res.setSearchResult3(searchResult);
         jaxbWriter.writeResponse(request, response, res);
+    }
+
+    /**
+     * Bounds a per-request count or offset to {@code [0, MAX_COUNT]} (#262). Silent — a client
+     * requesting more simply receives {@code MAX_COUNT} back rather than an error. The lower floor
+     * also normalises a negative value (which {@code getIntParameter} passes through unchanged).
+     */
+    static int clamp(int value) {
+        return Math.max(0, Math.min(MAX_COUNT, value));
     }
 
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicSearchControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicSearchControllerTest.java
@@ -1,0 +1,204 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.domain.Player;
+import org.airsonic.player.domain.SearchCriteria;
+import org.airsonic.player.domain.SearchResult;
+import org.airsonic.player.service.JaxbContentService;
+import org.airsonic.player.service.MediaFolderService;
+import org.airsonic.player.service.PlayerService;
+import org.airsonic.player.service.SearchService;
+import org.airsonic.player.service.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.subsonic.restapi.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for the count/offset clamp on the search endpoints (#262). Drives the controller with
+ * abusive and legitimate parameter values and snapshots the {@link SearchCriteria} count/offset
+ * actually handed to {@link SearchService} (search2/search3 reuse one mutable criteria across three
+ * calls, so the values are snapshotted per invocation rather than captured by reference).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SubsonicSearchControllerTest {
+
+    @Mock
+    private SearchService searchService;
+    @Mock
+    private MediaFolderService mediaFolderService;
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private JaxbContentService jaxbContentService;
+    @Mock
+    private PlayerService playerService;
+    @Mock
+    private org.airsonic.player.controller.JAXBWriter jaxbWriter;
+
+    private SubsonicSearchController controller;
+
+    // (count, offset) snapshotted at each searchService.search invocation.
+    private final List<int[]> searchArgs = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        controller = new SubsonicSearchController();
+        ReflectionTestUtils.setField(controller, "searchService", searchService);
+        ReflectionTestUtils.setField(controller, "mediaFolderService", mediaFolderService);
+        ReflectionTestUtils.setField(controller, "securityService", securityService);
+        ReflectionTestUtils.setField(controller, "jaxbContentService", jaxbContentService);
+        ReflectionTestUtils.setField(controller, "playerService", playerService);
+        ReflectionTestUtils.setField(controller, "jaxbWriter", jaxbWriter);
+
+        when(securityService.getCurrentUsername(any())).thenReturn("alice");
+        when(playerService.getPlayersForUserAndClientId(any(), any())).thenReturn(List.of(new Player()));
+        when(playerService.getPlayer(any(), any(), anyString())).thenReturn(new Player());
+        when(mediaFolderService.getMusicFoldersForUser(anyString())).thenReturn(List.of());
+        when(mediaFolderService.getMusicFoldersForUser(anyString(), any())).thenReturn(List.of());
+        when(jaxbWriter.createResponse(anyBoolean())).thenReturn(new Response());
+        when(searchService.search(any(SearchCriteria.class), any(), any())).thenAnswer(invocation -> {
+            SearchCriteria c = invocation.getArgument(0);
+            searchArgs.add(new int[] {c.getCount(), c.getOffset()});
+            return new SearchResult();
+        });
+    }
+
+    private MockHttpServletRequest req() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteUser("alice");
+        request.setParameter("c", "test");
+        return request;
+    }
+
+    @Test
+    void search_clampsAbusiveCountAndOffset() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("count", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("offset", String.valueOf(Integer.MAX_VALUE));
+
+        controller.search(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs).hasSize(1);
+        assertThat(searchArgs.get(0)[0]).isEqualTo(500);   // count clamped
+        assertThat(searchArgs.get(0)[1]).isEqualTo(500);   // offset clamped
+    }
+
+    @Test
+    void search2_clampsAllThreeCountParams() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("artistCount", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("albumCount", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("songCount", String.valueOf(Integer.MAX_VALUE));
+
+        controller.search2(request, new MockHttpServletResponse());
+
+        // artist, album, song — each clamped to 500.
+        assertThat(searchArgs).hasSize(3);
+        assertThat(searchArgs).allSatisfy(a -> assertThat(a[0]).isEqualTo(500));
+    }
+
+    @Test
+    void search3_clampsAllThreeCountParams() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("artistCount", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("albumCount", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("songCount", String.valueOf(Integer.MAX_VALUE));
+
+        controller.search3(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs).hasSize(3);
+        assertThat(searchArgs).allSatisfy(a -> assertThat(a[0]).isEqualTo(500));
+    }
+
+    @Test
+    void search_clampsAbusiveOffsetEvenWithSmallCount() throws Exception {
+        // The offset is added to count at the allocation point; an abusive offset alone (which
+        // would overflow offset+count to a negative) is independently clamped.
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("count", "20");
+        request.setParameter("offset", String.valueOf(Integer.MAX_VALUE));
+
+        controller.search(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs.get(0)[0]).isEqualTo(20);
+        assertThat(searchArgs.get(0)[1]).isEqualTo(500);
+    }
+
+    @Test
+    void search_negativeCountAndOffsetClampedToZero() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("count", "-5");
+        request.setParameter("offset", "-100");
+
+        controller.search(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs.get(0)[0]).isEqualTo(0);
+        assertThat(searchArgs.get(0)[1]).isEqualTo(0);
+    }
+
+    @Test
+    void search_legitimateCountPassesThroughUnchanged() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("count", "100");
+        request.setParameter("offset", "40");
+
+        controller.search(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs.get(0)[0]).isEqualTo(100);
+        assertThat(searchArgs.get(0)[1]).isEqualTo(40);
+    }
+
+    @Test
+    void clamp_helperBoundsToZeroAndMaxCount() {
+        // Direct seam: the load-bearing arithmetic, including the negative floor and the ceiling
+        // that bounds offset+count (and removes the offset+count integer-overflow path).
+        assertThat(SubsonicSearchController.clamp(Integer.MAX_VALUE)).isEqualTo(500);
+        assertThat(SubsonicSearchController.clamp(501)).isEqualTo(500);
+        assertThat(SubsonicSearchController.clamp(500)).isEqualTo(500);
+        assertThat(SubsonicSearchController.clamp(100)).isEqualTo(100);
+        assertThat(SubsonicSearchController.clamp(0)).isEqualTo(0);
+        assertThat(SubsonicSearchController.clamp(-1)).isEqualTo(0);
+        assertThat(SubsonicSearchController.clamp(Integer.MIN_VALUE)).isEqualTo(0);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
@@ -6,7 +6,12 @@ import org.airsonic.player.domain.MusicFolder.Type;
 import org.airsonic.player.domain.RandomSearchCriteria;
 import org.airsonic.player.domain.SearchCriteria;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test case for QueryFactory.
@@ -273,6 +279,64 @@ public class QueryFactoryTestCase {
                 "(folderId:" + FID1 + " folderId:"
                         + FID2 + ")",
                 query.toString(), MULTI_FOLDERS.stream().map(f -> f.toString()).collect(Collectors.joining(",")));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // #178 structural-defense contract lock (rider on #262). QueryFactory builds queries
+    // structurally (BooleanQuery / BoostQuery / TermQuery / WildcardQuery) — there is no
+    // QueryParser, so Lucene query-syntax operators in user input are NOT interpreted. These
+    // tests feed the exact adversarial inputs #178 was about (+folder:1, *, field:value) and
+    // assert the produced query is composed ONLY of those structural types. A contributor
+    // re-introducing QueryParser (reopening #178) would produce a different node type and fail.
+    // ---------------------------------------------------------------------------------------
+
+    private static final List<Class<? extends Query>> ALLOWED_QUERY_TYPES = List.of(
+            BooleanQuery.class, BoostQuery.class, TermQuery.class, WildcardQuery.class);
+
+    private void assertOnlyStructuralTypes(Query query) {
+        assertTrue(ALLOWED_QUERY_TYPES.contains(query.getClass()),
+                "unexpected (non-structural) query node — possible QueryParser reintroduction: "
+                        + query.getClass().getName() + " => " + query);
+        if (query instanceof BooleanQuery bq) {
+            for (BooleanClause clause : bq.clauses()) {
+                assertOnlyStructuralTypes(clause.query());
+            }
+        } else if (query instanceof BoostQuery boost) {
+            assertOnlyStructuralTypes(boost.getQuery());
+        }
+    }
+
+    private SearchCriteria criteria(String query) {
+        SearchCriteria c = new SearchCriteria();
+        c.setOffset(0);
+        c.setCount(20);
+        c.setQuery(query);
+        return c;
+    }
+
+    @Test
+    public void testSearchStructuralForAdversarialInput() throws IOException {
+        for (String adversarial : List.of("+folder:1", "*", "field:value")) {
+            for (IndexType type : List.of(IndexType.ARTIST, IndexType.ALBUM, IndexType.SONG)) {
+                Query query = queryFactory.search(criteria(adversarial), SINGLE_FOLDERS, type);
+                assertOnlyStructuralTypes(query);
+            }
+        }
+    }
+
+    @Test
+    public void testSearchByNameStructuralForAdversarialInput() throws IOException {
+        for (String adversarial : List.of("+folder:1", "*", "field:value")) {
+            assertOnlyStructuralTypes(queryFactory.searchByName(FieldNames.ARTIST, adversarial));
+        }
+    }
+
+    @Test
+    public void testGetRandomSongsStructuralForAdversarialGenre() throws IOException {
+        for (String adversarial : List.of("+folder:1", "*", "field:value")) {
+            RandomSearchCriteria rc = new RandomSearchCriteria(20, adversarial, null, null, SINGLE_FOLDERS);
+            assertOnlyStructuralTypes(queryFactory.getRandomSongs(rc));
+        }
     }
 
 }


### PR DESCRIPTION
Surfaced during #178 (Lucene-injection triage).

## The OOM mechanism

`SubsonicSearchController` read `count` / `songCount` / `albumCount` / `artistCount` and the `*Offset` params with no upper bound. They reach `SearchServiceImpl.search` as `searcher.search(query, offset + count)`, where Lucene pre-allocates a `TopDocs` collector sized to `offset + count` **before collecting any document**. An authenticated USER-role client passing `songCount=2147483647` could exhaust JVM heap — an authenticated DoS.

## Bonus fix — integer overflow

An abusive offset (e.g. `Integer.MAX_VALUE`) made `offset + count` wrap to a negative, which Lucene rejects with `IllegalArgumentException`. Clamping both operands before the addition closes this path too.

## The clamp

New `MAX_COUNT = 500` + `clamp(v) = Math.max(0, Math.min(MAX_COUNT, v))`, applied to every count AND offset read across `/search`, `/search2`, `/search3` (12 sites). Bounding both to `[0, 500]` caps `offset + count ≤ 1000` at the allocation point.

The `500` value **matches the existing `getAlbumList` / `getAlbumList2` size ceiling** already in this codebase — keeping the Subsonic surface consistent — and is comfortably above any legitimate client search request (clients page 20–100) while a 500-entry `TopDocs` is trivial (~16KB).

Silent clamp (per the issue): a client requesting more simply receives 500 results, no 4xx. `totalHits` still reflects the true corpus size, so clients can detect truncation. Negative values are floored to 0.

## Rider — #178 structural-defense contract lock

`QueryFactory` builds queries structurally (`BooleanQuery` / `BoostQuery` / `TermQuery` / `WildcardQuery`) with no `QueryParser`, so Lucene query-syntax operators in user input are never interpreted. The existing tests locked this for **benign** inputs only; this PR adds 3 tests asserting that the exact adversarial inputs #178 was about (`+folder:1`, `*`, `field:value`) produce a query composed only of those structural node types. A contributor re-introducing `QueryParser` (reopening #178) would produce a different node type and fail loudly.

## Verification

Security-audited: clamp bounds `offset+count` at the allocation point with no bypass, the overflow path is closed, and 500 is defensible — all three confirmed. HSQLDB full suite 1192/0/0. 10 new tests; floor 1182 → 1192. No schema change; pr_ci covers the matrix.

fixes #262