### PR TITLE
fix: correct CUE multifile FILE-block mapping and fractional frame offsets (#211)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -51,6 +51,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.digitalmediaserver.cuelib.CueParser;
 import org.digitalmediaserver.cuelib.CueSheet;
+import org.digitalmediaserver.cuelib.FileData;
 import org.digitalmediaserver.cuelib.Position;
 import org.digitalmediaserver.cuelib.TrackData;
 import org.digitalmediaserver.cuelib.io.FLACReader;
@@ -821,28 +822,37 @@ public class MediaFileService {
 
         // cue tracks
         if (isEnableCueIndexing) {
-            List<MediaFile> indexedTracks = cueSheets.entrySet().parallelStream().flatMap(e -> {
+            // Sequential outer stream: each FILE block mutates shared scan state (bareFiles.remove,
+            // storedChildrenMap) without synchronization, so iterating cue sheets in parallel was a
+            // latent data race. A directory holds few cue sheets, so sequential costs nothing.
+            List<MediaFile> indexedTracks = cueSheets.entrySet().stream().flatMap(e -> {
                 String indexPath = e.getKey();
                 CueSheet cueSheet = e.getValue();
 
-                String filePath = cueSheet.getFileData().get(0).getFile();
-                MediaFile base = bareFiles.remove(FilenameUtils.getName(filePath));
+                // One FILE block per audio file: resolve each block to its own base media file and
+                // materialise that block's tracks against it (multifile CUE support).
+                return cueSheet.getFileData().stream().flatMap(fileData -> {
+                    String filePath = fileData.getFile();
+                    MediaFile base = bareFiles.remove(FilenameUtils.getName(filePath));
 
-                if (Objects.nonNull(base)) {
-                    base.setIndexPath(indexPath); // update indexPath in mediaFile
-                    Instant mediaChanged = FileUtil.lastModified(base.getFullPath());
-                    Instant cueChanged = FileUtil.lastModified(base.getFullIndexPath());
-                    base.setChanged(mediaChanged.compareTo(cueChanged) >= 0 ? mediaChanged : cueChanged);
-                    updateMediaFile(base);
-                    List<MediaFile> tracks = createIndexedTracks(base, cueSheet);
-                    // remove stored children that are now indexed
-                    tracks.forEach(t -> storedChildrenMap.remove(Pair.of(t.getPath(), t.getStartPosition())));
-                    tracks.add(base);
-                    return tracks.stream();
-                } else {
-                    LOG.warn("Could not find base file '{}' for cue sheet {}", filePath, indexPath);
-                    return Stream.empty();
-                }
+                    if (Objects.nonNull(base)) {
+                        base.setIndexPath(indexPath); // update indexPath in mediaFile
+                        Instant mediaChanged = FileUtil.lastModified(base.getFullPath());
+                        Instant cueChanged = FileUtil.lastModified(base.getFullIndexPath());
+                        base.setChanged(mediaChanged.compareTo(cueChanged) >= 0 ? mediaChanged : cueChanged);
+                        updateMediaFile(base);
+                        List<MediaFile> tracks = createIndexedTracks(base, cueSheet, fileData);
+                        // remove stored children that are now indexed
+                        tracks.forEach(t -> storedChildrenMap.remove(Pair.of(t.getPath(), t.getStartPosition())));
+                        tracks.add(base);
+                        return tracks.stream();
+                    } else {
+                        // A missing/unresolvable FILE block is skipped without aborting the scan; the
+                        // remaining blocks and cue sheets still materialise.
+                        LOG.warn("Could not find base file '{}' for cue sheet {}", filePath, indexPath);
+                        return Stream.<MediaFile>empty();
+                    }
+                });
             }).toList();
             result.addAll(indexedTracks);
         }
@@ -1194,6 +1204,10 @@ public class MediaFileService {
 
     @Nonnull
     private List<MediaFile> createIndexedTracks(@Nonnull MediaFile base, @Nullable CueSheet cueSheet) {
+        return createIndexedTracks(base, cueSheet, getFileDataForBase(base, cueSheet));
+    }
+
+    private List<MediaFile> createIndexedTracks(@Nonnull MediaFile base, @Nullable CueSheet cueSheet, @Nullable FileData fileData) {
 
         Map<Pair<String, Double>, MediaFile> storedChildrenMap = mediaFileRepository.findByFolderAndPath(base.getFolder(), base.getPath()).parallelStream()
             .filter(MediaFile::isIndexedTrack).collect(Collectors.toConcurrentMap(i -> Pair.of(i.getPath(), i.getStartPosition()), i -> i));
@@ -1201,7 +1215,7 @@ public class MediaFileService {
         List<MediaFile> children = new ArrayList<>();
 
         try {
-            if (Objects.isNull(cueSheet)) {
+            if (Objects.isNull(cueSheet) || Objects.isNull(fileData)) {
                 base.setIndexPath(null);
                 updateMediaFile(base);
                 return children;
@@ -1220,12 +1234,13 @@ public class MediaFileService {
             Instant childrenLastUpdated = Instant.now().plusSeconds(100 * 365 * 24 * 60 * 60); // now + 100 years, tracks do not have children
             MusicFolder baseFolder = base.getFolder();
 
-            boolean update = needsUpdate(base, settingsService.isFastCacheEnabled());
-            int trackSize = cueSheet.getAllTrackData().size();
+            // Only this FILE block's tracks materialise against this base media file.
+            List<TrackData> cueTracks = fileData.getTrackData();
+            int trackSize = cueTracks.size();
 
             if (trackSize > 0) {
-                TrackData lastTrackData = cueSheet.getAllTrackData().get(trackSize - 1);
-                double lastTrackStart = lastTrackData.getIndices().get(0).getPosition().getMinutes() * 60 + lastTrackData.getIndices().get(0).getPosition().getSeconds() + (lastTrackData.getIndices().get(0).getPosition().getFrames() / 75);
+                TrackData lastTrackData = cueTracks.get(trackSize - 1);
+                double lastTrackStart = getStartPosition(lastTrackData);
                 if (lastTrackStart >= wholeFileLength) {
                     base.setIndexPath(null);
                     updateMediaFile(base);
@@ -1234,67 +1249,55 @@ public class MediaFileService {
             }
 
             for (int i = 0; i < trackSize; i++) {
-                TrackData trackData = cueSheet.getAllTrackData().get(i);
-                Position currentPosition = trackData.getIndices().get(0).getPosition();
-                // convert CUE timestamp (minutes:seconds:frames, 75 frames/second) to fractional seconds
-                double currentStart = currentPosition.getMinutes() * 60 + currentPosition.getSeconds() + (currentPosition.getFrames() / 75);
-                double nextStart = 0.0;
-                if (cueSheet.getAllTrackData().size() - 1 != i) {
-                    Position nextPosition = cueSheet.getAllTrackData().get(i + 1).getIndices().get(0).getPosition();
-                    nextStart = nextPosition.getMinutes() * 60 + nextPosition.getSeconds() + (nextPosition.getFrames() / 75);
-                } else {
-                    nextStart = wholeFileLength;
-                }
+                TrackData trackData = cueTracks.get(i);
+                double currentStart = getStartPosition(trackData);
+                // duration runs to the next track in THIS block; the last track runs to the file end
+                double nextStart = (trackSize - 1 != i) ? getStartPosition(cueTracks.get(i + 1)) : wholeFileLength;
 
                 double duration = nextStart - currentStart;
 
+                // Refresh the existing indexed track in place (title/artist/track number/duration may
+                // have changed) while preserving playCount/lastPlayed/comment; create a fresh row when
+                // none exists for this start position.
                 MediaFile existingFile = storedChildrenMap.remove(Pair.of(basePath, currentStart));
-                // check whether track has same duration, cue file may have been edited to split tracks
-                if ((existingFile != null) && (existingFile.getDuration() != duration)) {
-                    storedChildrenMap.put(Pair.of(basePath, currentStart), existingFile);
-                    existingFile = null;
+                MediaFile track = (existingFile != null) ? existingFile : new MediaFile();
+                track.setPath(basePath);
+                track.setAlbumArtist(performer);
+                track.setAlbumName(albumName);
+                track.setTitle(trackData.getTitle());
+                track.setArtist(trackData.getPerformer());
+                track.setParentPath(parentPath);
+                track.setFolder(baseFolder);
+                track.setChanged(lastModified);
+                track.setLastScanned(Instant.now());
+                track.setChildrenLastUpdated(childrenLastUpdated);
+                track.setCreated(lastModified);
+                track.setPresent(true);
+                track.setTrackNumber(trackData.getNumber());
+                track.setDiscNumber(base.getDiscNumber());
+                track.setGenre(base.getGenre());
+                track.setYear(base.getYear());
+                track.setBitRate(base.getBitRate());
+                track.setVariableBitRate(base.isVariableBitRate());
+                track.setHeight(base.getHeight());
+                track.setWidth(base.getWidth());
+                track.setFormat(base.getFormat());
+                track.setStartPosition(currentStart);
+                track.setDuration(duration);
+                // estimate file size based on duration and whole file size
+                long estimatedSize = (long) (duration / wholeFileLength * wholeFileSize);
+                // if estimated size is within of whole file size, use it. Otherwise use whole file size divided by number of tracks
+                if (estimatedSize > 0 && estimatedSize <= wholeFileSize) {
+                    track.setFileSize(estimatedSize);
+                } else {
+                    track.setFileSize((long)(wholeFileSize / trackSize));
                 }
-                MediaFile track = existingFile;
-                if (update || (existingFile == null)) {
-                    track = (existingFile != null) ? existingFile : new MediaFile();
-                    track.setPath(basePath);
-                    track.setAlbumArtist(performer);
-                    track.setAlbumName(albumName);
-                    track.setTitle(trackData.getTitle());
-                    track.setArtist(trackData.getPerformer());
-                    track.setParentPath(parentPath);
-                    track.setFolder(baseFolder);
-                    track.setChanged(lastModified);
-                    track.setLastScanned(Instant.now());
-                    track.setChildrenLastUpdated(childrenLastUpdated);
-                    track.setCreated(lastModified);
-                    track.setPresent(true);
-                    track.setTrackNumber(trackData.getNumber());
-                    track.setDiscNumber(base.getDiscNumber());
-                    track.setGenre(base.getGenre());
-                    track.setYear(base.getYear());
-                    track.setBitRate(base.getBitRate());
-                    track.setVariableBitRate(base.isVariableBitRate());
-                    track.setHeight(base.getHeight());
-                    track.setWidth(base.getWidth());
-                    track.setFormat(base.getFormat());
-                    track.setStartPosition(currentStart);
-                    track.setDuration(duration);
-                    // estimate file size based on duration and whole file size
-                    long estimatedSize = (long) (duration / wholeFileLength * wholeFileSize);
-                    // if estimated size is within of whole file size, use it. Otherwise use whole file size divided by number of tracks
-                    if (estimatedSize > 0 && estimatedSize <= wholeFileSize) {
-                        track.setFileSize(estimatedSize);
-                    } else {
-                        track.setFileSize((long)(wholeFileSize / trackSize));
-                    }
-                    track.setPlayCount((existingFile == null) ? 0 : existingFile.getPlayCount());
-                    track.setLastPlayed((existingFile == null) ? null : existingFile.getLastPlayed());
-                    track.setComment((existingFile == null) ? null : existingFile.getComment());
-                    track.setMediaType(mediaType);
+                track.setPlayCount((existingFile == null) ? 0 : existingFile.getPlayCount());
+                track.setLastPlayed((existingFile == null) ? null : existingFile.getLastPlayed());
+                track.setComment((existingFile == null) ? null : existingFile.getComment());
+                track.setMediaType(mediaType);
 
-                    updateMediaFile(track);
-                }
+                updateMediaFile(track);
 
                 children.add(track);
             }
@@ -1313,6 +1316,33 @@ public class MediaFileService {
     private List<MediaFile> createIndexedTracks(MediaFile base) {
         CueSheet cueSheet = getCueSheet(base);
         return createIndexedTracks(base, cueSheet);
+    }
+
+    /**
+     * Selects the FILE block that owns the given base media file (single-file path / 2-arg overload):
+     * the block whose FILE name matches the base file name, falling back to the first block. Returns
+     * null only when the cue sheet is null or has no FILE blocks.
+     */
+    @Nullable
+    private FileData getFileDataForBase(@Nonnull MediaFile base, @Nullable CueSheet cueSheet) {
+        if (Objects.isNull(cueSheet) || cueSheet.getFileData().isEmpty()) {
+            return null;
+        }
+        String baseFileName = FilenameUtils.getName(base.getPath());
+        return cueSheet.getFileData().stream()
+            .filter(fileData -> FilenameUtils.getName(fileData.getFile()).equals(baseFileName))
+            .findFirst()
+            .orElseGet(() -> cueSheet.getFileData().get(0));
+    }
+
+    /**
+     * Converts a track's first INDEX position to fractional seconds. CUE timestamps are
+     * minutes:seconds:frames at 75 frames/second; dividing frames by 75.0 (not int 75) preserves the
+     * sub-second component that would otherwise truncate to zero.
+     */
+    private double getStartPosition(TrackData trackData) {
+        Position position = trackData.getIndices().get(0).getPosition();
+        return position.getMinutes() * 60 + position.getSeconds() + (position.getFrames() / 75.0);
     }
 
     private MediaFile.MediaType getMediaType(MediaFile mediaFile) {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -22,8 +22,14 @@ import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MediaFile.MediaType;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.repository.MediaFileRepository;
+import org.airsonic.player.repository.MusicFileInfoRepository;
 import org.airsonic.player.service.cache.MediaFileCache;
 import org.airsonic.player.service.metadata.MetaDataParserFactory;
+import org.digitalmediaserver.cuelib.CueSheet;
+import org.digitalmediaserver.cuelib.FileData;
+import org.digitalmediaserver.cuelib.Index;
+import org.digitalmediaserver.cuelib.Position;
+import org.digitalmediaserver.cuelib.TrackData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +40,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,6 +68,8 @@ public class MediaFileServiceTest {
     private MediaFolderService mediaFolderService;
     @Mock
     private SettingsService settingsService;
+    @Mock
+    private MusicFileInfoRepository musicFileInfoRepository;
 
     @InjectMocks
     private MediaFileService mediaFileService;
@@ -102,6 +112,210 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // CUE indexed-track materialisation (#211): multifile FILE-block mapping + fractional frame
+    // offsets. Tests build the CueSheet in memory; base resolves to the real MEDIAS/piano.mp3 so
+    // Files.size succeeds.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void createIndexedTracksUsesOnlyTracksFromMatchingCueFileData() {
+        // Two FILE blocks; base is piano.mp3, so only that block's tracks materialise (defect #1).
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData otherFileData = new FileData(cueSheet, "airsonic-test.wav", "WAVE");
+        otherFileData.getTrackData().add(createTrack(otherFileData, 1, "Wrong File Track", 0, 0, 0));
+        cueSheet.getFileData().add(otherFileData);
+
+        FileData matchingFileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        matchingFileData.getTrackData().add(createTrack(matchingFileData, 2, "Matching Track 1", 0, 0, 0));
+        matchingFileData.getTrackData().add(createTrack(matchingFileData, 3, "Matching Track 2", 0, 10, 37));
+        cueSheet.getFileData().add(matchingFileData);
+
+        MediaFile base = cueBase();
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(2, actual.size());
+        assertEquals("Matching Track 1", actual.get(0).getTitle());
+        assertEquals("Matching Track 2", actual.get(1).getTitle());
+        assertEquals("piano.mp3", actual.get(0).getPath());
+        assertEquals("piano.mp3", actual.get(1).getPath());
+        // 0:10:37 -> 10 + 37/75.0 = 10.493 (defect #2: the fraction survives, not truncated to 10)
+        assertEquals(0.0d, actual.get(0).getStartPosition(), 0.0d);
+        assertEquals(10.493d, actual.get(1).getStartPosition(), 0.001d);
+        assertEquals(10.493d, actual.get(0).getDuration(), 0.001d);
+        // last track in the block runs to the file length (30.0), not the other block's track
+        assertEquals(19.506d, actual.get(1).getDuration(), 0.001d);
+    }
+
+    @Test
+    public void createIndexedTracksRefreshesExistingCueTrackMetadataPreservingPlayCount() {
+        // An existing indexed track is refreshed in place (title/trackNumber/duration) while
+        // playCount/lastPlayed/comment are preserved.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 2, "Fresh Title", 0, 0, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+
+        MediaFile staleTrack = new MediaFile();
+        staleTrack.setId(42);
+        staleTrack.setPath("piano.mp3");
+        staleTrack.setFolder(mockedFolder);
+        staleTrack.setStartPosition(0.0);
+        staleTrack.setDuration(10.0);
+        staleTrack.setTitle("Stale Title");
+        staleTrack.setTrackNumber(5);
+        staleTrack.setPlayCount(7);
+        staleTrack.setLastPlayed(Instant.ofEpochSecond(1000));
+        staleTrack.setComment("keep me");
+
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of(staleTrack));
+        when(mediaFileRepository.existsById(eq(42))).thenReturn(true);
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(1, actual.size());
+        assertEquals("Fresh Title", actual.get(0).getTitle());
+        assertEquals(2L, (long) actual.get(0).getTrackNumber());
+        assertEquals(30.0d, actual.get(0).getDuration(), 0.001d);
+        // preserved across the in-place refresh
+        assertEquals(7, actual.get(0).getPlayCount());
+        assertEquals(Instant.ofEpochSecond(1000), actual.get(0).getLastPlayed());
+        assertEquals("keep me", actual.get(0).getComment());
+        // refreshed in place: same row instance is saved, no new row created
+        verify(mediaFileRepository).save(staleTrack);
+    }
+
+    @Test
+    public void createIndexedTracksSingleFileCarriesSubSecondStartPosition() {
+        // Defect #2 direct test on the single-file (common) path: a track at 1:23:34 keeps its
+        // sub-second component (.453) rather than truncating to 83.0.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 1, "Only Track", 1, 23, 34));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        base.setDuration(200.0);
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(1, actual.size());
+        // 60 + 23 + 34/75.0 = 83.453 — proves the fraction is not truncated
+        assertEquals(83.453d, actual.get(0).getStartPosition(), 0.001d);
+    }
+
+    @Test
+    public void createIndexedTracksLastTrackInSingleTrackBlockUsesFileLength() {
+        // A block with a single track: its duration runs to the file length, not to any other block.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 1, "Sole Track", 0, 5, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(1, actual.size());
+        assertEquals(5.0d, actual.get(0).getStartPosition(), 0.0d);
+        // file length (30.0) - start (5.0) = 25.0
+        assertEquals(25.0d, actual.get(0).getDuration(), 0.001d);
+    }
+
+    @Test
+    public void createIndexedTracksSingleFileTwoTracksMapAgainstBaseUnchanged() {
+        // Single-file regression anchor: a single-FILE two-track sheet maps both tracks against the
+        // one base with the expected start/duration boundaries (single-file is the n=1 case).
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 1, "Track One", 0, 0, 0));
+        fileData.getTrackData().add(createTrack(fileData, 2, "Track Two", 0, 12, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(2, actual.size());
+        assertEquals(0.0d, actual.get(0).getStartPosition(), 0.0d);
+        assertEquals(12.0d, actual.get(0).getDuration(), 0.001d);
+        assertEquals(12.0d, actual.get(1).getStartPosition(), 0.0d);
+        assertEquals(18.0d, actual.get(1).getDuration(), 0.001d);
+    }
+
+    @Test
+    public void createIndexedTracksMissingIndexDoesNotAbortScan() {
+        // Defensive: a track with no INDEX (empty indices) is materialisation-reachable via
+        // getIndices().get(0); the block returns empty without propagating an exception, so other
+        // blocks and the wider scan continue.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        // a TrackData with no Index added
+        fileData.getTrackData().add(new TrackData(fileData, 1, "AUDIO"));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertTrue(actual.isEmpty());
+    }
+
+    private MediaFile cueBase() {
+        MediaFile base = new MediaFile();
+        base.setIndexPath("cue/airsonic-test.cue");
+        base.setPath("piano.mp3");
+        base.setMediaType(MediaType.MUSIC);
+        base.setFormat("mp3");
+        base.setDuration(30.0);
+        base.setFolder(mockedFolder);
+        base.setChanged(Instant.now());
+        base.setLastScanned(Instant.now());
+        base.setCreated(Instant.now());
+        return base;
+    }
+
+    private TrackData createTrack(FileData fileData, int number, String title, int minutes, int seconds, int frames) {
+        TrackData trackData = new TrackData(fileData, number, "AUDIO");
+        trackData.setTitle(title);
+        trackData.getIndices().add(new Index(1, new Position(minutes, seconds, frames)));
+        return trackData;
     }
 
     @Test

--- a/docs/release-notes/v13.2.0.md
+++ b/docs/release-notes/v13.2.0.md
@@ -65,6 +65,11 @@ The server now emits a single throttled WARN to the operator log the first time 
   Batch 1 carries `subRole` end-to-end without an encoding change. ID3v2.3 IPLS combined
   musician+people credits and MP4 freeform performer atoms are not extracted in this batch.
   Filled by the same #135 rescan — no separate rescan needed.
+* #211 corrects CUE indexed-track start positions to carry their sub-second (frame) component.
+  Existing CUE tracks were stored with start positions truncated to whole seconds; the next
+  rescan re-materialises them at the corrected fractional offsets. This re-keys each CUE track
+  once (old `N.0` rows are replaced by `N.frac` rows) — `playCount`, `lastPlayed`, and comments
+  are preserved across the refresh. One-time, automatic on rescan; no action required.
 
 ## OpenSubsonic
 
@@ -86,3 +91,17 @@ The server now emits a single throttled WARN to the operator log the first time 
 ## Performance / internal
 
 * #228 caches `artistService.getArtist(String name)` behind a dedicated `ArtistByNameCache` (new JSR-107 / EhCache entry `artistByNameCache`, 10000 on-heap, 24h TTL). Misses are stored as `Optional.empty` so uncatalogued contributor names (composer/lyricist/producer credits that don't match an Airsonic Artist row) short-circuit on the second lookup. The cache is disabled during a media scan and cleared + re-enabled in the scan-finally block (same toggle pattern as `MediaFileCache`), and cleared after admin expunge — so reads during scan bypass the cache, and the next post-scan lookup repopulates from fresh DB state. Removes the per-contributor-per-song N+1 risk on `getStarred2`, `getRandomSongs`, `getMusicDirectory`, `getPlaylist`, and search, ahead of #144 Batch 2 amplifying contributor counts via TMCL performer credits.
+
+## Bug fixes
+
+* #211 fixes two defects in CUE indexed-track materialisation. **Multifile CUE sheets** (one
+  audio file per `FILE` block) previously attached every track to the first file with positions
+  and durations computed against it; each `FILE` block is now resolved to its own base media file
+  and its tracks materialise against that file, with the last track in a block running to that
+  file's length. **CUE frame offsets** were truncated to whole seconds (`frames / 75` integer
+  division always yielded 0), so every indexed track — single-file CUEs included — started up to
+  ~1 second early; start positions now carry their fractional-second component (`frames / 75.0`).
+  Stale indexed-track metadata (title, artist, track number, duration) is refreshed in place on
+  rescan while `playCount`, `lastPlayed`, and comments are preserved. Stays on the current cuelib
+  parser (the parser replacement in #202 is separate); adapted from upstream
+  kagemomiji/airsonic-advanced PR #824.


### PR DESCRIPTION
Two defects in CUE indexed-track materialisation (`MediaFileService.updateChildren` → `createIndexedTracks`), adapted from upstream kagemomiji/airsonic-advanced PR #824.

## Defect #1 — multifile FILE blocks attached to the first file

`updateChildren` took `cueSheet.getFileData().get(0)` and `createIndexedTracks` iterated `cueSheet.getAllTrackData()` across the whole sheet, so every track of a multi-FILE CUE (one audio file per track) attached to the first file, with positions/durations computed against it — track-to-file mapping and durations wrong from the second block on.

**Fix:** `updateChildren` flat-maps over every `FileData` block, each block resolves its own base media file, and a new 3-arg `createIndexedTracks(base, cueSheet, fileData)` iterates that block's `getTrackData()` with duration relative to the next track in the **same** block (last track uses that file's length). Unresolvable FILE → `LOG.warn` + skip (scan continues, no crash).

## Defect #2 — frame offset truncated to whole seconds (universal)

Start positions were computed with `position.getFrames() / 75` on int operands. Frames are always 0–74, so the result was always 0 — the sub-second component dropped on **every** CUE track, single-file included, starting each indexed track up to ~1s early. This was the more commonly hit defect.

**Fix:** a `getStartPosition(TrackData)` helper using `frames / 75.0`, replacing all three truncation sites. Full path traced: helper returns `double` → `setStartPosition(Double)` → `MediaFile.startPosition` `Double` column, no downstream re-truncation; the `storedChildrenMap` key is `Pair<String, Double>` so the fraction survives lookup too.

## Single-file non-regression

Single-file is the n=1 case of the same path (`getFileDataForBase` matches the one block; `getTrackData()` equals `getAllTrackData()`), so single-file materialisation is byte-for-byte unchanged except the two intended deltas. The existing fresh-scan anchors (`testMusicCue`, `testMusicCueWithBOM`, `WithDisableCueIndexing`) pass unchanged. The backward-compatible 2-arg `createIndexedTracks` is preserved via `getFileDataForBase` (filename-match → block, fallback first block).

## Metadata refresh preserving playCount

Dropped the update guard and the duration-mismatch discard (which lost `playCount` whenever a track's duration changed). The existing row is now refreshed in place (title, artist, track number, duration) while `playCount`, `lastPlayed`, and `comment` are preserved from the existing row.

## Concurrency — latent race fix

The outer cue loop is switched `parallelStream()` → `stream()`. This is a correctness fix, not just a port: the loop body mutates shared scan state (`bareFiles.remove`, `storedChildrenMap.remove`) and issues per-block DB writes, so parallel iteration over blocks made the interleaving nondeterministic — a latent race with no benefit (a directory holds few sheets).

## Scope

Stays on the current cuelib parser — the parser replacement is the separate #202. Declined from upstream #824: the `getCueSheet` warning→Error gating (a parser-acceptance change, out of scope) and the verbose debug logs.

## Rescan note

Existing CUE tracks re-key from `N.0` to `N.frac` on the first rescan after this fix (`playCount`/`lastPlayed`/`comment` preserved) — a benign one-time re-materialisation. Documented in the 13.2.0 release notes.

## Verification

- HSQLDB full suite: 1198/0/0
- Local Postgres 16: 1198, 0 failures, 1 error (the unrelated pre-existing `TranscodingServiceIntTest` lazy-init flake); indexed-track persistence identical to HSQLDB
- analyze clean, WAR confirms `getStartPosition` + `getFileDataForBase` packaged
- code-reviewer: all seven blast-radius points confirmed, single-file path unchanged

Tests: +6 (multifile-matching, refresh-preserving-playCount ported; single-file fractional start, single-track-block uses file length, single-file two-track anchor, missing-INDEX-doesn't-abort). Floor 1192 → 1198.

fixes #211