### PR TITLE
fix: advertise getPodcastEpisode in getOpenSubsonicExtensions (#294)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -66,7 +66,8 @@ public class SubsonicRESTController extends AbstractSubsonicController {
             buildExtension("transcodeOffset", 1),
             buildExtension("songLyrics", 1),
             buildExtension("indexBasedQueue", 1),
-            buildExtension("apiKeyAuthentication", 1)
+            buildExtension("apiKeyAuthentication", 1),
+            buildExtension("getPodcastEpisode", 1)
         );
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/api/OpenSubsonicExtensionsApiTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/OpenSubsonicExtensionsApiTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.MediaType;
 
 import jakarta.transaction.Transactional;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -65,6 +66,42 @@ public class OpenSubsonicExtensionsApiTest extends AbstractRESTTest {
             .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
             .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[*].name").value(hasItem("indexBasedQueue")))
             .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[?(@.name=='indexBasedQueue')].versions[0]").value(hasItem(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getOpenSubsonicExtensions", "/rest/getOpenSubsonicExtensions.view"})
+    void getOpenSubsonicExtensions_returnsGetPodcastEpisodeExtension(String endpoint) throws Exception {
+        mvc.perform(get(endpoint)
+            .param("v", AIRSONIC_API_VERSION)
+            .param("c", CLIENT_NAME)
+            .param("u", AIRSONIC_USER)
+            .param("p", AIRSONIC_PASSWORD)
+            .param("f", EXPECTED_FORMAT)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+            .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[*].name").value(hasItem("getPodcastEpisode")))
+            .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[?(@.name=='getPodcastEpisode')].versions[0]").value(hasItem(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getOpenSubsonicExtensions", "/rest/getOpenSubsonicExtensions.view"})
+    void getOpenSubsonicExtensions_advertisesExactlyTheExpectedSet(String endpoint) throws Exception {
+        // Asserts the COMPLETE advertised set, not a per-extension subset. The pre-existing
+        // hasItem(...) tests pass whenever a named extension is present and so never catch a
+        // *missing* one — which is why getPodcastEpisode shipped (#133) unadvertised until #294.
+        // This assertion fails if any extension is added or dropped without updating the test.
+        mvc.perform(get(endpoint)
+            .param("v", AIRSONIC_API_VERSION)
+            .param("c", CLIENT_NAME)
+            .param("u", AIRSONIC_USER)
+            .param("p", AIRSONIC_PASSWORD)
+            .param("f", EXPECTED_FORMAT)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.openSubsonicExtensions.openSubsonicExtension[*].name")
+                .value(containsInAnyOrder("formPost", "transcodeOffset", "songLyrics",
+                    "indexBasedQueue", "apiKeyAuthentication", "getPodcastEpisode")));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
`getPodcastEpisode` shipped in #133 (a real mapped endpoint in `SubsonicPodcastController`) but `getOpenSubsonicExtensions` never advertised it. OpenSubsonic clients discover capabilities via the extensions endpoint and gracefully degrade for anything not listed — so a working endpoint that isn't advertised is invisible to clients, who won't call it. Surfaced by the #35 close-readiness audit.

## Fix

One line adding `buildExtension("getPodcastEpisode", 1)` to the advertised list, mirroring the existing entries (`formPost`, `transcodeOffset`, `songLyrics`, `indexBasedQueue`, `apiKeyAuthentication`). The key and version were verified verbatim against the OpenSubsonic spec (case-sensitive). The endpoint itself (#133) is untouched — this is purely the advertisement.

## Why it slipped through

The existing `OpenSubsonicExtensionsApiTest` asserted only per-extension `hasItem(...)` subsets, which pass whenever a named extension is present and **never** detect a missing one. No test asserted the advertised set was *complete*, so `getPodcastEpisode`'s omission went unnoticed from #133 until the #35 audit.

The new `getOpenSubsonicExtensions_advertisesExactlyTheExpectedSet` test uses `containsInAnyOrder` over all six keys — it fails if any extension is added or dropped without updating the test, so a future shipped-extension can't go unadvertised the same way.

## Verification

- HSQLDB full suite: 1222/0/0
- analyze clean, WAR confirms `getPodcastEpisode` in the compiled advertisement list
- No schema change; pr_ci covers the matrix

Tests: +4 (presence+version and exact-set completeness, each across the `/rest` and `.view` endpoint variants). Floor 1218 → 1222.

fixes #294