### PR TITLE
fix: podcastSettings 500 — mutation of immutable list in formBackingObject (#296)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PodcastSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PodcastSettingsController.java
@@ -39,6 +39,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -79,15 +80,23 @@ public class PodcastSettingsController {
 
         List<PodcastChannel> channels = podcastPersistenceService.getAllChannels();
         List<PodcastChannelRule> rules = podcastPersistenceService.getAllChannelRules();
-        command.setRules(rules.stream()
-                .map(cr -> new PodcastRule(
-                        cr,
-                        channels.stream()
-                            .filter(c -> c.getId().equals(cr.getId()))
-                            .findFirst()
-                            .map(c -> c.getTitle()).orElse(null)))
+        // A synthetic "DEFAULT" rule (channel id -1) carrying the global podcast settings is
+        // appended after the per-channel rules. Built in a single immutable pass via Stream.concat
+        // rather than a build-then-add, since Stream.toList() is unmodifiable.
+        PodcastRule defaultRule = new PodcastRule(new PodcastChannelRule(-1,
+                settingsService.getPodcastUpdateInterval(),
+                settingsService.getPodcastEpisodeRetentionCount(),
+                settingsService.getPodcastEpisodeDownloadCount()), "DEFAULT");
+        command.setRules(Stream.concat(
+                rules.stream()
+                    .map(cr -> new PodcastRule(
+                            cr,
+                            channels.stream()
+                                .filter(c -> c.getId().equals(cr.getId()))
+                                .findFirst()
+                                .map(PodcastChannel::getTitle).orElse(null))),
+                Stream.of(defaultRule))
                 .toList());
-        command.getRules().add(new PodcastRule(new PodcastChannelRule(-1, settingsService.getPodcastUpdateInterval(), settingsService.getPodcastEpisodeRetentionCount(), settingsService.getPodcastEpisodeDownloadCount()), "DEFAULT"));
 
         command.setNewRule(new PodcastRule());
         command.setNoRuleChannels(channels.parallelStream()

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastSettingsControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastSettingsControllerTest.java
@@ -1,0 +1,124 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.command.PodcastSettingsCommand;
+import org.airsonic.player.command.PodcastSettingsCommand.PodcastRule;
+import org.airsonic.player.domain.PodcastChannel;
+import org.airsonic.player.domain.PodcastChannelRule;
+import org.airsonic.player.service.MediaFolderService;
+import org.airsonic.player.service.PodcastPersistenceService;
+import org.airsonic.player.service.SettingsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for {@link PodcastSettingsController#formBackingObject} (#296). The page appended
+ * a synthetic "DEFAULT" rule to the rules list with {@code .add()}, but the list came from
+ * {@code Stream.toList()} (unmodifiable since a Collectors.toList()→Stream.toList() refactor), so
+ * every GET /podcastSettings threw {@link UnsupportedOperationException} and the page 500'd. These
+ * assert the page model builds without throwing and the DEFAULT rule is appended after the
+ * per-channel rules.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PodcastSettingsControllerTest {
+
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private PodcastPersistenceService podcastPersistenceService;
+    @Mock
+    private MediaFolderService mediaFolderService;
+
+    @InjectMocks
+    private PodcastSettingsController controller;
+
+    private void stubSettings() {
+        when(mediaFolderService.getAllMusicFolders()).thenReturn(List.of());
+        when(mediaFolderService.getAllMusicFolders(true, true)).thenReturn(List.of());
+        when(settingsService.getPodcastUpdateInterval()).thenReturn(24);
+        when(settingsService.getPodcastEpisodeRetentionCount()).thenReturn(-1);
+        when(settingsService.getPodcastEpisodeDownloadCount()).thenReturn(-1);
+    }
+
+    @Test
+    void formBackingObject_appendsDefaultRule_whenNoChannelRules() {
+        // Reporter's case: default podcast config, no channel-specific rules. Pre-fix this threw
+        // UnsupportedOperationException on the .add() and the page was completely inaccessible.
+        stubSettings();
+        when(podcastPersistenceService.getAllChannels()).thenReturn(List.of());
+        when(podcastPersistenceService.getAllChannelRules()).thenReturn(List.of());
+
+        Model model = new ExtendedModelMap();
+        String view = assertDoesNotThrow(() -> controller.formBackingObject(model));
+
+        assertEquals("podcastSettings", view);
+        PodcastSettingsCommand command = (PodcastSettingsCommand) model.getAttribute("command");
+        assertEquals(1, command.getRules().size(), "only the DEFAULT rule is present");
+        PodcastRule defaultRule = command.getRules().get(0);
+        assertEquals(-1, defaultRule.getId());
+        assertEquals("DEFAULT", defaultRule.getName());
+        assertEquals(-1, defaultRule.getEpisodeRetentionCount());
+        assertEquals(-1, defaultRule.getEpisodeDownloadCount());
+    }
+
+    @Test
+    void formBackingObject_appendsDefaultRuleAfterChannelRules() {
+        // A per-channel rule plus the DEFAULT: proves ordering (channel rules first, DEFAULT last)
+        // and that the per-channel rules survive the single-pass build.
+        stubSettings();
+        PodcastChannelRule channelRule = org.mockito.Mockito.mock(PodcastChannelRule.class);
+        when(channelRule.getId()).thenReturn(5);
+        when(channelRule.getCheckInterval()).thenReturn(12);
+        when(channelRule.getRetentionCount()).thenReturn(10);
+        when(channelRule.getDownloadCount()).thenReturn(3);
+        PodcastChannel channel = org.mockito.Mockito.mock(PodcastChannel.class);
+        when(channel.getId()).thenReturn(5);
+        when(channel.getTitle()).thenReturn("My Podcast");
+        when(podcastPersistenceService.getAllChannels()).thenReturn(List.of(channel));
+        when(podcastPersistenceService.getAllChannelRules()).thenReturn(List.of(channelRule));
+
+        Model model = new ExtendedModelMap();
+        String view = assertDoesNotThrow(() -> controller.formBackingObject(model));
+
+        assertEquals("podcastSettings", view);
+        PodcastSettingsCommand command = (PodcastSettingsCommand) model.getAttribute("command");
+        assertEquals(2, command.getRules().size());
+        // per-channel rule first
+        assertEquals(5, command.getRules().get(0).getId());
+        assertEquals("My Podcast", command.getRules().get(0).getName());
+        // DEFAULT appended last
+        assertEquals(-1, command.getRules().get(1).getId());
+        assertEquals("DEFAULT", command.getRules().get(1).getName());
+    }
+}


### PR DESCRIPTION
GET `/podcastSettings` returned a 500 on every page load — the page was fully inaccessible.

## Root cause

`formBackingObject` built the rules list with `.toList()` (immutable) and then called `command.getRules().add(...)` to append a synthetic DEFAULT rule, throwing `UnsupportedOperationException`.

The immutable list came from commit e360edce (`replace Collectors.toList() with Stream.toList()`), which converted this site's mutable `ArrayList` to an immutable list while the pre-existing `.add()` still ran. That refactor deliberately kept three sites mutable because they mutate after collection (`PlaylistService`, `PlayQueueService`, `SecurityService`) — this site was missed. Present in 13.1.0 and current main: pre-existing, not a 13.2.x regression.

## Fix

Build the list in one pass with `Stream.concat(channelRules, Stream.of(defaultRule)).toList()` and remove the `.add()`. Order and contents are identical to the original (per-channel rules first, DEFAULT last). Chosen over a `new ArrayList<>` wrap because it removes the mutation entirely rather than re-enabling it on a mutable copy.

## Verification

- HSQLDB full suite: 1224/0/0
- analyze clean, WAR confirms the `Stream.concat` build
- code-reviewer: high-confidence approval; both regression tests fail pre-fix (the empty-rules test reproduces the exact UOE)

Tests: +2. Floor 1222 → 1224.

A follow-up audit of the other e360edce conversion sites for the same missed `.toList()`-then-mutate pattern is tracked in #300.

fixes #296