### PR TITLE
fix: MediaFile.equals NPE on null folder and startPosition (#216)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -736,10 +736,10 @@ public class MediaFile {
         } else if (!path.equals(other.path)) {
             return false;
         }
-        if (!folder.equals(other.folder)) {
+        if (!Objects.equals(this.folder, other.folder)) {
             return false;
         }
-        if (!startPosition.equals(other.startPosition)) {
+        if (!Objects.equals(this.startPosition, other.startPosition)) {
             return false;
         }
         return true;

--- a/airsonic-main/src/test/java/org/airsonic/player/domain/MediaFileTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/domain/MediaFileTestCase.java
@@ -1,0 +1,124 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.airsonic.player.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test of {@link MediaFile#equals(Object)} and its null tolerance.
+ *
+ * <p>equals compares path, folder and startPosition. hashCode is null-safe (Objects.hash), so
+ * equals must tolerate a null folder or startPosition rather than throwing — otherwise any
+ * collection operation that compares MediaFiles (contains, indexOf, dedup) can blow up on a
+ * value hashCode happily accepts.
+ */
+public class MediaFileTestCase {
+
+    private static final MusicFolder FOLDER = new MusicFolder(1, Paths.get("/music"), "Music",
+            MusicFolder.Type.MEDIA, true, Instant.EPOCH);
+
+    private static MediaFile mediaFile(String path, MusicFolder folder, Double startPosition) {
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.setPath(path);
+        mediaFile.setFolder(folder);
+        mediaFile.setStartPosition(startPosition);
+        return mediaFile;
+    }
+
+    @Test
+    public void testEqualsWithNullFolderOnEitherSide() {
+        MediaFile nullFolder = mediaFile("a.mp3", null, MediaFile.NOT_INDEXED);
+        MediaFile withFolder = mediaFile("a.mp3", FOLDER, MediaFile.NOT_INDEXED);
+
+        assertDoesNotThrow(() -> nullFolder.equals(withFolder));
+        assertDoesNotThrow(() -> withFolder.equals(nullFolder));
+
+        assertFalse(nullFolder.equals(withFolder));
+        assertFalse(withFolder.equals(nullFolder));
+    }
+
+    @Test
+    public void testEqualsWithNullStartPositionOnEitherSide() {
+        MediaFile nullStart = mediaFile("a.mp3", FOLDER, null);
+        MediaFile withStart = mediaFile("a.mp3", FOLDER, MediaFile.NOT_INDEXED);
+
+        assertDoesNotThrow(() -> nullStart.equals(withStart));
+        assertDoesNotThrow(() -> withStart.equals(nullStart));
+
+        assertFalse(nullStart.equals(withStart));
+        assertFalse(withStart.equals(nullStart));
+    }
+
+    @Test
+    public void testEqualsWhenBothFoldersAreNull() {
+        MediaFile a = mediaFile("a.mp3", null, MediaFile.NOT_INDEXED);
+        MediaFile b = mediaFile("a.mp3", null, MediaFile.NOT_INDEXED);
+
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(a));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsWhenBothStartPositionsAreNull() {
+        MediaFile a = mediaFile("a.mp3", FOLDER, null);
+        MediaFile b = mediaFile("a.mp3", FOLDER, null);
+
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(a));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsWhenAllComparedFieldsAreNull() {
+        MediaFile a = mediaFile(null, null, null);
+        MediaFile b = mediaFile(null, null, null);
+
+        assertDoesNotThrow(() -> a.equals(b));
+        assertTrue(a.equals(b));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithIdenticalFields() {
+        MediaFile a = mediaFile("a.mp3", FOLDER, 12.5);
+        MediaFile b = mediaFile("a.mp3", FOLDER, 12.5);
+
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(a));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithDifferingFields() {
+        MediaFile base = mediaFile("a.mp3", FOLDER, MediaFile.NOT_INDEXED);
+        MusicFolder otherFolder = new MusicFolder(2, Paths.get("/other"), "Other",
+                MusicFolder.Type.MEDIA, true, Instant.EPOCH);
+
+        assertFalse(base.equals(mediaFile("b.mp3", FOLDER, MediaFile.NOT_INDEXED)));
+        assertFalse(base.equals(mediaFile("a.mp3", otherFolder, MediaFile.NOT_INDEXED)));
+        assertFalse(base.equals(mediaFile("a.mp3", FOLDER, 12.5)));
+    }
+}


### PR DESCRIPTION
`MediaFile.equals` threw `NullPointerException` when either compared instance had a null `folder` or null `startPosition`, while `hashCode` (`Objects.hash(path, folder, startPosition)`) is null-safe — a broken equals/hashCode contract that any comparing collection or stream op (`indexOf`, `contains`, dedup) can hit.

## Root cause

`equals` called `folder.equals(...)` and `startPosition.equals(...)` directly. The `path` comparison in the same method was already null-guarded; these two were not. All three fields are in the null-safe `hashCode`, so one compared field was guarded and two weren't.

Latent in normal use — media files carry a folder, and `startPosition` defaults to `NOT_INDEXED` (-1.0) rather than null — but reachable: the #141 test worked around the folder case by forcing `folder=testFolder` on its helper.

The issue's line reference (651) was stale (`equals` now at 721) and named only `folder`. `startPosition` is the identical unguarded pattern in the same method and is fixed alongside it.

## Fix

`Objects.equals(this.folder, other.folder)` and `Objects.equals(this.startPosition, other.startPosition)`, matching the existing null-safe `path` comparison and `hashCode`'s null tolerance. No import added — `java.util.Objects` was already imported for `hashCode`. Only the two comparison lines change; no other method touched.

## Verification

- HSQLDB full suite: 1231/0/0 (floor 1224 → 1231, exactly the 7 added tests, no regressions)
- checkstyle clean
- Tests verified to catch the bug: with the unguarded comparisons temporarily restored, 5 of the 7 fail with the exact NPEs from the issue (`Cannot invoke "MusicFolder.equals(Object)" because "this.folder" is null` and the `Double` equivalent); the 2 sanity cases pass in both states.

Tests: +7 (`MediaFileTestCase`, new — no prior MediaFile domain equals test existed).

fixes #216