### PR TITLE
fix: use SecureRandom in SearchServiceImpl random-songs path (#263)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceImpl.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.function.BiConsumer;
 
@@ -49,8 +50,7 @@ public class SearchServiceImpl implements SearchService {
     @Autowired
     private SearchServiceUtilities util;
 
-    // TODO Should be changed to SecureRandom?
-    private final Random random = new Random(System.currentTimeMillis());
+    private final SecureRandom random = new SecureRandom();
 
     /**
      * Extracts the integer value from a TotalHits string.


### PR DESCRIPTION
`SearchServiceImpl` seeded a `java.util.Random` with `System.currentTimeMillis()` for random-song / random-album selection (`getRandomSongs`, `createRandomDocsList`), carrying a decade-old TODO from the original Subsonic codebase asking whether it should be `SecureRandom`.

Not security-sensitive in practice — the random instance controls only which subset of music plays, not access — but the cleanup clears the long-standing TODO and removes a predictable time-seed.

## Fix

`private final SecureRandom random = new SecureRandom()`. `SecureRandom` IS-A `Random`, so every existing call site (`random.nextInt(...)`) compiles unchanged. Dropped the `System.currentTimeMillis()` seed — `SecureRandom` self-seeds from the JVM entropy source, and a time seed would make it predictable, defeating the change. Removed the TODO. Added `import java.security.SecureRandom;`; the `java.util.*` wildcard stays for other `java.util` types in the file. Only `SearchServiceImpl.java` changed.

## Verification

- HSQLDB full suite: 1231/0/0 (floor unchanged — field-type swap, no tests added)
- checkstyle clean
- The changed path is exercised by `SearchServiceTestCase`, `SearchServiceSpecialGenreTestCase` and `SearchServiceSpecialPathTestCase`, all green under `SecureRandom` — confirmed working through real test exercise, not just compilation.

No new test: the random path already has coverage and there is no behavioral contract change to assert.

fixes #263