### PR TITLE
fix: guard null base duration in CUE and audiobook indexed-track creation (#289)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -1179,7 +1179,9 @@ public class MediaFileService {
                     track.setFormat(base.getFormat());
                     track.setMusicBrainzRecordingId(base.getMusicBrainzRecordingId());
                     track.setMusicBrainzReleaseId(base.getMusicBrainzReleaseId());
-                    long estimatedSize = (long) (duration / base.getDuration() * Files.size(audioFile));
+                    Double baseDuration = base.getDuration();
+                    double wholeFileLength = baseDuration != null ? baseDuration : 0.0;
+                    long estimatedSize = (long) (duration / wholeFileLength * Files.size(audioFile));
                     if (estimatedSize > 0 && estimatedSize < Files.size(audioFile)) {
                         track.setFileSize(estimatedSize);
                     } else {
@@ -1224,7 +1226,8 @@ public class MediaFileService {
 
             Path audioFile = base.getFullPath();
             long wholeFileSize = Files.size(audioFile);
-            double wholeFileLength = base.getDuration();
+            Double baseDuration = base.getDuration();
+            double wholeFileLength = baseDuration != null ? baseDuration : 0.0;
 
             String basePath = base.getPath();
             String parentPath = base.getParentPath();

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -44,7 +44,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -295,6 +297,61 @@ public class MediaFileServiceTest {
         List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
 
         assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void createIndexedTracksNullBaseDurationSkipsBlockWithoutNpe() {
+        // #289: the eager unbox of base.getDuration() aborted the whole FILE block with an NPE when the
+        // base file's duration was null (unparsed). The 0.0-sentinel guard removes the NPE; the
+        // pre-existing line-1245 guard (lastTrackStart >= wholeFileLength) then fires against the 0.0
+        // length and the block is skipped gracefully — empty result, index path cleared — rather than
+        // crashing the scan. The tracks reappear on a later scan once the base duration parses.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 1, "Sole Track", 0, 5, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        base.setDuration(null);
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = assertDoesNotThrow(
+                () -> ReflectionTestUtils.<List<MediaFile>>invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet));
+
+        // block skipped gracefully: no tracks, and the base's index path is cleared (1245 side effect)
+        assertTrue(actual.isEmpty());
+        assertNull(base.getIndexPath());
+    }
+
+    @Test
+    public void createIndexedTracksNonNullBaseDurationStillMaterialises() {
+        // Sanity counterpart to the null-base case: with a known base duration the line-1245 guard does
+        // NOT fire, so the block materialises normally with a non-null computed duration. Proves the
+        // 0.0-sentinel guard only degrades the degenerate null case and leaves the happy path intact.
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 1, "Sole Track", 0, 5, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = cueBase();
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(1, actual.size());
+        assertNotNull(actual.get(0).getDuration());
+        // file length (30.0) - start (5.0) = 25.0
+        assertEquals(25.0d, actual.get(0).getDuration(), 0.001d);
     }
 
     private MediaFile cueBase() {


### PR DESCRIPTION
`createIndexedTracks` unboxed `base.getDuration()` (nullable `Double`) into a primitive `double` at the top of each FILE block, before the track loop. A base file whose duration wasn't parsed at scan time (unreadable/corrupt header, unsupported codec, mid-scan) carries a null duration, so the unbox threw `NullPointerException` and aborted the **whole FILE block's** track creation — not just the last track, as this issue originally framed it.

Reachable before #211 on the single-base path; #211's multifile change raised the odds by resolving a distinct base per FILE block, so a multi-FILE CUE where any referenced file has a null duration can hit it.

## Fix

Guard the unbox with a 0.0 sentinel (`baseDuration != null ? baseDuration : 0.0`).

For the CUE path, a null base duration means the file's total length is unknown and CUE track boundaries can't be computed correctly. With the 0.0 sentinel the pre-existing guard (`lastTrackStart >= wholeFileLength`) fires and the block is **skipped gracefully** — it returns empty and the base file's index path is cleared, rather than aborting the scan with an NPE. The tracks reappear on a later scan once the base duration parses. Skipping is more honest than materialising tracks with fabricated boundaries.

The identical unguarded unbox in `createAudioBookTracks` (m4b chapters) is guarded the same way; there base duration is only a divisor for the size estimate, so the sentinel takes the safe else-branch.

## Verification

- HSQLDB full suite: 1233/0/0 (floor 1231 → 1233, +2 tests, no regressions)
- checkstyle clean
- Two new tests (`MediaFileServiceTest`): null-base block skips without NPE (empty result, index path cleared); non-null base still materialises tracks normally, proving the guard fires only for the degenerate null case.
- Verified the null-base test fails pre-fix with the exact NPE (`Cannot invoke "java.lang.Double.doubleValue()" because ...MediaFile.getDuration() is null` at `createIndexedTracks`), passes post-fix.

## Related

Three other unguarded `getDuration()` unboxes surfaced during this trace (`incrementPlayCount`, XSPF export, Sonos metadata) are tracked separately in #322, not bundled here.

fixes #289