### PR TITLE
fix: match MP4 ReplayGain atoms case-insensitively (#251)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -409,7 +409,8 @@ public class JaudiotaggerParser extends MetaDataParser {
      * {@link FieldKey}, so it is read directly: from ID3v2 it lives in a TXXX frame keyed by a
      * (case-insensitive) description; Vorbis comments (FLAC/Ogg/Opus) expose it as a plain
      * keyed field; MP4 stores it as an iTunes-style reverse-DNS freeform atom keyed by the
-     * lowercase descriptor under {@link #MP4_ITUNES_FREEFORM_PREFIX}.
+     * (conventionally lowercase) descriptor under {@link #MP4_ITUNES_FREEFORM_PREFIX}, matched
+     * case-insensitively here so a tagger that capitalizes the descriptor still resolves.
      */
     static String getReplayGainField(Tag tag, String name) {
         try {
@@ -427,12 +428,13 @@ public class JaudiotaggerParser extends MetaDataParser {
                 return null;
             }
             if (tag instanceof Mp4Tag mp4) {
-                List<TagField> fields = mp4.getFields(MP4_ITUNES_FREEFORM_PREFIX + name.toLowerCase());
-                if (fields != null) {
-                    for (TagField field : fields) {
-                        if (field instanceof Mp4TagReverseDnsField rdns) {
-                            return StringUtils.trimToNull(rdns.getContent());
-                        }
+                String atomId = MP4_ITUNES_FREEFORM_PREFIX + name;
+                Iterator<TagField> it = mp4.getFields();
+                while (it.hasNext()) {
+                    TagField field = it.next();
+                    if (field instanceof Mp4TagReverseDnsField rdns
+                            && atomId.equalsIgnoreCase(rdns.getId())) {
+                        return StringUtils.trimToNull(rdns.getContent());
                     }
                 }
                 return null;

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/JaudiotaggerParserTestCase.java
@@ -74,15 +74,15 @@ public class JaudiotaggerParserTestCase {
         assertEquals("-7.50 dB", JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
-    private static Mp4Tag mp4TagWithItunesFreeform(String descriptorLower, String value) {
+    private static Mp4Tag mp4TagWithItunesFreeform(String descriptor, String value) {
         Mp4Tag tag = new Mp4Tag();
         // jaudiotagger's 4-string Mp4TagReverseDnsField(id, issuer, descriptor, content) sets
         // the field's id directly to the first argument (the iTunes reverse-DNS atom name);
-        // that's what Mp4Tag.getFields(String) matches against and what
-        // JaudiotaggerParser.getReplayGainField composes its lookup key for.
-        String id = JaudiotaggerParser.MP4_ITUNES_FREEFORM_PREFIX + descriptorLower;
+        // that's the id JaudiotaggerParser.getReplayGainField compares its composed atom name
+        // against when it walks the tag's fields.
+        String id = JaudiotaggerParser.MP4_ITUNES_FREEFORM_PREFIX + descriptor;
         Mp4TagReverseDnsField field = new Mp4TagReverseDnsField(id, "com.apple.iTunes",
-                descriptorLower, value);
+                descriptor, value);
         tag.addField(field);
         return tag;
     }
@@ -95,9 +95,34 @@ public class JaudiotaggerParserTestCase {
     }
 
     @Test
+    public void testGetReplayGainFieldMp4AtomMatchIsCaseInsensitive() {
+        // fixes #251: the MP4 branch used to demand an exact lowercase atom name, so a tagger
+        // that capitalized the descriptor was silently missed. The ID3v2 TXXX branch has always
+        // matched case-insensitively; this asserts the MP4 branch now does too.
+        Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_Track_gain", "-6.50 dB");
+        assertEquals("-6.50 dB",
+                JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
+    }
+
+    @Test
+    public void testGetReplayGainFieldMp4AtomInUpperCaseResolves() {
+        Mp4Tag tag = mp4TagWithItunesFreeform("REPLAYGAIN_ALBUM_GAIN", "-4.25 dB");
+        assertEquals("-4.25 dB",
+                JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_ALBUM_GAIN));
+    }
+
+    @Test
     public void testGetReplayGainFieldMp4MissingAtomReturnsNull() {
         Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain", "-7.50 dB");
         assertNull(JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_ALBUM_PEAK));
+    }
+
+    @Test
+    public void testGetReplayGainFieldMp4UnrelatedAtomIsNotMatched() {
+        // Widening to case-insensitive must not widen to substring/prefix matching: an atom whose
+        // descriptor merely resembles the target must still miss.
+        Mp4Tag tag = mp4TagWithItunesFreeform("replaygain_track_gain_ratio", "-7.50 dB");
+        assertNull(JaudiotaggerParser.getReplayGainField(tag, MetaDataParser.RG_TRACK_GAIN));
     }
 
     // parseR128GainQ78 itself was lifted to MetaDataParser (so FFmpegParser can reuse the


### PR DESCRIPTION
`JaudiotaggerParser.getReplayGainField` had an asymmetry between its two lookup branches: the ID3v2 TXXX branch matched the frame description with `equalsIgnoreCase`, but the MP4 freeform branch did an exact lookup on a lowercased key, so an atom written with non-canonical casing (`replaygain_Track_gain`, `REPLAYGAIN_ALBUM_GAIN`) was silently missed.

Real-world MP4 ReplayGain atoms are uniformly lowercase per the iTunes convention, so every conformant writer was already handled and nothing has failed in the wild. This restores the symmetry before it bites.

## Fix

Iterate the tag's fields and match the composed atom id with `equalsIgnoreCase`, structurally mirroring the TXXX branch.

Matching is on the full id (`----:com.apple.iTunes:replaygain_track_gain`) rather than the descriptor alone. Descriptor-only matching would mirror the TXXX branch more literally, but would also accept the atom under a non-iTunes issuer, which widens beyond casing. Matching the full id keeps the widening strictly to case; the side effect is that the issuer segment is also compared case-insensitively.

Conformant lowercase atoms resolve exactly as before. TXXX, the Opus/R128 path and all other methods are untouched.

## Verification

- HSQLDB full suite: 1236/0/0 (floor 1233 → 1236, +3 tests, no regressions)
- checkstyle clean
- `Tag.getFields()` → `Iterator<TagField>` and `TagField.getId()` confirmed against `jaudiotagger-3.0.1.jar` with `javap` rather than assumed.
- Three new tests extend the existing in-memory MP4 freeform harness (no binary fixtures added): mixed-case and upper-case atoms resolve; an unrelated atom (`replaygain_track_gain_ratio`) still returns null. The existing canonical-lowercase and missing-atom tests are kept as regression guards.
- Two-state check: with the case-sensitive lookup temporarily restored, exactly the two new casing tests fail (`expected: <-6.50 dB> but was: <null>`) while the lowercase guard and both null-contract tests still pass.

fixes #251