### PR TITLE
feat: show version on the login screen behind an admin toggle (#246)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/command/GeneralSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/GeneralSettingsCommand.java
@@ -43,6 +43,7 @@ public class GeneralSettingsCommand {
     private String shortcuts;
     private boolean sortAlbumsByYear;
     private boolean gettingStartedEnabled;
+    private boolean showVersionOnLogin;
     private String welcomeTitle;
     private String welcomeSubtitle;
     private String welcomeMessage;
@@ -230,6 +231,14 @@ public class GeneralSettingsCommand {
 
     public void setGettingStartedEnabled(boolean gettingStartedEnabled) {
         this.gettingStartedEnabled = gettingStartedEnabled;
+    }
+
+    public boolean isShowVersionOnLogin() {
+        return showVersionOnLogin;
+    }
+
+    public void setShowVersionOnLogin(boolean showVersionOnLogin) {
+        this.showVersionOnLogin = showVersionOnLogin;
     }
 
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/GeneralSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/GeneralSettingsController.java
@@ -70,6 +70,7 @@ public class GeneralSettingsController {
         command.setVideoFileTypes(settingsService.getVideoFileTypes());
         command.setSortAlbumsByYear(settingsService.isSortAlbumsByYear());
         command.setGettingStartedEnabled(settingsService.isGettingStartedEnabled());
+        command.setShowVersionOnLogin(settingsService.isShowVersionOnLogin());
         command.setWelcomeTitle(settingsService.getWelcomeTitle());
         command.setWelcomeSubtitle(settingsService.getWelcomeSubtitle());
         command.setWelcomeMessage(settingsService.getWelcomeMessage());
@@ -133,6 +134,7 @@ public class GeneralSettingsController {
         settingsService.setCoverArtQuality(command.getCoverArtQuality());
         settingsService.setSortAlbumsByYear(command.isSortAlbumsByYear());
         settingsService.setGettingStartedEnabled(command.isGettingStartedEnabled());
+        settingsService.setShowVersionOnLogin(command.isShowVersionOnLogin());
         settingsService.setWelcomeTitle(command.getWelcomeTitle());
         settingsService.setWelcomeSubtitle(command.getWelcomeSubtitle());
         settingsService.setWelcomeMessage(command.getWelcomeMessage());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/LoginController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/LoginController.java
@@ -2,6 +2,7 @@ package org.airsonic.player.controller;
 
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
+import org.airsonic.player.service.VersionService;
 import org.airsonic.player.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -28,6 +29,8 @@ public class LoginController {
     private SecurityService securityService;
     @Autowired
     private SettingsService settingsService;
+    @Autowired
+    private VersionService versionService;
 
     @GetMapping
     public ModelAndView login(HttpServletRequest request, HttpServletResponse response) {
@@ -49,6 +52,15 @@ public class LoginController {
         map.put("error", request.getParameter("error") != null);
         map.put("brand", settingsService.getBrand());
         map.put("loginMessage", settingsService.getLoginMessage());
+
+        // Version under the logo, gated by the admin-only toggle. The display version already
+        // embeds the build timestamp, so no separate build date is exposed. Read here rather
+        // than in the template so the pre-authentication view stays free of service lookups.
+        boolean showVersion = settingsService.isShowVersionOnLogin();
+        map.put("showVersion", showVersion);
+        if (showVersion) {
+            map.put("displayVersion", versionService.getDisplayVersion());
+        }
 
         if (securityService.checkDefaultAdminCredsPresent()) {
             map.put("insecure", true);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -115,6 +115,7 @@ public class SettingsService {
     private static final String KEY_SETTINGS_CHANGED = "SettingsChanged";
     private static final String KEY_ORGANIZE_BY_FOLDER_STRUCTURE = "OrganizeByFolderStructure";
     private static final String KEY_SORT_ALBUMS_BY_YEAR = "SortAlbumsByYear";
+    private static final String KEY_SHOW_VERSION_ON_LOGIN = "ShowVersionOnLogin";
     private static final String KEY_DLNA_ENABLED = "DlnaEnabled";
     private static final String KEY_DLNA_SERVER_NAME = "DlnaServerName";
     private static final String KEY_DLNA_SERVER_ID = "DlnaServerId";
@@ -222,6 +223,7 @@ public class SettingsService {
     private static final long DEFAULT_SETTINGS_CHANGED = 0L;
     private static final boolean DEFAULT_ORGANIZE_BY_FOLDER_STRUCTURE = true;
     private static final boolean DEFAULT_SORT_ALBUMS_BY_YEAR = true;
+    private static final boolean DEFAULT_SHOW_VERSION_ON_LOGIN = true;
     private static final boolean DEFAULT_DLNA_ENABLED = false;
     private static final String DEFAULT_DLNA_SERVER_NAME = "Airsonic";
     private static final String DEFAULT_DLNA_SERVER_ID = null;
@@ -1145,6 +1147,19 @@ public class SettingsService {
 
     public void setSortAlbumsByYear(boolean b) {
         setBoolean(KEY_SORT_ALBUMS_BY_YEAR, b);
+    }
+
+    /**
+     * Whether the login screen displays the running version and build timestamp. Defaults to
+     * on for support and troubleshooting value; operators who prefer not to advertise the
+     * version pre-authentication can turn it off in general settings.
+     */
+    public boolean isShowVersionOnLogin() {
+        return getBoolean(KEY_SHOW_VERSION_ON_LOGIN, DEFAULT_SHOW_VERSION_ON_LOGIN);
+    }
+
+    public void setShowVersionOnLogin(boolean b) {
+        setBoolean(KEY_SHOW_VERSION_ON_LOGIN, b);
     }
 
     public boolean getIgnoreSymLinks() {

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle.properties
@@ -375,6 +375,7 @@ generalsettings.genreseparators=Genre separation characters
 generalsettings.shortcuts=Shortcuts
 generalsettings.sortalbumsbyyear=Sort albums by year
 generalsettings.showgettingstarted=Show Getting started on startup
+generalsettings.showversiononlogin=Show version on login page
 generalsettings.welcometitle=Welcome title
 generalsettings.welcomesubtitle=Welcome subtitle
 generalsettings.welcomemessage=Welcome message

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -375,6 +375,7 @@ generalsettings.genreseparators=Genre separation characters
 generalsettings.shortcuts=Shortcuts
 generalsettings.sortalbumsbyyear=Sort albums by year
 generalsettings.showgettingstarted=Show Getting started on startup
+generalsettings.showversiononlogin=Show version on login page
 generalsettings.welcometitle=Welcome title
 generalsettings.welcomesubtitle=Welcome subtitle
 generalsettings.welcomemessage=Welcome message

--- a/airsonic-main/src/main/resources/templates/generalSettings.html
+++ b/airsonic-main/src/main/resources/templates/generalSettings.html
@@ -152,6 +152,14 @@
                 <label th:for="${#ids.prev('gettingStartedEnabled')}" th:text="#{generalsettings.showgettingstarted}"></label>
             </td>
         </tr>
+        <tr>
+            <td>
+            </td>
+            <td>
+                <input type="checkbox" th:field="*{showVersionOnLogin}"/>
+                <label th:for="${#ids.prev('showVersionOnLogin')}" th:text="#{generalsettings.showversiononlogin}"></label>
+            </td>
+        </tr>
 
         <tr><td colspan="2">&nbsp;</td></tr>
 

--- a/airsonic-main/src/main/resources/templates/login.html
+++ b/airsonic-main/src/main/resources/templates/login.html
@@ -15,6 +15,9 @@
 
             <img th:src="${themes?.get('logoImage') ?: 'icons/default_light/logo.png'}" alt="">
 
+            <div class="detail" th:if="${model.showVersion}" th:with="unknownLabel=#{common.unknown}"
+                 th:text="${#strings.isEmpty(model.displayVersion) ? unknownLabel : model.displayVersion}"></div>
+
             <div class="loginmessagetop" th:text="${model.loginMessage}"></div>
 
             <input required type="text" autofocus id="j_username" name="j_username" tabindex="1"

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/GeneralSettingsControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/GeneralSettingsControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.command.GeneralSettingsCommand;
+import org.airsonic.player.domain.Theme;
+import org.airsonic.player.service.PlaylistFileService;
+import org.airsonic.player.service.SettingsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link GeneralSettingsController} binds the show-version-on-login toggle (#246) in
+ * both directions — read into the form-backing command on GET, written back to
+ * {@link SettingsService} on POST.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GeneralSettingsControllerTest {
+
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private PlaylistFileService playlistFileService;
+
+    @InjectMocks
+    private GeneralSettingsController controller;
+
+    private void stubThemesAndLocales() {
+        when(settingsService.getAvailableThemes()).thenReturn(new Theme[] {new Theme("default", "Default")});
+        when(settingsService.getThemeId()).thenReturn("default");
+        when(settingsService.getAvailableLocales()).thenReturn(new Locale[] {Locale.ENGLISH});
+        when(settingsService.getLocale()).thenReturn(Locale.ENGLISH);
+    }
+
+    @Test
+    void formBackingObjectReadsShowVersionOnLogin() {
+        stubThemesAndLocales();
+        when(settingsService.isShowVersionOnLogin()).thenReturn(true);
+
+        Model model = new ExtendedModelMap();
+        controller.formBackingObject(model);
+
+        GeneralSettingsCommand command = (GeneralSettingsCommand) model.getAttribute("command");
+        assertTrue(command.isShowVersionOnLogin());
+    }
+
+    @Test
+    void formBackingObjectReadsShowVersionOnLoginWhenOff() {
+        stubThemesAndLocales();
+        when(settingsService.isShowVersionOnLogin()).thenReturn(false);
+
+        Model model = new ExtendedModelMap();
+        controller.formBackingObject(model);
+
+        GeneralSettingsCommand command = (GeneralSettingsCommand) model.getAttribute("command");
+        assertFalse(command.isShowVersionOnLogin());
+    }
+
+    @Test
+    void doSubmitActionWritesShowVersionOnLogin() {
+        stubThemesAndLocales();
+
+        GeneralSettingsCommand command = new GeneralSettingsCommand();
+        command.setThemeIndex("0");
+        command.setLocaleIndex("0");
+        command.setShowVersionOnLogin(false);
+
+        controller.doSubmitAction(command, new RedirectAttributesModelMap());
+
+        verify(settingsService).setShowVersionOnLogin(false);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/LoginControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/LoginControllerTest.java
@@ -1,0 +1,106 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.airsonic.player.service.SecurityService;
+import org.airsonic.player.service.SettingsService;
+import org.airsonic.player.service.VersionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link LoginController} exposes the display version to the pre-authentication login
+ * view only when the show-version-on-login toggle is on (#246). The display version already embeds
+ * the build timestamp, so no separate build date is exposed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LoginControllerTest {
+
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private VersionService versionService;
+
+    @InjectMocks
+    private LoginController controller;
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loginModel() {
+        ModelAndView mav = controller.login(new MockHttpServletRequest(), new MockHttpServletResponse());
+        return (Map<String, Object>) mav.getModel().get("model");
+    }
+
+    @Test
+    void modelExposesVersionWhenToggleOn() {
+        when(settingsService.isShowVersionOnLogin()).thenReturn(true);
+        when(versionService.getDisplayVersion()).thenReturn("13.3.0-SNAPSHOT.20260718141619");
+
+        Map<String, Object> model = loginModel();
+
+        assertEquals(true, model.get("showVersion"));
+        // the display version already embeds the build timestamp — no separate build date is exposed
+        assertEquals("13.3.0-SNAPSHOT.20260718141619", model.get("displayVersion"));
+    }
+
+    @Test
+    void modelOmitsVersionWhenToggleOff() {
+        when(settingsService.isShowVersionOnLogin()).thenReturn(false);
+
+        Map<String, Object> model = loginModel();
+
+        assertEquals(false, model.get("showVersion"));
+        assertNull(model.get("displayVersion"));
+        // the version is not merely hidden by the template — it is never read from the service
+        verify(versionService, never()).getDisplayVersion();
+    }
+
+    @Test
+    void showVersionDefaultsToWhateverSettingsServiceReports() {
+        // SettingsService.isShowVersionOnLogin() applies the default (true when unset); the
+        // controller must pass it through untouched rather than defaulting on its own.
+        when(settingsService.isShowVersionOnLogin()).thenReturn(true);
+        when(versionService.getDisplayVersion()).thenReturn("13.3.0");
+
+        assertTrue((Boolean) loginModel().get("showVersion"));
+
+        when(settingsService.isShowVersionOnLogin()).thenReturn(false);
+        assertFalse((Boolean) loginModel().get("showVersion"));
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
@@ -119,6 +119,7 @@ public class SettingsServiceTestCase {
         assertEquals("30m", settingsService.getSessionDuration());
         assertEquals(true, settingsService.getEnableCueIndexing());
         assertEquals(true, settingsService.getHideVirtualTracks());
+        assertTrue(settingsService.isShowVersionOnLogin());
     }
 
     @Test
@@ -147,6 +148,7 @@ public class SettingsServiceTestCase {
         settingsService.setLdapAutoShadowing(true);
         settingsService.setEnableCueIndexing(false);
         settingsService.setHideVirtualTracks(false);
+        settingsService.setShowVersionOnLogin(false);
 
         verifySettings(settingsService);
 
@@ -185,6 +187,7 @@ public class SettingsServiceTestCase {
         assertTrue(settingsService.isLdapAutoShadowing());
         assertFalse(settingsService.getEnableCueIndexing());
         assertFalse(settingsService.getHideVirtualTracks());
+        assertFalse(ss.isShowVersionOnLogin());
     }
 
     @Test


### PR DESCRIPTION
The running version wasn't visible without logging in, which made it awkward to confirm what an instance is actually running when troubleshooting.

## What it does

Adds a version line under the logo on the login screen, showing `VersionService.getDisplayVersion()`. That accessor embeds the build timestamp in both formats (`13.3.0-SNAPSHOT.20260719133402` for snapshots, `13.2.0 (build 20260719133402)` for finals). `common.unknown` covers the case where `build.properties` can't be read and `getDisplayVersion()` returns empty.

Can be disabled via ShowVersionOnLogin setting on the General Settings page, defaulting to on. /generalSettings* is already restricted to ADMIN in GlobalSecurityConfig, so the control is admin-only through the existing mechanism with nothing added. Default setting is on.

## Implementation

The setting mirrors the `sortAlbumsByYear` pattern end to end: key constant, read-time default, getter/setter, command field, controller binding, checkbox. Admin-only comes from the existing mechanism - `/generalSettings*` is already `.hasRole("ADMIN")` in `GlobalSecurityConfig`, so nothing was added. `LoginController` reads `SettingsService` with no session, the same way it already reads `getBrand()` and `getLoginMessage()`; `/login` is `permitAll`.

Formatting is done in the controller rather than the template. `help.html` renders an `Instant` via Thymeleaf's `#dates` (the `java.util.Date` utility) while six other templates use `#temporals` for `java.time` types - a suspect idiom worth not replicating on the pre-authentication page, where an expression failure would lock out every user.

The new i18n key is in both `ResourceBundle.properties` and `ResourceBundle_en.properties`. Worth noting: the antrun copy at `airsonic-main/pom.xml:648-663` overwrites the packaged base bundle with `_en` at generate-resources, so a key added only to base is silently discarded in the WAR - the #297 mechanism.

## Verification

- HSQLDB full suite: 1242/0/0 (floor 1236 → 1242, +6 tests, no regressions)
- checkstyle clean
- WAR verified from inside the archive: packaged `login.html` carries the version block, both packaged bundles carry the new key and still carry `common.unknown`.
- Template rendering isn't exercised by the suite, so the rendered result was confirmed by deploy: version line present under the logo, both keys resolve (no `??key_en??`), checkbox round-trips through a real form POST, toggling off removes the line, no exception on login render.

Tests: +6 (`LoginControllerTest` and `GeneralSettingsControllerTest` new, `SettingsServiceTestCase` extended). The most useful one asserts `verify(versionService, never())` when the toggle is off, proving the toggle suppresses the work rather than hiding markup.

fixes #246