### PR TITLE
fix: resolve ambiguous /ext/stream handler mapping (#325)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicMediaController.java
@@ -50,7 +50,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Controller
-@RequestMapping(value = {"/rest", "/ext"}, method = {RequestMethod.GET, RequestMethod.POST})
+// Maps /rest only, unlike the other Subsonic controllers' {"/rest", "/ext"}: the wrapped
+// binary controllers self-register their /ext/* routes (StreamController maps /ext/stream,
+// HLSController /ext/hls/**), and a second /ext/stream registration here made Spring throw
+// "Ambiguous handler methods mapped" on every JWT stream request — external players, UPnP,
+// Sonos, shares (#325). No server-issued JWT URL targets /ext/<subsonic-name>, so nothing
+// legitimate resolves through an /ext prefix on this controller.
+@RequestMapping(value = "/rest", method = {RequestMethod.GET, RequestMethod.POST})
 public class SubsonicMediaController extends AbstractSubsonicController {
 
     @Autowired

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/HandlerMappingUniquenessTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/HandlerMappingUniquenessTest.java
@@ -1,0 +1,130 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2026 (C) Airsonic Authors
+ */
+package org.airsonic.player.controller;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards against two controllers registering the same (pattern, method) pair, which Spring
+ * accepts at startup (the full RequestMappingInfos differ) but rejects at request time with
+ * "Ambiguous handler methods mapped" once per-request matching reduces both infos to the same
+ * conditions. #325 hit exactly this: StreamController mapped /ext/stream directly while
+ * SubsonicMediaController composed the same pattern from its class-level /ext prefix, killing
+ * every external-player, UPnP, Sonos and share stream request.
+ *
+ * Only unconditional mappings are compared — a params/headers/consumes/produces condition is a
+ * legitimate disambiguator, so infos carrying one are skipped.
+ */
+@SpringBootTest
+public class HandlerMappingUniquenessTest {
+
+    @TempDir
+    private static Path tempAirsonicHome;
+
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty("airsonic.home", tempAirsonicHome.toString());
+    }
+
+    @Autowired
+    @Qualifier("requestMappingHandlerMapping")
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @Test
+    public void noTwoHandlersShareAnUnconditionalPatternAndMethod() {
+        Map<String, HandlerMethod> seen = new HashMap<>();
+        List<String> collisions = new ArrayList<>();
+
+        for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : handlerMapping.getHandlerMethods().entrySet()) {
+            RequestMappingInfo info = entry.getKey();
+            if (!info.getParamsCondition().getExpressions().isEmpty()
+                    || !info.getHeadersCondition().getExpressions().isEmpty()
+                    || !info.getConsumesCondition().getExpressions().isEmpty()
+                    || !info.getProducesCondition().getExpressions().isEmpty()) {
+                continue;
+            }
+
+            Set<String> patterns = new HashSet<>();
+            if (info.getPathPatternsCondition() != null) {
+                info.getPathPatternsCondition().getPatterns()
+                        .forEach(pattern -> patterns.add(pattern.getPatternString()));
+            } else {
+                patterns.addAll(info.getPatternsCondition().getPatterns());
+            }
+
+            Set<RequestMethod> methods = info.getMethodsCondition().getMethods();
+            if (methods.isEmpty()) {
+                methods = Set.of(RequestMethod.values());
+            }
+
+            for (String pattern : patterns) {
+                for (RequestMethod method : methods) {
+                    String key = method + " " + pattern;
+                    HandlerMethod previous = seen.putIfAbsent(key, entry.getValue());
+                    if (previous != null && !previous.equals(entry.getValue())) {
+                        collisions.add(key + " -> " + previous + " AND " + entry.getValue());
+                    }
+                }
+            }
+        }
+
+        assertTrue(collisions.isEmpty(),
+                "Ambiguous handler registrations (same pattern and method, no disambiguating condition"
+                        + " — these throw \"Ambiguous handler methods mapped\" at request time):\n"
+                        + String.join("\n", collisions));
+    }
+
+    @Test
+    public void streamEndpointsResolveToTheirControllers() throws Exception {
+        assertEquals(StreamController.class, resolveHandler("/ext/stream").getBeanType());
+        assertEquals("handleRequest", resolveHandler("/ext/stream").getMethod().getName());
+
+        assertEquals(SubsonicMediaController.class, resolveHandler("/rest/stream").getBeanType());
+        assertEquals("stream", resolveHandler("/rest/stream").getMethod().getName());
+    }
+
+    private HandlerMethod resolveHandler(String path) throws Exception {
+        HandlerExecutionChain chain = handlerMapping.getHandler(new MockHttpServletRequest("GET", path));
+        assertNotNull(chain, "No handler mapped for GET " + path);
+        return (HandlerMethod) chain.getHandler();
+    }
+}


### PR DESCRIPTION
`StreamController` maps `{"/stream", "/ext/stream"}` (GET only). `SubsonicMediaController`, extracted in #111, carries the class-level `{"/rest", "/ext"}` prefix shared by all split Subsonic controllers, so its `{"/stream", "/stream.view"}` method also registers `/ext/stream`. Spring accepts both at startup because the full mapping infos differ (extra `/rest` patterns, extra POST), but at lookup both reduce to the same `(/ext/stream, GET)` match and compare equal, so every GET `/ext/stream` fails with `IllegalStateException: Ambiguous handler methods mapped for '/ext/stream'`.

Everything that streams through a server-issued JWT URL was affected: external players (m3u), shares, UPnP/DLNA, Sonos and cast URLs. The browser play queue uses `/stream` and was never hit. The colliding annotations are identical at v13.1.0 and v13.2.0, so both finals carry the bug.

## Fix

`SubsonicMediaController` now maps `/rest` only. Subsonic clients call `/rest/*`, and nothing in the codebase produces an `/ext/<subsonic-name>` URL for any of its endpoints. The wrapped binary controllers keep their own `/ext` routes. `StreamController` is untouched and no `params` condition is introduced.

Scope note: the six producer-less `/ext/<subsonic-name>` routes (download, hls, getCoverArt, getAvatar, getLyrics, getLyricsBySongId, getCaptions, plus `.view` aliases) are unregistered along with `/ext/stream`. The other 14 split Subsonic controllers still carry the unused `/ext` prefix; that is a separate cleanup.

## Verification

- HSQLDB full suite: 1244/0/0 (floor 1242 → 1244, +2 tests, no regressions)
- checkstyle clean
- New `HandlerMappingUniquenessTest` (full context): a class-level guard asserts no unconditional `(pattern, method)` pair maps to two handler methods anywhere in `RequestMappingHandlerMapping` (mappings with params/headers/consumes/produces conditions are exempt as legitimate disambiguators), plus a resolution test pinning GET `/ext/stream` to `StreamController.handleRequest` and GET `/rest/stream` to `SubsonicMediaController.stream`.
- Two-state check: on unmodified code the guard lists exactly the `/ext/stream` GET pair and the resolution test throws the production exception at `AbstractHandlerMethodMapping.lookupHandlerMethod:431`, the frame from the reporter's log.
- Manual on the test instance: an external-player-with-playlist m3u entry (`/ext/stream?player=...&jwt=...`) returned 500 with the ambiguity exception before the fix and 206 after.

Thanks to @gzsombor for independently diagnosing the same collision and proposing a `params`-based variant on the fork.

fixes #325