### PR TITLE
fix: stop clamping offset on search3 empty-query enumeration (#333)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSearchController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicSearchController.java
@@ -53,15 +53,24 @@ import static org.springframework.web.bind.ServletRequestUtils.getIntParameter;
 public class SubsonicSearchController extends AbstractSubsonicController {
 
     /**
-     * Upper bound for any per-request count or offset on the search endpoints (#262). Both flow to
-     * {@code SearchServiceImpl} as {@code searcher.search(query, offset + count)}, which makes
-     * Lucene pre-allocate a {@code TopDocs} collector sized to {@code offset + count} before
-     * collecting any document — an authenticated client passing {@code songCount=2147483647} could
-     * OOM the JVM (and an abusive {@code offset} could overflow {@code offset + count} to a
-     * negative). Clamping both to this ceiling bounds the allocation to {@code 2 * MAX_COUNT} and
-     * removes the overflow. The value matches the existing getAlbumList / getAlbumList2 size
-     * ceiling, keeping the Subsonic surface consistent; it is comfortably above any legitimate
-     * client search request (clients page 20–100 at a time) and below memory pressure.
+     * Upper bound for any per-request count, and for offsets on the Lucene-scored paths (#262).
+     * Scored queries flow to {@code SearchServiceImpl} as
+     * {@code searcher.search(query, offset + count)}, which makes Lucene pre-allocate a collector
+     * sized to {@code offset + count} before collecting any document — an authenticated client
+     * passing {@code songCount=2147483647} could OOM the JVM (and an abusive {@code offset} could
+     * overflow {@code offset + count} to a negative). Clamping both operands to this ceiling
+     * bounds the allocation to {@code 2 * MAX_COUNT} and removes the overflow (#285).
+     * <p>
+     * The search3 empty-query branch is different: it enumerates the database through
+     * {@code OffsetBasedPageRequest} (SQL OFFSET, O(1) server memory, offset held as a long with
+     * no int arithmetic), so a deep offset is legitimate pagination there, not an allocation.
+     * Clamping those offsets to 500 made every page beyond the first 500 entries return the same
+     * slice, silently stalling full-library scans (#333). Enumeration offsets are therefore only
+     * floored at zero — mirroring getAlbumList2 and getSongsByGenre, which clamp size only.
+     * <p>
+     * The value matches the existing getAlbumList / getAlbumList2 size ceiling, keeping the
+     * Subsonic surface consistent; it is comfortably above any legitimate client page size
+     * (clients page 20–500 at a time) and below memory pressure.
      */
     static final int MAX_COUNT = 500;
 
@@ -175,40 +184,40 @@ public class SubsonicSearchController extends AbstractSubsonicController {
         // replace empty string with null
         query = "\"\"".equals(query) ? null : query;
         int songCount = clamp(getIntParameter(request, "songCount", 20));
-        int songOffset = clamp(getIntParameter(request, "songOffset", 0));
+        int songOffset = getIntParameter(request, "songOffset", 0);
         int albumCount = clamp(getIntParameter(request, "albumCount", 20));
-        int albumOffset = clamp(getIntParameter(request, "albumOffset", 0));
+        int albumOffset = getIntParameter(request, "albumOffset", 0);
         int artistCount = clamp(getIntParameter(request, "artistCount", 20));
-        int artistOffset = clamp(getIntParameter(request, "artistOffset", 0));
+        int artistOffset = getIntParameter(request, "artistOffset", 0);
         if (StringUtils.isEmpty(query)) {
             if (artistCount > 0) {
-                artistService.getArtists(musicFolders, artistCount, artistOffset).forEach(artist -> searchResult.getArtist().add(jaxbContentService.createJaxbArtist(new ArtistID3(), artist, username)));
+                artistService.getArtists(musicFolders, artistCount, enumerationOffset(artistOffset)).forEach(artist -> searchResult.getArtist().add(jaxbContentService.createJaxbArtist(new ArtistID3(), artist, username)));
             }
             if (albumCount > 0) {
-                albumService.getAlbums(musicFolders, albumCount, albumOffset).forEach(album -> searchResult.getAlbum().add(jaxbContentService.createJaxbAlbum(new AlbumID3(), album, username)));
+                albumService.getAlbums(musicFolders, albumCount, enumerationOffset(albumOffset)).forEach(album -> searchResult.getAlbum().add(jaxbContentService.createJaxbAlbum(new AlbumID3(), album, username)));
             }
             if (songCount > 0) {
-                mediaFileService.getSongs(musicFolders, songCount, songOffset).forEach(song -> searchResult.getSong().add(jaxbContentService.createJaxbChild(player, song, username)));
+                mediaFileService.getSongs(musicFolders, songCount, enumerationOffset(songOffset)).forEach(song -> searchResult.getSong().add(jaxbContentService.createJaxbChild(player, song, username)));
             }
         } else {
             SearchCriteria criteria = new SearchCriteria();
             criteria.setQuery(StringUtils.trimToEmpty(query));
             criteria.setCount(artistCount);
-            criteria.setOffset(artistOffset);
+            criteria.setOffset(clamp(artistOffset));
             org.airsonic.player.domain.SearchResult result = searchService.search(criteria, musicFolders, IndexType.ARTIST_ID3);
             for (org.airsonic.player.domain.Artist artist : result.getArtists()) {
                 searchResult.getArtist().add(jaxbContentService.createJaxbArtist(new ArtistID3(), artist, username));
             }
 
             criteria.setCount(albumCount);
-            criteria.setOffset(albumOffset);
+            criteria.setOffset(clamp(albumOffset));
             result = searchService.search(criteria, musicFolders, IndexType.ALBUM_ID3);
             for (Album album : result.getAlbums()) {
                 searchResult.getAlbum().add(jaxbContentService.createJaxbAlbum(new AlbumID3(), album, username));
             }
 
             criteria.setCount(songCount);
-            criteria.setOffset(songOffset);
+            criteria.setOffset(clamp(songOffset));
             result = searchService.search(criteria, musicFolders, IndexType.SONG);
             for (MediaFile song : result.getMediaFiles()) {
                 searchResult.getSong().add(jaxbContentService.createJaxbChild(player, song, username));
@@ -227,6 +236,16 @@ public class SubsonicSearchController extends AbstractSubsonicController {
      */
     static int clamp(int value) {
         return Math.max(0, Math.min(MAX_COUNT, value));
+    }
+
+    /**
+     * Bounds an offset for the search3 empty-query database enumeration (#333): non-negative
+     * only, no upper ceiling. The offset feeds {@code OffsetBasedPageRequest} as a SQL OFFSET —
+     * no allocation scales with it, and no int arithmetic touches it on that path — so any
+     * depth is safe and deep values are required for full-library pagination.
+     */
+    static int enumerationOffset(int value) {
+        return Math.max(0, value);
     }
 
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicSearchControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/SubsonicSearchControllerTest.java
@@ -21,7 +21,10 @@ package org.airsonic.player.controller;
 import org.airsonic.player.domain.Player;
 import org.airsonic.player.domain.SearchCriteria;
 import org.airsonic.player.domain.SearchResult;
+import org.airsonic.player.service.AlbumService;
+import org.airsonic.player.service.ArtistService;
 import org.airsonic.player.service.JaxbContentService;
+import org.airsonic.player.service.MediaFileService;
 import org.airsonic.player.service.MediaFolderService;
 import org.airsonic.player.service.PlayerService;
 import org.airsonic.player.service.SearchService;
@@ -44,6 +47,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -69,11 +73,22 @@ class SubsonicSearchControllerTest {
     private PlayerService playerService;
     @Mock
     private org.airsonic.player.controller.JAXBWriter jaxbWriter;
+    @Mock
+    private ArtistService artistService;
+    @Mock
+    private AlbumService albumService;
+    @Mock
+    private MediaFileService mediaFileService;
 
     private SubsonicSearchController controller;
 
     // (count, offset) snapshotted at each searchService.search invocation.
     private final List<int[]> searchArgs = new ArrayList<>();
+
+    // (count, offset) received by the search3 empty-query database enumeration (#333).
+    private final List<int[]> artistArgs = new ArrayList<>();
+    private final List<int[]> albumArgs = new ArrayList<>();
+    private final List<int[]> songArgs = new ArrayList<>();
 
     @BeforeEach
     void setUp() throws Exception {
@@ -84,6 +99,9 @@ class SubsonicSearchControllerTest {
         ReflectionTestUtils.setField(controller, "jaxbContentService", jaxbContentService);
         ReflectionTestUtils.setField(controller, "playerService", playerService);
         ReflectionTestUtils.setField(controller, "jaxbWriter", jaxbWriter);
+        ReflectionTestUtils.setField(controller, "artistService", artistService);
+        ReflectionTestUtils.setField(controller, "albumService", albumService);
+        ReflectionTestUtils.setField(controller, "mediaFileService", mediaFileService);
 
         when(securityService.getCurrentUsername(any())).thenReturn("alice");
         when(playerService.getPlayersForUserAndClientId(any(), any())).thenReturn(List.of(new Player()));
@@ -95,6 +113,18 @@ class SubsonicSearchControllerTest {
             SearchCriteria c = invocation.getArgument(0);
             searchArgs.add(new int[] {c.getCount(), c.getOffset()});
             return new SearchResult();
+        });
+        when(artistService.getArtists(any(), anyInt(), anyInt())).thenAnswer(invocation -> {
+            artistArgs.add(new int[] {invocation.getArgument(1), invocation.getArgument(2)});
+            return List.of();
+        });
+        when(albumService.getAlbums(any(), anyInt(), anyInt())).thenAnswer(invocation -> {
+            albumArgs.add(new int[] {invocation.getArgument(1), invocation.getArgument(2)});
+            return List.of();
+        });
+        when(mediaFileService.getSongs(any(), anyInt(), anyInt())).thenAnswer(invocation -> {
+            songArgs.add(new int[] {invocation.getArgument(1), invocation.getArgument(2)});
+            return List.of();
         });
     }
 
@@ -187,6 +217,86 @@ class SubsonicSearchControllerTest {
 
         assertThat(searchArgs.get(0)[0]).isEqualTo(100);
         assertThat(searchArgs.get(0)[1]).isEqualTo(40);
+    }
+
+    @Test
+    void search3_emptyQuery_passesDeepOffsetsToDatabaseEnumeration() throws Exception {
+        // #333: the empty-query branch enumerates the database (SQL OFFSET), where a deep offset
+        // is legitimate pagination, not a Lucene allocation. Clamping it to 500 made every page
+        // beyond 500 return the same slice, stalling full-library scans (Symfonium pages in
+        // 500-entry slices).
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "\"\"");
+        request.setParameter("artistCount", "500");
+        request.setParameter("artistOffset", "2000");
+        request.setParameter("albumCount", "500");
+        request.setParameter("albumOffset", "2000");
+        request.setParameter("songCount", "500");
+        request.setParameter("songOffset", "2000");
+
+        controller.search3(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs).isEmpty();   // never reaches Lucene
+        assertThat(artistArgs).containsExactly(new int[] {500, 2000});
+        assertThat(albumArgs).containsExactly(new int[] {500, 2000});
+        assertThat(songArgs).containsExactly(new int[] {500, 2000});
+    }
+
+    @Test
+    void search3_emptyQuery_abusiveOffsetDoesNotThrow() throws Exception {
+        // OffsetBasedPageRequest stores the offset as a long and performs no int arithmetic on
+        // it, so Integer.MAX_VALUE passes through safely — the enumeration bound is
+        // non-negative only.
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "\"\"");
+        request.setParameter("artistCount", "500");
+        request.setParameter("artistOffset", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("albumCount", "500");
+        request.setParameter("albumOffset", String.valueOf(Integer.MAX_VALUE));
+        request.setParameter("songCount", "500");
+        request.setParameter("songOffset", String.valueOf(Integer.MAX_VALUE));
+
+        controller.search3(request, new MockHttpServletResponse());
+
+        assertThat(artistArgs).containsExactly(new int[] {500, Integer.MAX_VALUE});
+        assertThat(albumArgs).containsExactly(new int[] {500, Integer.MAX_VALUE});
+        assertThat(songArgs).containsExactly(new int[] {500, Integer.MAX_VALUE});
+    }
+
+    @Test
+    void search3_emptyQuery_negativeOffsetFloorsToZero() throws Exception {
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "\"\"");
+        request.setParameter("artistCount", "500");
+        request.setParameter("artistOffset", "-100");
+        request.setParameter("albumCount", "500");
+        request.setParameter("albumOffset", "-100");
+        request.setParameter("songCount", "500");
+        request.setParameter("songOffset", "-100");
+
+        controller.search3(request, new MockHttpServletResponse());
+
+        assertThat(artistArgs).containsExactly(new int[] {500, 0});
+        assertThat(albumArgs).containsExactly(new int[] {500, 0});
+        assertThat(songArgs).containsExactly(new int[] {500, 0});
+    }
+
+    @Test
+    void search3_withQuery_offsetStillClampedTo500() throws Exception {
+        // The Lucene branch keeps the #262/#285 policy untouched: offset and count both bounded
+        // to 500, capping the offset+count TopDocs allocation.
+        MockHttpServletRequest request = req();
+        request.setParameter("query", "anything");
+        request.setParameter("artistCount", "500");
+        request.setParameter("artistOffset", "2000");
+
+        controller.search3(request, new MockHttpServletResponse());
+
+        assertThat(searchArgs).hasSize(3);
+        assertThat(searchArgs.get(0)[1]).isEqualTo(500);   // artist criteria is first in search3
+        assertThat(artistArgs).isEmpty();
+        assertThat(albumArgs).isEmpty();
+        assertThat(songArgs).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
#285 (for #262) clamped both count and offset to `MAX_COUNT = 500` at all 14 read sites in `SubsonicSearchController`, because the Lucene path calls `searcher.search(query, offset + count)` and allocates the collector at that size. That bound is right for the Lucene path.

search3 with an empty query never reaches Lucene. The controller maps a literal `""` to null and enumerates the database instead (`getArtists`, `getAlbums`, `getSongs` with an id-sorted `OffsetBasedPageRequest`), where the offset becomes a SQL `OFFSET`. Clamping it there has no allocation rationale and breaks full-library enumeration: any offset above 500 folds back to 500, so every page past the first thousand entries returns the same slice, and clients that sync a library through search3 in 500-entry pages (Symfonium) stall. 13.1.0 passed the offset through unbounded; this is a 13.2.0 regression.

## Fix

search3 keeps `clamp()` on the three counts and, in the Lucene branch, on the three offsets; the values reaching `SearchService` are unchanged. The empty-query branch passes offsets through a new `enumerationOffset()` that floors negatives to zero and applies no ceiling. `OffsetBasedPageRequest` stores the offset as `long` and does no `int` arithmetic on it, so no overflow guard is needed there. This mirrors `getAlbumList2` and `getSongsByGenre`, which already clamp size only.

Untouched: `/search`, `/search2`, search3 with a non-empty query, `SearchServiceImpl`, `QueryFactory`, the services and repositories. Deep paging of relevance-ranked results stays capped at 500 by design; #262's allocation and overflow protections are byte-for-byte intact on the Lucene path.

## Verification

- HSQLDB full suite: 1248/0/0 (floor 1244 → 1248, +4 tests, no regressions)
- checkstyle clean
- `OffsetBasedPageRequest` arithmetic inspected line by line: `long offset`, division and `long` addition only; service signatures take `int` and widen at the constructor call.
- New tests: deep offsets (2000) reach the DB services on the empty-query path and `SearchService` is never called; `Integer.MAX_VALUE` passes through without throwing; negatives floor to zero; a non-empty query still hands offset 500 to `SearchService` and never calls the DB services.
- Two-state check: on unmodified code the deep-offset and abusive-offset tests fail (`[[500, 500]]` received, `[[500, 2000]]` expected); the negative-floor test is invariant by construction and the Lucene pin passes in both states. All 7 #285 tests unchanged and passing.
- Manual on the test instance: `search3.view?query=%22%22&songOffset=500&songCount=3` and `songOffset=1000` return distinct id-ordered slices (2022/2024/2027 vs 3339/3342/3345); before the fix both returned the offset-500 slice.

Thanks to @UVJkiNTQ for the precise reproduction; the fix takes a different shape from the fork branch, bounding by branch rather than by a larger offset ceiling.

fixes #333