### PR TITLE
docs: release notes for v13.2.1-rc.1

### DIFF
--- a/docs/release-notes/v13.2.1-rc.1.md
+++ b/docs/release-notes/v13.2.1-rc.1.md
@@ -1,0 +1,42 @@
+# Airsonic-Pulse v13.2.1-rc.1
+
+## Upgrade notes
+
+Patch release for 13.2.0. No database schema changes: upgrading from 13.2.0 needs no migration, and rolling back to 13.2.0 is safe.
+
+If you skipped 13.1.0 and 13.2.0 because external playback or shares stopped working, this is the release to test.
+
+## Summary
+
+Restores every stream flow that uses a server-issued JWT URL: external players (m3u), shares, UPnP/DLNA, Sonos and cast. A duplicate `/ext/stream` mapping introduced in 13.1.0 made Spring reject the request with an ambiguous-handler error (#325, PR #334).
+
+Restores full-library enumeration through search3 with an empty query, used by clients such as Symfonium to sync. 13.2.0 clamped the offset to 500 on that path along with the count (#333, PR #337). Relevance-ranked search keeps the 500 offset ceiling from 13.2.0 by design.
+
+Also carries three small fixes from the 13.3 line: MediaFile.equals no longer throws on a null folder or start position (#216), CUE and audiobook indexing no longer fails on a null base duration (#289), MP4 ReplayGain atoms are matched case-insensitively (#251).
+
+This is the first preview of 13.2.1; the "What's Changed" list below is the complete delta since 13.2.0.
+
+## Known issues
+
+Under investigation for a later 13.2.x or 13.3.0: media scan slowdown reported on 13.2.0 (#331), database pool exhaustion after shuffle on a folder or DSub radio (#323), podcast channel deletion failing on MariaDB (#330). Add your environment details to those issues if you're affected.
+
+<!-- AUTO-GENERATED-BELOW -->
+## What's Changed
+
+### Features & Enhancements
+* #246 Add version to login screen by @litebito in #329
+
+### Bug Fixes
+* #216 MediaFile.equals throws NPE on null folder (asymmetric with null-safe hashCode) by @litebito in #320
+* #289 CUE last-track duration: NPE-on-unbox when a base FILE has null duration by @litebito in #326
+* #325 [Bug]: External playback no longer works by @litebito in #334
+* #333 search3 deep-pagination broken: offset > 500 returns the same page (clamp from #285) by @litebito in #337
+
+### Infrastructure & CI
+* chore: bump version to 13.3.0-SNAPSHOT by @litebito in #328
+
+### Maintenance
+* #263 Replace Random with SecureRandom in SearchServiceImpl random-songs path by @litebito in #321
+* #251 JaudiotaggerParser MP4 ReplayGain branch is case-sensitive; TXXX branch is not by @litebito in #327
+
+**Full Changelog**: https://github.com/Airsonic-Pulse/airsonic-pulse/compare/v13.2.0...v13.2.1-rc.1

--- a/docs/release-notes/v13.2.1-rc.1.md
+++ b/docs/release-notes/v13.2.1-rc.1.md
@@ -23,20 +23,12 @@ Under investigation for a later 13.2.x or 13.3.0: media scan slowdown reported o
 <!-- AUTO-GENERATED-BELOW -->
 ## What's Changed
 
-### Features & Enhancements
-* #246 Add version to login screen by @litebito in #329
-
 ### Bug Fixes
+
 * #216 MediaFile.equals throws NPE on null folder (asymmetric with null-safe hashCode) by @litebito in #320
 * #289 CUE last-track duration: NPE-on-unbox when a base FILE has null duration by @litebito in #326
-* #325 [Bug]: External playback no longer works by @litebito in #334
-* #333 search3 deep-pagination broken: offset > 500 returns the same page (clamp from #285) by @litebito in #337
-
-### Infrastructure & CI
-* chore: bump version to 13.3.0-SNAPSHOT by @litebito in #328
-
-### Maintenance
-* #263 Replace Random with SecureRandom in SearchServiceImpl random-songs path by @litebito in #321
 * #251 JaudiotaggerParser MP4 ReplayGain branch is case-sensitive; TXXX branch is not by @litebito in #327
+* #325 External playback no longer works by @litebito in #334
+* #333 search3 deep-pagination broken: offset > 500 returns the same page (clamp from #285) by @litebito in #337
 
 **Full Changelog**: https://github.com/Airsonic-Pulse/airsonic-pulse/compare/v13.2.0...v13.2.1-rc.1


### PR DESCRIPTION
Cherry-picked from release/13.2.x so docs/release-notes on main stays complete.