### PR TITLE
fix: stamp MediaFile.VERSION on re-parse so a version bump settles (#341)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -697,6 +697,16 @@ public class MediaFile {
         return version;
     }
 
+    /**
+     * Stamps the row with the current schema {@link #VERSION}. Must be called by every
+     * re-parse path before the row is saved — a bumped VERSION flags older rows for one
+     * re-read, and without the stamp the row stays below VERSION forever, turning every
+     * scan into a full re-parse (#341).
+     */
+    public void markCurrentVersion() {
+        this.version = VERSION;
+    }
+
     public Double getAverageRating() {
         return averageRating;
     }
@@ -765,6 +775,11 @@ public class MediaFile {
 
     public static final double NOT_INDEXED = -1.0;
 
+    /**
+     * Media-file schema version. Bumping it makes {@code needsUpdate} re-parse every row once;
+     * the re-parse stamps the new value via {@link #markCurrentVersion()} — without that stamp
+     * the bump never settles and every scan re-parses the whole library.
+     */
     public static final int VERSION = 5;
 
     public static enum MediaType {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -309,6 +309,10 @@ public class MediaFileService {
                         createIndexedTracks(mediaFile);
                         // update media file
                         mediaFile.setChanged(mediaChanged.compareTo(cueChanged) >= 0 ? mediaChanged : cueChanged);
+                        // stamp the base row so a VERSION bump doesn't re-materialise the
+                        // indexed tracks on every scan (#341) — this branch bypasses
+                        // updateMediaFileByFile, which stamps the plain-file path
+                        mediaFile.markCurrentVersion();
                         updateMediaFile(mediaFile);
                     } catch (Exception e) {
                         LOG.error("create indexed tracks error: {}", mediaFile.getFullPath(), e);
@@ -1104,6 +1108,11 @@ public class MediaFileService {
                 mediaFile.setTitle(folder.getName());
             }
         }
+
+        // Stamp the freshly reflected row with the current schema version. This mutates the
+        // loaded entity in place, so without the stamp an upgraded row keeps its old stored
+        // version and needsUpdate re-parses it on every scan (#341).
+        mediaFile.markCurrentVersion();
 
         return mediaFile;
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -25,6 +25,7 @@ import org.airsonic.player.repository.MediaFileRepository;
 import org.airsonic.player.repository.MusicFileInfoRepository;
 import org.airsonic.player.service.cache.MediaFileCache;
 import org.airsonic.player.service.metadata.MetaDataParserFactory;
+import org.airsonic.player.util.FileUtil;
 import org.digitalmediaserver.cuelib.CueSheet;
 import org.digitalmediaserver.cuelib.FileData;
 import org.digitalmediaserver.cuelib.Index;
@@ -33,6 +34,7 @@ import org.digitalmediaserver.cuelib.TrackData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -43,6 +45,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -419,5 +422,61 @@ public class MediaFileServiceTest {
         // Cross-frame multi-value: two frames, one numeric, one text → both mapped, deduped,
         // joined with the primary separator.
         assertEquals("Rock;Metal", mediaFileService.packGenres(List.of("(17)", "Metal")));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // media_file.version write-back (#341): a VERSION bump flags every older row for one
+    // re-parse, and the re-parse must stamp the new version onto the row it saves — otherwise
+    // the row stays below VERSION forever and every scan is a full re-parse.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void updateMediaFileByFile_stampsCurrentVersionOnReparsedRow() {
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.setId(7);
+        mediaFile.setPath("piano.mp3");
+        mediaFile.setFolder(mockedFolder);
+        // a row written by an older release: stored version below current
+        ReflectionTestUtils.setField(mediaFile, "version", MediaFile.VERSION - 1);
+
+        when(mockedFolder.getId()).thenReturn(1);
+        when(mockedFolder.getType()).thenReturn(MusicFolder.Type.MEDIA);
+        when(mediaFolderService.getMusicFolderForFile(any(), eq(true), eq(true))).thenReturn(Optional.empty());
+        when(metaDataParserFactory.getParser(any())).thenReturn(null);
+        when(settingsService.getVideoFileTypesSet()).thenReturn(Set.of());
+        when(mediaFileRepository.existsById(any())).thenReturn(true);
+
+        mediaFileService.refreshMediaFile(mediaFile);
+
+        ArgumentCaptor<MediaFile> saved = ArgumentCaptor.forClass(MediaFile.class);
+        verify(mediaFileRepository).save(saved.capture());
+        assertEquals(MediaFile.VERSION, saved.getValue().getVersion());
+    }
+
+    @Test
+    public void needsUpdate_skipsRowAtCurrentVersionWithUnchangedFile() {
+        MediaFile mediaFile = new MediaFile();   // entity default: version == MediaFile.VERSION
+        mediaFile.setPath("piano.mp3");
+        mediaFile.setFolder(mockedFolder);
+        mediaFile.setChanged(FileUtil.lastModified(mediaFile.getFullPath()));
+
+        when(settingsService.getFullScan()).thenReturn(false);
+
+        Boolean result = ReflectionTestUtils.invokeMethod(mediaFileService, "needsUpdate", mediaFile, false);
+        assertEquals(Boolean.FALSE, result);
+    }
+
+    @Test
+    public void needsUpdate_reparsesRowBelowCurrentVersion() {
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.setPath("piano.mp3");
+        mediaFile.setFolder(mockedFolder);
+        mediaFile.setChanged(FileUtil.lastModified(mediaFile.getFullPath()));
+        ReflectionTestUtils.setField(mediaFile, "version", MediaFile.VERSION - 1);
+
+        // no getFullScan stub: version < VERSION short-circuits the OR before the setting is read
+
+        Boolean result = ReflectionTestUtils.invokeMethod(mediaFileService, "needsUpdate", mediaFile, false);
+        assertEquals(Boolean.TRUE, result);
     }
 }


### PR DESCRIPTION
`needsUpdate` re-parses any row whose stored `media_file.version` is below `MediaFile.VERSION`. The old `MediaFileDao` wrote the `VERSION` constant into its SQL on every save, so a re-parsed row came out stamped and a bump settled after one scan. The upstream JPA migration (#212, kagemomiji 11.1.3) deleted the DAO and the stamping with it. Nothing noticed for two years because VERSION stayed at 4 from 11.x through v13.1.0; the 13.2.0 bump to 5 (#197) exposed the gap.

With no write-back the promised one-time rescan never terminates: `updateMediaFileByFile` mutates the loaded entity, which carries the stored version, and saves it back at 4. Every scan after an upgrade re-parses every pre-upgrade file. Reported as #331. Measured on a 25k-file test library, full-scan off, no changes: 24,058 re-parses vs 69 skips on every scan.

## Fix

`MediaFile.markCurrentVersion()`, called at the end of `updateMediaFileByFile`'s parse path (covers the scan path, `refreshMediaFile`, and the 1-arg overload) and in `checkLastModified`'s CUE `hasIndex` branch, which re-materializes indexed tracks and saves without entering `updateMediaFileByFile`. The file-not-found early return deliberately does not stamp: nothing was parsed, so the row stays eligible for a real re-parse. New rows already carry VERSION via the field default.

Untouched: `needsUpdate`, the skip-path `lastScanned` write, migrations, the full-scan setting. The first scan after upgrading remains the legitimate one-time backfill; the second is incremental again. For #331's 600k library that means one more long scan, then back to the 13.1-era duration.

## Verification

- HSQLDB full suite: 1251/0/0 (floor 1248 → 1251, +3 tests, no regressions)
- checkstyle clean
- Two-state, unit: a version-4 row re-parsed through `refreshMediaFile` is captured at save with version 5; on unmodified code the same test fails with `expected: <5> but was: <4>`. Two `needsUpdate` pin tests pass in both states.
- Two-state, runtime, same 25k-file library, full-scan off, no library changes between scans: second consecutive scan logged 24,058 `Updating database file from disk` before the fix and 0 after (24,389 `Detected unmodified file`).
- History verified, not assumed: `git log -S` shows the DAO's `args.put("ver", VERSION)` removed by the #212 JPA migration.

fixes #341