### PR TITLE
fix: run podcast episode deletes sequentially inside the delete transaction (#345)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastPersistenceService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastPersistenceService.java
@@ -565,7 +565,10 @@ public class PodcastPersistenceService {
     public boolean deleteChannel(int channelId) {
         // Delete all associated episodes (in case they have files that need to be deleted).
         return podcastChannelRepository.findById(channelId).map(channel -> {
-            podcastEpisodeRepository.findByChannel(channel).parallelStream()
+            // Sequential on purpose: transactions are thread-bound, so parallel workers would run
+            // mediaFileService.delete in their own transactions and commit mid-delete, colliding
+            // with this transaction's flush (#330 — MariaDB snapshot isolation rejects the write).
+            podcastEpisodeRepository.findByChannel(channel).stream()
                 .filter(filterAllowed)
                 .forEach(episode -> {
                     MediaFile mediaFile = episode.getMediaFile();

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PodcastPersistenceServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PodcastPersistenceServiceTestCase.java
@@ -39,8 +39,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -151,6 +154,50 @@ public class PodcastPersistenceServiceTestCase {
         verify(mediaFileService).delete(mockedMediaFile);
         assertFalse(Files.exists(tempFolder.resolve("test.mp3")));
         assertTrue(actual);
+    }
+
+    @Test
+    void deleteChannelRunsEpisodeDeletesOnCallingThread() throws Exception {
+        // #345: the episode loop used parallelStream(), so mediaFileService.delete ran on
+        // ForkJoin common-pool workers. Transaction context is thread-bound, so those calls
+        // opened their own transactions and committed mid-delete, colliding with the outer
+        // @Transactional's flush (MariaDB snapshot isolation rejects the write with "Record
+        // has changed since last read", #330). This class has no transaction manager, so
+        // thread identity is the proxy for transaction membership: entity work on the calling
+        // thread joins the outer transaction; work on any other thread cannot.
+        int episodeCount = 64;
+        MusicFolder folder = new MusicFolder(1, tempFolder, "podcast", MusicFolder.Type.PODCAST, true, Instant.now());
+        List<PodcastEpisode> episodes = new ArrayList<>();
+        for (int i = 0; i < episodeCount; i++) {
+            MediaFile mediaFile = new MediaFile();
+            mediaFile.setPath("episode-" + i + ".mp3");
+            mediaFile.setFolder(folder);
+            PodcastEpisode episode = new PodcastEpisode();
+            episode.setMediaFile(mediaFile);
+            episodes.add(episode);
+        }
+
+        when(podcastChannelRepository.findById(1)).thenReturn(Optional.of(mockedChannel));
+        when(podcastEpisodeRepository.findByChannel(mockedChannel)).thenReturn(episodes);
+        when(securityService.isReadAllowed(any(MediaFile.class), eq(false))).thenReturn(true);
+        when(mockedChannel.getMediaFile()).thenReturn(null);
+
+        List<String> deleteThreads = Collections.synchronizedList(new ArrayList<>());
+        when(mediaFileService.delete(any(MediaFile.class))).thenAnswer(invocation -> {
+            deleteThreads.add(Thread.currentThread().getName());
+            // brief pause so a parallel stream provably distributes work across pool workers
+            Thread.sleep(1);
+            return invocation.getArgument(0);
+        });
+
+        boolean actual = podcastService.deleteChannel(1);
+
+        assertTrue(actual);
+        assertEquals(episodeCount, deleteThreads.size());
+        String callingThread = Thread.currentThread().getName();
+        List<String> foreignThreads = deleteThreads.stream().filter(name -> !name.equals(callingThread)).distinct().toList();
+        assertTrue(foreignThreads.isEmpty(),
+                "episode entity deletes must run on the calling thread (outer transaction); ran on: " + foreignThreads);
     }
 
     @Test


### PR DESCRIPTION
`PodcastPersistenceService.deleteChannel` is `@Transactional` and iterated the channel's episodes with `parallelStream()`, calling `mediaFileService.delete` per episode. Transactions are thread-bound: invocations landing on ForkJoin common-pool workers found no active transaction and opened their own, committing mid-delete, while the same `MediaFile` entities stayed managed by the outer persistence context. One logical delete became several concurrent transactions over shared rows and cross-thread JPA entities.

On MariaDB 11.6.2+, where `innodb_snapshot_isolation` defaults ON (MDEV-35124), the outer transaction's auto-flush before the child query in `MediaFileService.delete` hits a row already rewritten by a committed worker transaction and fails with `Record has changed since last read` (ER_CHECKREAD) — reported as #330. On other databases the defect passes silently but leaves a partially deleted channel if any step fails. Verified against the reporter's stack trace and MariaDB documentation; not reproduced live (HSQLDB cannot exhibit ER_CHECKREAD), the structural test below pins the corrected behaviour deterministically.

The pattern arrived with upstream's podcast-service split (Nov 2023) and survived the fork unexamined. An audit of all 53 `parallelStream` sites found this the only one with the full shape; adjacent hazards (`getChildrenOf` under callers' transactions, `PodcastRefresher` cross-thread updates) are noted for separate issues.

## Fix

`stream()` instead of `parallelStream()`, with a comment stating why the loop must stay sequential. The filesystem delete per episode was the only work that benefited from parallelism; if channel-delete latency ever matters, parallelise the file removal alone, never the entity work.

## Verification

- HSQLDB full suite: 1252/0/0 (floor 1251 → 1252, +1 test, no regressions)
- checkstyle clean
- Two-state, structural: 64 mocked episodes, per-invocation thread capture on `mediaFileService.delete`; on unmodified code the assertion fails listing `ForkJoinPool.commonPool-worker-1..7`, after the fix all 64 invocations run on the calling thread. Thread identity is the deterministic proxy for transaction membership (thread-bound context); an ER_CHECKREAD reproduction would be probabilistic and MariaDB-version-dependent.
- Packaged class checked with `javap -c`: `deleteChannel`'s lambda invokes `List.stream`; the three remaining `parallelStream` sites in the class are read-only/pure and were classified safe in the audit.

fixes #345