### PR TITLE
ci: pin MariaDB to 11.8 in the PR matrix and skip docs-only PRs

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, 'release/**']
     paths-ignore:
+      - "**.md"
+      - "*.txt"
+      - "docs/**"
       - "contrib/**"
 env:
   DEFAULT_MUSIC_FOLDER: /tmp/music
@@ -40,7 +43,7 @@ jobs:
           --health-retries 5
 
       mariadb:
-        image: ${{ matrix.db == 'mariadb' && 'mariadb:11-jammy' || '' }}
+        image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
         ports:
           - 3306:3306
         env:
@@ -53,7 +56,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
+        # 11.8 is the current LTS; 
+        image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
     env:
       spring_datasource_url: >-
         ${{ matrix.db == 'postgres'


### PR DESCRIPTION
Two small CI corrections found during the #330/#345 work:

- `mariadb:11-jammy` froze when the official image moved to noble, so the matrix tested an unknown old minor. Pinned to `mariadb:11.8` (current LTS). From 11.6.2 `innodb_snapshot_isolation` defaults ON, which is the setting under which the #330/#345 class of write-write conflict is detectable at all; a comment in the workflow records this.
- `paths-ignore` gains `**.md`, `*.txt`, `docs/**`, matching `pm_ci`, so docs-only PRs (like the release-notes cherry-picks) stop running the three-database matrix.

Partially addresses #340 (item 2); the release-notes script (item 1) and the image revision label (item 3) remain.