### PR TITLE
pick: pr_ci MariaDB 11.8 pin and docs paths-ignore (for 13.2.x)

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, 'release/**']
     paths-ignore:
+      - "**.md"
+      - "*.txt"
+      - "docs/**"
       - "contrib/**"
 env:
   DEFAULT_MUSIC_FOLDER: /tmp/music
@@ -40,7 +43,7 @@ jobs:
           --health-retries 5
 
       mariadb:
-        image: ${{ matrix.db == 'mariadb' && 'mariadb:11-jammy' || '' }}
+        image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
         ports:
           - 3306:3306
         env:
@@ -53,7 +56,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
+        # 11.8 is the current LTS; 
+        image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
     env:
       spring_datasource_url: >-
         ${{ matrix.db == 'postgres'

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -43,6 +43,7 @@ jobs:
           --health-retries 5
 
       mariadb:
+        # 11.8 is the current LTS, needs to be a controlled update when the LTS changes
         image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
         ports:
           - 3306:3306
@@ -55,9 +56,7 @@ jobs:
           --health-cmd "healthcheck.sh --connect --innodb_initialized"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5
-        # 11.8 is the current LTS; 
-        image: ${{ matrix.db == 'mariadb' && 'mariadb:11.8' || '' }}
+          --health-retries 5 
     env:
       spring_datasource_url: >-
         ${{ matrix.db == 'postgres'


### PR DESCRIPTION
Cherry-picks the pr_ci MariaDB pin and its follow-up image-line fix onto release/13.2.x. PR-triggered workflows read the file from the merge ref, so the branch needs its own copy for future pick PRs to run against the pinned image.