### PR TITLE
docs: release notes for v13.2.1-rc.3

### DIFF
--- a/docs/release-notes/v13.2.1-rc.3.md
+++ b/docs/release-notes/v13.2.1-rc.3.md
@@ -1,0 +1,49 @@
+# Airsonic-Pulse v13.2.1-rc.3
+
+## Upgrade notes (applies when coming from v13.2.0 or earlier)
+
+- The first library scan after upgrading is intentionally slow. It re-parses every file once to write back a scan version stamp that earlier releases never stored (#341). Every scan after that first one is fast again. Let the first scan finish; interrupting it means the next scan starts over.
+- No database schema changes in this release. Downgrading to v13.2.0 is safe.
+
+## Summary of changes since v13.2.0
+
+v13.2.1 is a bug-fix release. It fixes:
+
+- External playback via /ext/stream, broken by an ambiguous Spring request mapping (#325).
+- search3 deep pagination: offsets past 500 kept returning the same page (#333).
+- Library scans re-parsing every pre-13.2 file on every run because the scan version was never written back (#341). This was also the root cause of scans slowing down over time (#331) and of shuffle requests stalling on large folders (#323).
+- Podcast channel delete failing on MariaDB with ER_CHECKREAD because episode deletes ran in parallel across transactions (#345, reported in #330).
+- Two NPE fixes: MediaFile.equals on a null folder (#216) and CUE last-track duration unboxing when the base FILE has no duration (#289).
+- MP4 ReplayGain tag matching is now case-insensitive, matching the existing TXXX behavior (#251).
+- The podcast delete fix (#345): episode deletes now run sequentially inside the delete transaction, fixing the MariaDB failures reported in #330 that rc.2 listed as under investigation. Awaiting reporter confirmation on rc.3.
+
+CI on the release line now pins the PR matrix to MariaDB 11.8 LTS and skips builds for docs-only changes.
+
+## New in this release candidate (rc.3)
+
+- The podcast delete fix (#345): episode deletes now run sequentially inside the delete transaction, fixing the MariaDB ER_CHECKREAD failures from #330.
+- CI: MariaDB 11.8 pin and docs paths-ignore picked to the release line (#350).
+- Field confirmation for rc.2: the scan and shuffle fixes are confirmed by tester reports. Two full scans of a 110,000-file library completed in about three minutes, and shuffle on a 26,000-track folder works again (#331, #323).
+
+
+<!-- AUTO-GENERATED-BELOW -->
+## What's Changed
+
+### Features & Enhancements
+
+### Bug Fixes
+* #216 MediaFile.equals throws NPE on null folder (asymmetric with null-safe hashCode) by @litebito in #320
+* #289 CUE last-track duration: NPE-on-unbox when a base FILE has null duration by @litebito in #326
+* #325 [Bug]: External playback no longer works by @litebito in #334
+* #333 search3 deep-pagination broken: offset > 500 returns the same page (clamp from #285) by @litebito in #337
+* #341 Scan re-parses every pre-13.2 file on every run: MediaFile.VERSION is never written back by @litebito in #342
+* #345 Podcast channel delete runs episode deletes in parallel across transactions by @litebito in #346
+
+### Infrastructure & CI
+* docs: release notes for v13.2.1-rc.1 by @litebito in #339
+* ci: pin MariaDB to 11.8 in the PR matrix and skip docs-only PRs by @litebito in #348
+
+### Maintenance
+* #251 JaudiotaggerParser MP4 ReplayGain branch is case-sensitive; TXXX branch is not by @litebito in #327
+
+**Full Changelog**: https://github.com/Airsonic-Pulse/airsonic-pulse/compare/v13.2.0...v13.2.1-rc.3


### PR DESCRIPTION
Adds the rc.3 release notes file required by release.yml before tagging. Preamble carries the cumulative upgrade notes and summary since v13.2.0 plus the new-in-rc.3 section, including field confirmation of the rc.2 scan and shuffle fixes.