### PR TITLE
fix: add image revision label to release builds (refs #340)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           tags: ${{ steps.docker-tags.outputs.tags }}
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+            REVISION=${{ github.sha }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -16,10 +16,12 @@ RUN mv WEB-INF/classes/liquibase cliquibase
 
 FROM eclipse-temurin:${IMAGE_JAVA_VERSION}-jre-jammy
 ARG VERSION=dev
+ARG REVISION=""
 
 LABEL description="Airsonic-Pulse is a free, web-based media streamer, providing ubiquitous access to your music." \
       url="https://github.com/Airsonic-Pulse/airsonic-pulse" \
-      org.opencontainers.image.version=${VERSION}
+      org.opencontainers.image.version=${VERSION} \
+      org.opencontainers.image.revision=${REVISION}
 
 ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0
 


### PR DESCRIPTION
Item 3 of #340. Images carried org.opencontainers.image.version but no revision. Adds ARG REVISION and the org.opencontainers.image.revision label to the Dockerfile next to the existing version pair, and passes REVISION=github.sha from the release workflow's build-args, so a running container identifies its source commit. Proven locally with a two-state build: pre-change inspect shows no revision key, post-change shows the injected value alongside the unchanged version label. End-to-end confirmation on GHCR happens at the next tag build. Needs a cherry-pick to release/13.2.x so v13.2.1 final ships labeled; #340 closes after that pick.